### PR TITLE
remove capture of shortcut

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -23,14 +23,6 @@ function createWindow() {
     }
 
     mainWindow.on('closed', () => mainWindow = null);
-    // Enable refresh shortcut
-    const globalShortcut = electron.globalShortcut;
-    globalShortcut.register('f5', function() {
-		mainWindow.reload()
-	})
-	globalShortcut.register('CommandOrControl+R', function() {
-		mainWindow.reload()
-	})
 }
 
 function createMenu() {


### PR DESCRIPTION
Electron is capture shortcut even if it is minimined.
Removing it as now the menu supports refresh and the short key would only kick in when electron is being focused.
