### PR TITLE
enable get model definition from device

### DIFF
--- a/src/app/constants/apiConstants.ts
+++ b/src/app/constants/apiConstants.ts
@@ -31,3 +31,8 @@ export const HEADERS = {
     PUBLISHER_NAME: 'x-ms-model-publisher-name',
     REQUEST_ID: 'x-ms-request-id',
 };
+
+export enum DataPlaneStatusCode{
+    SuccessLowerBound = 200,
+    SuccessUpperBound = 299
+}

--- a/src/app/settings/components/__snapshots__/repositoryLocationList.spec.tsx.snap
+++ b/src/app/settings/components/__snapshots__/repositoryLocationList.spec.tsx.snap
@@ -2266,6 +2266,9 @@ exports[`components/settings/repositoryLocationList matches snapshot with each t
                               "settings.modelDefinitions.repositoryTypes.public.label",
                             ],
                             Array [
+                              "settings.modelDefinitions.repositoryTypes.device.label",
+                            ],
+                            Array [
                               "settings.modelDefinitions.add",
                             ],
                             Array [
@@ -2319,6 +2322,10 @@ exports[`components/settings/repositoryLocationList matches snapshot with each t
                             Object {
                               "type": "return",
                               "value": "settings.modelDefinitions.repositoryTypes.public.label",
+                            },
+                            Object {
+                              "type": "return",
+                              "value": "settings.modelDefinitions.repositoryTypes.device.label",
                             },
                             Object {
                               "type": "return",
@@ -5875,6 +5882,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with each t
               "onClick": [Function],
               "text": "settings.modelDefinitions.repositoryTypes.public.label",
             },
+            Object {
+              "disabled": true,
+              "key": "DEVICE",
+              "onClick": [Function],
+              "text": "settings.modelDefinitions.repositoryTypes.device.label",
+            },
           ],
         }
       }
@@ -5901,6 +5914,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with each t
                 "key": "PUBLIC",
                 "onClick": [Function],
                 "text": "settings.modelDefinitions.repositoryTypes.public.label",
+              },
+              Object {
+                "disabled": true,
+                "key": "DEVICE",
+                "onClick": [Function],
+                "text": "settings.modelDefinitions.repositoryTypes.device.label",
               },
             ],
           }
@@ -6164,6 +6183,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with each t
                   "key": "PUBLIC",
                   "onClick": [Function],
                   "text": "settings.modelDefinitions.repositoryTypes.public.label",
+                },
+                Object {
+                  "disabled": true,
+                  "key": "DEVICE",
+                  "onClick": [Function],
+                  "text": "settings.modelDefinitions.repositoryTypes.device.label",
                 },
               ],
             }
@@ -7215,6 +7240,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with no ite
               "onClick": [Function],
               "text": "settings.modelDefinitions.repositoryTypes.public.label",
             },
+            Object {
+              "disabled": true,
+              "key": "DEVICE",
+              "onClick": [Function],
+              "text": "settings.modelDefinitions.repositoryTypes.device.label",
+            },
           ],
         }
       }
@@ -7241,6 +7272,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with no ite
                 "key": "PUBLIC",
                 "onClick": [Function],
                 "text": "settings.modelDefinitions.repositoryTypes.public.label",
+              },
+              Object {
+                "disabled": true,
+                "key": "DEVICE",
+                "onClick": [Function],
+                "text": "settings.modelDefinitions.repositoryTypes.device.label",
               },
             ],
           }
@@ -7504,6 +7541,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with no ite
                   "key": "PUBLIC",
                   "onClick": [Function],
                   "text": "settings.modelDefinitions.repositoryTypes.public.label",
+                },
+                Object {
+                  "disabled": true,
+                  "key": "DEVICE",
+                  "onClick": [Function],
+                  "text": "settings.modelDefinitions.repositoryTypes.device.label",
                 },
               ],
             }
@@ -9656,6 +9699,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with public
               "onClick": [Function],
               "text": "settings.modelDefinitions.repositoryTypes.public.label",
             },
+            Object {
+              "disabled": false,
+              "key": "DEVICE",
+              "onClick": [Function],
+              "text": "settings.modelDefinitions.repositoryTypes.device.label",
+            },
           ],
         }
       }
@@ -9682,6 +9731,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with public
                 "key": "PUBLIC",
                 "onClick": [Function],
                 "text": "settings.modelDefinitions.repositoryTypes.public.label",
+              },
+              Object {
+                "disabled": false,
+                "key": "DEVICE",
+                "onClick": [Function],
+                "text": "settings.modelDefinitions.repositoryTypes.device.label",
               },
             ],
           }
@@ -9945,6 +10000,12 @@ exports[`components/settings/repositoryLocationList matches snapshot with public
                   "key": "PUBLIC",
                   "onClick": [Function],
                   "text": "settings.modelDefinitions.repositoryTypes.public.label",
+                },
+                Object {
+                  "disabled": false,
+                  "key": "DEVICE",
+                  "onClick": [Function],
+                  "text": "settings.modelDefinitions.repositoryTypes.device.label",
                 },
               ],
             }

--- a/src/app/settings/components/__snapshots__/settingsPane.spec.tsx.snap
+++ b/src/app/settings/components/__snapshots__/settingsPane.spec.tsx.snap
@@ -3253,6 +3253,9 @@ exports[`components/settings/settingsPane matches snapshot open 1`] = `
                                                   "settings.modelDefinitions.repositoryTypes.public.label",
                                                 ],
                                                 Array [
+                                                  "settings.modelDefinitions.repositoryTypes.device.label",
+                                                ],
+                                                Array [
                                                   "settings.modelDefinitions.add",
                                                 ],
                                                 Array [
@@ -3355,6 +3358,10 @@ exports[`components/settings/settingsPane matches snapshot open 1`] = `
                                                 Object {
                                                   "type": "return",
                                                   "value": "settings.modelDefinitions.repositoryTypes.public.label",
+                                                },
+                                                Object {
+                                                  "type": "return",
+                                                  "value": "settings.modelDefinitions.repositoryTypes.device.label",
                                                 },
                                                 Object {
                                                   "type": "return",
@@ -9278,6 +9285,12 @@ exports[`components/settings/settingsPane matches snapshot open 1`] = `
                                                       "onClick": [Function],
                                                       "text": "settings.modelDefinitions.repositoryTypes.public.label",
                                                     },
+                                                    Object {
+                                                      "disabled": false,
+                                                      "key": "DEVICE",
+                                                      "onClick": [Function],
+                                                      "text": "settings.modelDefinitions.repositoryTypes.device.label",
+                                                    },
                                                   ],
                                                 }
                                               }
@@ -9304,6 +9317,12 @@ exports[`components/settings/settingsPane matches snapshot open 1`] = `
                                                         "key": "PUBLIC",
                                                         "onClick": [Function],
                                                         "text": "settings.modelDefinitions.repositoryTypes.public.label",
+                                                      },
+                                                      Object {
+                                                        "disabled": false,
+                                                        "key": "DEVICE",
+                                                        "onClick": [Function],
+                                                        "text": "settings.modelDefinitions.repositoryTypes.device.label",
                                                       },
                                                     ],
                                                   }
@@ -9567,6 +9586,12 @@ exports[`components/settings/settingsPane matches snapshot open 1`] = `
                                                           "key": "PUBLIC",
                                                           "onClick": [Function],
                                                           "text": "settings.modelDefinitions.repositoryTypes.public.label",
+                                                        },
+                                                        Object {
+                                                          "disabled": false,
+                                                          "key": "DEVICE",
+                                                          "onClick": [Function],
+                                                          "text": "settings.modelDefinitions.repositoryTypes.device.label",
                                                         },
                                                       ],
                                                     }
@@ -16469,6 +16494,9 @@ exports[`components/settings/settingsPane matches snapshot with repositoryLocati
                                                   "settings.modelDefinitions.repositoryTypes.public.label",
                                                 ],
                                                 Array [
+                                                  "settings.modelDefinitions.repositoryTypes.device.label",
+                                                ],
+                                                Array [
                                                   "settings.modelDefinitions.add",
                                                 ],
                                                 Array [
@@ -16595,6 +16623,10 @@ exports[`components/settings/settingsPane matches snapshot with repositoryLocati
                                                 Object {
                                                   "type": "return",
                                                   "value": "settings.modelDefinitions.repositoryTypes.public.label",
+                                                },
+                                                Object {
+                                                  "type": "return",
+                                                  "value": "settings.modelDefinitions.repositoryTypes.device.label",
                                                 },
                                                 Object {
                                                   "type": "return",
@@ -22632,6 +22664,9 @@ exports[`components/settings/settingsPane matches snapshot with repositoryLocati
                                                                       "settings.modelDefinitions.repositoryTypes.public.label",
                                                                     ],
                                                                     Array [
+                                                                      "settings.modelDefinitions.repositoryTypes.device.label",
+                                                                    ],
+                                                                    Array [
                                                                       "settings.modelDefinitions.add",
                                                                     ],
                                                                     Array [
@@ -22758,6 +22793,10 @@ exports[`components/settings/settingsPane matches snapshot with repositoryLocati
                                                                     Object {
                                                                       "type": "return",
                                                                       "value": "settings.modelDefinitions.repositoryTypes.public.label",
+                                                                    },
+                                                                    Object {
+                                                                      "type": "return",
+                                                                      "value": "settings.modelDefinitions.repositoryTypes.device.label",
                                                                     },
                                                                     Object {
                                                                       "type": "return",
@@ -26326,6 +26365,12 @@ exports[`components/settings/settingsPane matches snapshot with repositoryLocati
                                                       "onClick": [Function],
                                                       "text": "settings.modelDefinitions.repositoryTypes.public.label",
                                                     },
+                                                    Object {
+                                                      "disabled": false,
+                                                      "key": "DEVICE",
+                                                      "onClick": [Function],
+                                                      "text": "settings.modelDefinitions.repositoryTypes.device.label",
+                                                    },
                                                   ],
                                                 }
                                               }
@@ -26352,6 +26397,12 @@ exports[`components/settings/settingsPane matches snapshot with repositoryLocati
                                                         "key": "PUBLIC",
                                                         "onClick": [Function],
                                                         "text": "settings.modelDefinitions.repositoryTypes.public.label",
+                                                      },
+                                                      Object {
+                                                        "disabled": false,
+                                                        "key": "DEVICE",
+                                                        "onClick": [Function],
+                                                        "text": "settings.modelDefinitions.repositoryTypes.device.label",
                                                       },
                                                     ],
                                                   }
@@ -26615,6 +26666,12 @@ exports[`components/settings/settingsPane matches snapshot with repositoryLocati
                                                           "key": "PUBLIC",
                                                           "onClick": [Function],
                                                           "text": "settings.modelDefinitions.repositoryTypes.public.label",
+                                                        },
+                                                        Object {
+                                                          "disabled": false,
+                                                          "key": "DEVICE",
+                                                          "onClick": [Function],
+                                                          "text": "settings.modelDefinitions.repositoryTypes.device.label",
                                                         },
                                                       ],
                                                     }

--- a/src/app/settings/components/repositoryLocationList.tsx
+++ b/src/app/settings/components/repositoryLocationList.tsx
@@ -63,13 +63,12 @@ export default class RepositoryLocationList extends React.Component<RepositoryLo
                             onClick: () => this.onAddRepositoryType(REPOSITORY_LOCATION_TYPE.Public),
                             text: context.t(ResourceKeys.settings.modelDefinitions.repositoryTypes.public.label)
                         },
-                        // uncomment the following code once we can test getting model definition from devices
-                        // {
-                        //     disabled: !items || items.some(item => item.repositoryLocationType === REPOSITORY_LOCATION_TYPE.Device),
-                        //     key: REPOSITORY_LOCATION_TYPE.Device,
-                        //     onClick: () => this.onAddRepositoryType(REPOSITORY_LOCATION_TYPE.Device),
-                        //     text: context.t(ResourceKeys.settings.modelDefinitions.repositoryTypes.device.label),
-                        // }
+                        {
+                            disabled: !items || items.some(item => item.repositoryLocationType === REPOSITORY_LOCATION_TYPE.Device),
+                            key: REPOSITORY_LOCATION_TYPE.Device,
+                            onClick: () => this.onAddRepositoryType(REPOSITORY_LOCATION_TYPE.Device),
+                            text: context.t(ResourceKeys.settings.modelDefinitions.repositoryTypes.device.label),
+                        }
                     ];
                     return(
                         <div className="location-list">


### PR DESCRIPTION
- Enable getting model definition from device
- Handle happy failure cases, when device failure is returned as one of the header
- Handle cases when request has no body