### PR TITLE
telemetry memory leak and bug fix

### DIFF
--- a/src/app/devices/deviceContent/components/deviceCommands/deviceCommandsContainer.tsx
+++ b/src/app/devices/deviceContent/components/deviceCommands/deviceCommandsContainer.tsx
@@ -10,14 +10,12 @@ import { StateType } from '../../../../shared/redux/state';
 import DeviceCommands, { DeviceCommandDispatchProps, DeviceCommandsProps } from './deviceCommands';
 import { getDeviceCommandPairs } from './selectors';
 import { invokeDigitalTwinInterfaceCommandAction, setInterfaceIdAction, InvokeDigitalTwinInterfaceCommandActionParameters, getModelDefinitionAction } from '../../actions';
-import { getDeviceTwinStateSelector } from '../deviceTwin/selectors';
 import { getModelDefinitionSyncStatusSelector, getInterfaceNameSelector } from '../../selectors';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
 
 const mapStateToProps = (state: StateType): DeviceCommandsProps => {
     return {
-        isLoading: getDeviceTwinStateSelector(state) === SynchronizationStatus.working ||
-            getModelDefinitionSyncStatusSelector(state) === SynchronizationStatus.working,
+        isLoading: getModelDefinitionSyncStatusSelector(state) === SynchronizationStatus.working,
         ...getDeviceCommandPairs(state),
         interfaceName: getInterfaceNameSelector(state)
     };

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEvents.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEvents.tsx
@@ -34,6 +34,7 @@ interface DeviceEventsState {
 export default class DeviceEventsComponent extends React.Component<DeviceEventsDataProps & RouteComponentProps, DeviceEventsState> {
     // tslint:disable-next-line:no-any
     private timerID: any;
+    private isComponentMounted: boolean;
     constructor(props: DeviceEventsDataProps & RouteComponentProps) {
         super(props);
 
@@ -46,7 +47,8 @@ export default class DeviceEventsComponent extends React.Component<DeviceEventsD
 
     public componentWillUnmount() {
         clearInterval(this.timerID);
-      }
+        this.isComponentMounted = false;
+    }
 
     public render(): JSX.Element {
         return (
@@ -85,6 +87,10 @@ export default class DeviceEventsComponent extends React.Component<DeviceEventsD
         );
     }
 
+    public componentDidMount() {
+        this.isComponentMounted = true;
+    }
+
     private readonly renderInfiniteScroll = (context: LocalizationContextInterface) => {
         const { hasMore } = this.state;
         return (
@@ -98,12 +104,12 @@ export default class DeviceEventsComponent extends React.Component<DeviceEventsD
                 role="feed"
                 isReverse={true}
             >
-            {this.renderEvents(context)}
+            {this.renderEvents()}
             </InfiniteScroll>
         );
     }
 
-    private readonly renderEvents = (context: LocalizationContextInterface) => {
+    private readonly renderEvents = () => {
         const { events } = this.state;
 
         return events && events.map((event: Message, index) => {
@@ -141,11 +147,13 @@ export default class DeviceEventsComponent extends React.Component<DeviceEventsD
                     })
                     .then(results => {
                         const messages = results && results.reverse().map((message: Message) => message);
-                        this.setState({
-                            events: [...messages, ...this.state.events],
-                            loading: false,
-                            startTime: new Date()
-                        });
+                        if (this.isComponentMounted) {
+                            this.setState({
+                                events: [...messages, ...this.state.events],
+                                loading: false,
+                                startTime: new Date()
+                            });
+                        }
                     });
                 },
                 LOADING_LOCK);

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterfaceContainer.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterfaceContainer.tsx
@@ -10,7 +10,6 @@ import { StateType } from '../../../../shared/redux/state';
 import DeviceEventsPerInterfaceComponent, { DeviceEventsDataProps, DeviceEventsDispatchProps } from './deviceEventsPerInterface';
 import { getConnectionStringSelector } from '../../../../login/selectors';
 import { getDeviceTelemetrySelector } from './selectors';
-import { getDeviceTwinStateSelector } from '../deviceTwin/selectors';
 import { getModelDefinitionSyncStatusSelector } from '../../selectors';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
 import { setInterfaceIdAction, getModelDefinitionAction } from '../../actions';
@@ -18,8 +17,7 @@ import { setInterfaceIdAction, getModelDefinitionAction } from '../../actions';
 const mapStateToProps = (state: StateType): DeviceEventsDataProps => {
     return {
         connectionString: getConnectionStringSelector(state),
-        isLoading: getDeviceTwinStateSelector(state) === SynchronizationStatus.working ||
-            getModelDefinitionSyncStatusSelector(state) === SynchronizationStatus.working,
+        isLoading: getModelDefinitionSyncStatusSelector(state) === SynchronizationStatus.working,
         telemetrySchema: getDeviceTelemetrySelector(state)
     };
 };

--- a/src/app/devices/deviceContent/components/deviceProperties/devicePropertiesContainer.tsx
+++ b/src/app/devices/deviceContent/components/deviceProperties/devicePropertiesContainer.tsx
@@ -10,13 +10,12 @@ import { StateType } from '../../../../shared/redux/state';
 import DeviceProperties, { DevicePropertiesDataProps, DevicePropertiesDispatchProps } from './deviceProperties';
 import { getDevicePropertyTupleSelector } from './selectors';
 import { setInterfaceIdAction, getDigitalTwinInterfacePropertiesAction, getModelDefinitionAction } from '../../actions';
-import { getDeviceTwinStateSelector } from '../deviceTwin/selectors';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
-import { getModelDefinitionSyncStatusSelector } from '../../selectors';
+import { getModelDefinitionSyncStatusSelector, getDigitalTwinInterfacePropertiesStateSelector } from '../../selectors';
 
 const mapStateToProps = (state: StateType): DevicePropertiesDataProps => {
     return {
-        isLoading: getDeviceTwinStateSelector(state) === SynchronizationStatus.working ||
+        isLoading: getDigitalTwinInterfacePropertiesStateSelector(state) === SynchronizationStatus.working ||
             getModelDefinitionSyncStatusSelector(state) === SynchronizationStatus.working,
         twinAndSchema: getDevicePropertyTupleSelector(state)
     };

--- a/src/app/devices/deviceContent/components/deviceSettings/deviceSettingsContainer.tsx
+++ b/src/app/devices/deviceContent/components/deviceSettings/deviceSettingsContainer.tsx
@@ -10,13 +10,12 @@ import { StateType } from '../../../../shared/redux/state';
 import DeviceSettings, { DeviceSettingDispatchProps, DeviceSettingsProps } from './deviceSettings';
 import { setInterfaceIdAction, patchDigitalTwinInterfacePropertiesAction, PatchDigitalTwinInterfacePropertiesActionParameters, getDigitalTwinInterfacePropertiesAction, getModelDefinitionAction } from '../../actions';
 import { getDeviceSettingTupleSelector } from './selectors';
-import { getDeviceTwinStateSelector } from '../deviceTwin/selectors';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
-import { getModelDefinitionSyncStatusSelector } from '../../selectors';
+import { getModelDefinitionSyncStatusSelector, getDigitalTwinInterfacePropertiesStateSelector } from '../../selectors';
 
 const mapStateToProps = (state: StateType): DeviceSettingsProps => {
     return {
-        isLoading: getDeviceTwinStateSelector(state) === SynchronizationStatus.working ||
+        isLoading: getDigitalTwinInterfacePropertiesStateSelector(state) === SynchronizationStatus.working ||
             getModelDefinitionSyncStatusSelector(state) === SynchronizationStatus.working,
         ...getDeviceSettingTupleSelector(state)
     };

--- a/src/app/devices/deviceContent/components/deviceTwin/selectors.ts
+++ b/src/app/devices/deviceContent/components/deviceTwin/selectors.ts
@@ -19,10 +19,3 @@ export const getDeviceTwinStateSelector = (state: StateType): SynchronizationSta
     state.deviceContentState.deviceTwin &&
     state.deviceContentState.deviceTwin.deviceTwinSynchronizationStatus;
 };
-
-export const getReportedPropertiesSelector = (state: StateType) => {
-    const deviceTwin = getDeviceTwinSelector(state);
-    return deviceTwin &&
-    deviceTwin.properties &&
-    deviceTwin.properties.reported as any; // tslint:disable-line:no-any
-};

--- a/src/app/devices/deviceContent/selectors.ts
+++ b/src/app/devices/deviceContent/selectors.ts
@@ -50,6 +50,13 @@ export const getDigitalTwinInterfacePropertiesWrapperSelector = (state: StateTyp
         state.deviceContentState.digitalTwinInterfaceProperties;
 };
 
+export const getDigitalTwinInterfacePropertiesStateSelector = createSelector(
+    getDigitalTwinInterfacePropertiesWrapperSelector,
+    properties => {
+        return properties && properties.digitalTwinInterfacePropertiesSyncStatus;
+    }
+);
+
 export const getDigitalTwinInterfacePropertiesSelector = (state: StateInterface): DigitalTwinInterfaces => {
     return state &&
         state.deviceContentState &&


### PR DESCRIPTION
1. Fix memory leak on telemetry tab, where the promise finishes when the component is unmounted
2. Fix unique key warning for inifiniteScroll, when using custom loader, the loader itself needs a "key"
3. Fix a few loading property, where only device properties and settings are depend on digital twin's status, where commands and events don't have anything to do with digital twin
4. Need to cleanup the events when users switch between different interfaces