### PR TITLE
allow PauseOnHover for notification: github issue 107

### DIFF
--- a/src/app/notifications/components/notificationToast.tsx
+++ b/src/app/notifications/components/notificationToast.tsx
@@ -43,6 +43,7 @@ export const raiseNotificationToast = (notification: Notification) => {
     const options: ToastOptions = {
         bodyClassName: 'notification-toast-body',
         closeButton: <CloseButton />,
+        pauseOnHover: true,
         position: toast.POSITION.TOP_RIGHT,
         progressClassName: `notification-toast-progress-bar`,
         toastId: notification.id,


### PR DESCRIPTION
user would like command reponse to be preserved. While we do have the notification queue, but enabling the toast pauseOnHover can be an easy improvement.