### PR TITLE
move scroll down to the events under header

### DIFF
--- a/src/app/css/_devicePnpDetailList.scss
+++ b/src/app/css/_devicePnpDetailList.scss
@@ -48,7 +48,6 @@
 
 .pnp-detail-list {
     padding-top: 20px;
-    position: sticky;
     top: 0;
     background-color: $white;
     .list-header {
@@ -230,6 +229,6 @@
 }
 
 .scrollable-sm {
-    height: calc(100vh - 350px);
+    height: calc(100vh - 392px);
     overflow-y: auto;
 }

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
@@ -231,7 +231,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                 role="feed"
                 isReverse={true}
             >
-            <section role="list" className="list-content scrollable-sm">
+            <section role="list" className="list-content">
                 {this.renderEvents(context)}
             </section>
             </InfiniteScroll>
@@ -252,6 +252,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                         <span className="column-value">{context.t(ResourceKeys.deviceEvents.columns.value)}</span>
                     </div>
                 </div>
+                <div className="scrollable-sm">
                 {
                     events && events.map((event: Message, index) => {
                         const matchingSchema = this.props.telemetrySchema.filter(schema => schema.telemetryModelDefinition.name ===
@@ -272,6 +273,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                         );
                     })
                 }
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
Similar to the height fix in raw telemetry tab, the scroll also needs to be fixed on the per interface page. Also move the scrollbar down to the body of the table under header.