### PR TITLE
only allow one electron instance to be open a time

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -82,8 +82,8 @@ function createMenu() {
 }
 
 // prevent multiple instances in Electron
-const gotTheLock = app.requestSingleInstanceLock();
-if (!gotTheLock) {
+const lock = app.requestSingleInstanceLock();
+if (!lock) {
     app.quit();
 }
 else {


### PR DESCRIPTION
Using Electron's api, we would be able to limit only one azure iot explorer instance to open at a time. 
This should be able to prevent the port in use error in a lot of cases