### PR TITLE
remove localize logic in reducer

### DIFF
--- a/src/app/api/dataTransforms/modelDefinitionTransform.spec.ts
+++ b/src/app/api/dataTransforms/modelDefinitionTransform.spec.ts
@@ -3,66 +3,16 @@
  * Licensed under the MIT License
  **********************************************************/
 import 'jest';
-import { transformModelDefinition } from './modelDefinitionTransform';
-import { ModelDefinition } from './../models/modelDefinition';
+import { getLocalizedData } from './modelDefinitionTransform';
 
 describe('modelDefinitionTransform', () => {
 
-    /* tslint:disable */
-    const modelDefinitionTransformed: ModelDefinition = {
-        "@id": "urn:azureiot:ModelDiscovery:ModelInformation:1",
-        "@type": "Interface",
-        "displayName": "Model Information",
-        "description": "Model Information description",
-        "contents": [
-        {
-            "@type": "Telemetry",
-            "name": "modelInformation",
-            "displayName": "Model Information ",
-            "description": "Ids for the capability model and interfaces implemented on the device.",
-            "schema": {
-                "@type": "Object",
-                "fields": [
-                    {
-                        "name": "capabilityModelId",
-                        "schema": "string"
-                    },
-                    {
-                        "name": "interfaces",
-                        "schema": {
-                            "@type": "Map",
-                            "mapKey": {
-                                "name": "name",
-                                "schema": "string"
-                            },
-                            "mapValue": {
-                                "name": "schema",
-                                "schema": "string"
-                            }
-                        }
-                    }
-                ]
-            }
-        }],
-        "@context": "http://azureiot.com/v1/contexts/Interface.json"
-    };
-    /* tslint:enable */
-
-    describe('transformModelDefinition', () => {
-        it('transforms ModelDefinition to localized ModelDefinition', () => {
-            const modelDefinition1 = {
-                ...modelDefinitionTransformed,
-                description: 'Model Information description',
-                displayName: 'Model Information'
-            };
-            expect(transformModelDefinition(modelDefinition1)).toEqual(modelDefinitionTransformed);
-            const modelDefinition2 = {
-                ...modelDefinitionTransformed,
-                description: {en: 'Model Information description'},
-                displayName: {zh: 'Model Information'}
-            };
-            modelDefinitionTransformed.displayName = '';
-            expect(transformModelDefinition(modelDefinition2)).toEqual(modelDefinitionTransformed);
+    describe('getLocalizedData', () => {
+        it('transforms data to localized data', () => {
+            expect(getLocalizedData('Model Information description')).toEqual('Model Information description');
+            expect(getLocalizedData({en: 'Model Information description'})).toEqual('Model Information description');
+            expect(getLocalizedData({})).toEqual('');
+            expect(getLocalizedData({zh: '模型信息'})).toEqual('');
         });
     });
 });

--- a/src/app/api/dataTransforms/modelDefinitionTransform.ts
+++ b/src/app/api/dataTransforms/modelDefinitionTransform.ts
@@ -2,16 +2,6 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
-import { ModelDefinition } from './../models/modelDefinition';
-
-export const transformModelDefinition = (model: ModelDefinition): ModelDefinition => {
-    return {
-        ...model,
-        description: getLocalizedData(model.description),
-        displayName: getLocalizedData(model.displayName)
-    };
-};
-
 // tslint:disable-next-line:cyclomatic-complexity
 export const getLocalizedData = (data: string | object) => {
     if (typeof(data) === 'string')

--- a/src/app/devices/deviceContent/reducer.spec.ts
+++ b/src/app/devices/deviceContent/reducer.spec.ts
@@ -81,18 +81,12 @@ describe('deviceContentStateReducer', () => {
         it (`handles ${FETCH_MODEL_DEFINITION}/ACTION_START action`, () => {
             const action = getModelDefinitionAction.started({digitalTwinId: 'testDevice', interfaceId: 'urn:azureiot:ModelDiscovery:ModelInformation:1'});
             expect(reducer(deviceContentStateInitial(), action).modelDefinitionWithSource.modelDefinitionSynchronizationStatus).toEqual(SynchronizationStatus.working);
-            expect(reducer(deviceContentStateInitial(), action).modelDefinitionWithSource.source).toEqual(REPOSITORY_LOCATION_TYPE.None);
         });
 
         it (`handles ${FETCH_MODEL_DEFINITION}/ACTION_DONE action`, () => {
             const action = getModelDefinitionAction.done({params: {digitalTwinId: 'testDevice', interfaceId: 'urn:azureiot:ModelDiscovery:ModelInformation:1'}, result: {modelDefinition, source: REPOSITORY_LOCATION_TYPE.Public }});
-            const modelDefinitionTransformed = {
-                ...modelDefinition,
-                description: '',
-                displayName: modelDefinition.displayName
-            };
             expect(reducer(deviceContentStateInitial(), action).modelDefinitionWithSource).toEqual({
-                modelDefinition: modelDefinitionTransformed,
+                modelDefinition,
                 modelDefinitionSynchronizationStatus: SynchronizationStatus.fetched,
                 source: REPOSITORY_LOCATION_TYPE.Public
             });
@@ -101,7 +95,6 @@ describe('deviceContentStateReducer', () => {
         it (`handles ${FETCH_MODEL_DEFINITION}/ACTION_FAILED action`, () => {
             const action = getModelDefinitionAction.failed({error: -1, params: {digitalTwinId: 'testDevice', interfaceId: 'urn:azureiot:ModelDiscovery:ModelInformation:1'}});
             expect(reducer(deviceContentStateInitial(), action).modelDefinitionWithSource.modelDefinitionSynchronizationStatus).toEqual(SynchronizationStatus.failed);
-            expect(reducer(deviceContentStateInitial(), action).modelDefinitionWithSource.source).toEqual(REPOSITORY_LOCATION_TYPE.None);
         });
 
         it (`handles ${CLEAR_MODEL_DEFINITIONS} action`, () => {
@@ -171,7 +164,7 @@ describe('deviceContentStateReducer', () => {
 
         /* tslint:disable */
         const deviceIdentity: DeviceIdentity = {
-            cloudToDeviceMessageCount: '0',
+            cloudToDeviceMessageCount: 0,
             deviceId,
             etag: 'AAAAAAAAAAk=',
             status: 'enabled',
@@ -218,7 +211,7 @@ describe('deviceContentStateReducer', () => {
                 deviceIdentitySynchronizationStatus: SynchronizationStatus.fetched
             }
         });
-        deviceIdentity.cloudToDeviceMessageCount = '1';
+        deviceIdentity.cloudToDeviceMessageCount = 1;
 
         it (`handles ${UPDATE_DEVICE_IDENTITY}/ACTION_START action`, () => {
             const action = updateDeviceIdentityAction.started(deviceIdentity);

--- a/src/app/devices/deviceContent/reducer.ts
+++ b/src/app/devices/deviceContent/reducer.ts
@@ -25,7 +25,6 @@ import { DeviceIdentity } from '../../api/models/deviceIdentity';
 import { SynchronizationStatus } from '../../api/models/synchronizationStatus';
 import { InvokeMethodParameters } from '../../api/parameters/deviceParameters';
 import { DigitalTwinInterfaces } from '../../api/models/digitalTwinModels';
-import { transformModelDefinition } from './../../api/dataTransforms/modelDefinitionTransform';
 
 const reducer = reducerWithInitialState<DeviceContentStateType>(deviceContentStateInitial())
     //#region DeviceIdentity-related actions
@@ -135,7 +134,7 @@ const reducer = reducerWithInitialState<DeviceContentStateType>(deviceContentSta
     .case(getModelDefinitionAction.done, (state: DeviceContentStateType, payload: {params: GetModelDefinitionActionParameters} & {result: ModelDefinitionActionResult}) => {
         return state.merge({
             modelDefinitionWithSource: {
-                modelDefinition: transformModelDefinition(payload.result.modelDefinition),
+                modelDefinition: payload.result.modelDefinition,
                 modelDefinitionSynchronizationStatus: SynchronizationStatus.fetched,
                 source: payload.result.source
             }


### PR DESCRIPTION
Remove localize logic in reducer. The reason is, if we localize it first and then put in the store, when user navigate to "interface" tab, they would see a interface definition being different from the repo. 
Since now our UI handles the extra logic to localize description, displayname, this transform logic can and should be removed.
Also updated some outdated tests, not sure why npm run test is not catching the complication errors.