### PR TITLE
fix error when it is not in json format

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 node-version: [8.x, 10.x, 12.x]
-                os: [ubuntu-latest, windows-latest, macOS-latest]
+                os: [ubuntu-latest, windows-2016, macOS-latest]
 
         steps:
         - uses: actions/checkout@v1
@@ -23,6 +23,7 @@ jobs:
           with:
               node-version: ${{ matrix.node-version }}
         - name: npm install, build, and test
+          timeout-minutes: 10
           run: |
               npm install
               npm run build --if-present

--- a/src/app/api/services/devicesService.spec.ts
+++ b/src/app/api/services/devicesService.spec.ts
@@ -75,41 +75,15 @@ describe('deviceTwinService', () => {
             expect(DevicesService.fetchDeviceTwin(parameters)).toEqual(emptyPromise);
         });
 
-        it ('returns if connection string is not valid', () => {
-            expect(DevicesService.fetchDeviceTwin({...parameters, deviceId, connectionString: undefined})).toEqual(emptyPromise);
-            expect(DevicesService.fetchDeviceTwin({...parameters, deviceId, connectionString: 'SharedAccessKeyName=owner;SharedAccessKey=fakeKey='})).toEqual(emptyPromise);
+        it ('throws if connection string is not valid', async () => {
+            await expect(DevicesService.fetchDeviceTwin({...parameters, deviceId, connectionString: undefined})).rejects.toThrow();
+            await expect(DevicesService.fetchDeviceTwin({...parameters, deviceId, connectionString: 'SharedAccessKeyName=owner;SharedAccessKey=fakeKey='})).rejects.toThrow();
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and returns deviceTwin when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.fetchDeviceTwin({
-                ...parameters,
-                deviceId
-            });
 
-            const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
-            const dataPlaneRequest: DevicesService.DataPlaneRequest = {
-                apiVersion: DIGITAL_TWIN_API_VERSION,
-                hostName: connectionInformation.connectionInfo.hostName,
-                httpMethod: HTTP_OPERATION_TYPES.Get,
-                path: `twins/${deviceId}`,
-                sharedAccessSignature: connectionInformation.sasToken
-            };
-
-            const serviceRequestParams = {
-                body: JSON.stringify(dataPlaneRequest),
-                cache: 'no-cache',
-                credentials: 'include',
-                headers,
-                method: HTTP_OPERATION_TYPES.Post,
-                mode: 'cors',
-            };
-
-            expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('returns deviceTwin when response is 200', async done => {
             // tslint:disable
             const response = {
                 json: () => {return {
@@ -121,34 +95,39 @@ describe('deviceTwinService', () => {
             // tslint:enable
             jest.spyOn(window, 'fetch').mockResolvedValue(response);
 
+            const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
+            const dataPlaneRequest: DevicesService.DataPlaneRequest = {
+                apiVersion: DIGITAL_TWIN_API_VERSION,
+                hostName: connectionInformation.connectionInfo.hostName,
+                httpMethod: HTTP_OPERATION_TYPES.Get,
+                path: `twins/${deviceId}`,
+                sharedAccessSignature: connectionInformation.sasToken
+            };
+
             const result = await DevicesService.fetchDeviceTwin({
                 ...parameters,
                 deviceId
             });
+
+            const serviceRequestParams = {
+                body: JSON.stringify(dataPlaneRequest),
+                cache: 'no-cache',
+                credentials: 'include',
+                headers,
+                method: HTTP_OPERATION_TYPES.Post,
+                mode: 'cors',
+            };
+
+            expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
             expect(result).toEqual(twin);
-            done();
         });
 
-        it('throws Error when response status is 404', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {
-                    return {
-                        body: {
-                            Message: 'Not found'
-                        },
-                        headers:{}
-                        }
-                    },
-                status: 404
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
+        it('throws Error when promise rejects', async done => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error('Not found'));
             await expect(DevicesService.fetchDeviceTwin({
                 ...parameters,
                 deviceId
-            })).rejects.toThrow(new Error('Not found'));
+            })).rejects.toThrowError('Not found');
             done();
         });
     });
@@ -162,36 +141,9 @@ describe('deviceTwinService', () => {
             expect(DevicesService.fetchDigitalTwinInterfaceProperties(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and returns digitalTwin interfaces when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.fetchDigitalTwinInterfaceProperties({
-                ...parameters,
-                digitalTwinId: deviceId
-            });
-
-            const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
-            const dataPlaneRequest: DevicesService.DataPlaneRequest = {
-                apiVersion: DIGITAL_TWIN_API_VERSION,
-                hostName: connectionInformation.connectionInfo.hostName,
-                httpMethod: HTTP_OPERATION_TYPES.Get,
-                path: `/digitalTwins/${deviceId}/interfaces`,
-                sharedAccessSignature: connectionInformation.sasToken
-            };
-
-            const serviceRequestParams = {
-                body: JSON.stringify(dataPlaneRequest),
-                cache: 'no-cache',
-                credentials: 'include',
-                headers,
-                method: HTTP_OPERATION_TYPES.Post,
-                mode: 'cors',
-            };
-
-            expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('returns digitalTwin interfaces when response is 200', async done => {
             // tslint:disable
             const digitalTwin = {
                 interfaces: {
@@ -226,29 +178,35 @@ describe('deviceTwinService', () => {
                 ...parameters,
                 digitalTwinId: deviceId
             });
+
+            const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
+            const dataPlaneRequest: DevicesService.DataPlaneRequest = {
+                apiVersion: DIGITAL_TWIN_API_VERSION,
+                hostName: connectionInformation.connectionInfo.hostName,
+                httpMethod: HTTP_OPERATION_TYPES.Get,
+                path: `/digitalTwins/${deviceId}/interfaces`,
+                sharedAccessSignature: connectionInformation.sasToken
+            };
+
+            const serviceRequestParams = {
+                body: JSON.stringify(dataPlaneRequest),
+                cache: 'no-cache',
+                credentials: 'include',
+                headers,
+                method: HTTP_OPERATION_TYPES.Post,
+                mode: 'cors',
+            };
+
+            expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
             expect(result).toEqual(digitalTwin);
-            done();
         });
 
-        it('throws Error when response status is 500', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {
-                        ExceptionMessage: 'Internal server error'
-                    },
-                    headers:{}
-                    }},
-                status: 500
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error('Internal server error'));
             await expect(DevicesService.fetchDigitalTwinInterfaceProperties({
                 ...parameters,
                 digitalTwinId: deviceId
-            })).rejects.toThrow(new Error('Internal server error'));
-            done();
+            })).rejects.toThrow('Internal server error');
         });
     });
 
@@ -264,10 +222,27 @@ describe('deviceTwinService', () => {
             expect(DevicesService.invokeDigitalTwinInterfaceCommand(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes DigitalTwinInterfaceCommand when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.invokeDigitalTwinInterfaceCommand({
+
+            // tslint:disable
+            const responseBody = {
+                description: 'Invoked'
+            };
+            const response = {
+                json: () => {
+                    return {
+                        body: responseBody,
+                        headers:{}
+                        }
+                    },
+                status: 200
+            } as any;
+            // tslint:enable
+            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+            const result = await DevicesService.invokeDigitalTwinInterfaceCommand({
                 ...parameters,
                 digitalTwinId: deviceId
             });
@@ -294,53 +269,15 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes DigitalTwinInterfaceCommand when response is 200', async done => {
-            // tslint:disable
-            const responseBody = {
-                description: 'Invoked'
-            };
-            const response = {
-                json: () => {
-                    return {
-                        body: responseBody,
-                        headers:{}
-                        }
-                    },
-                status: 200
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            const result = await DevicesService.invokeDigitalTwinInterfaceCommand({
-                ...parameters,
-                digitalTwinId: deviceId
-            });
             expect(result).toEqual(responseBody);
-            done();
         });
 
-        it('throws Error when response status is 500', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {
-                        Message: 'Internal server error',
-                        ExceptionMessage: 'Internal hub error'
-                    },
-                    headers:{}
-                    }},
-                status: 500
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error('Internal server error'));
             await expect(DevicesService.invokeDigitalTwinInterfaceCommand({
                 ...parameters,
                 digitalTwinId: deviceId
-            })).rejects.toThrow(new Error('Internal server error'));
-            done();
+            })).rejects.toThrow('Internal server error');
         });
     });
 
@@ -367,10 +304,27 @@ describe('deviceTwinService', () => {
             expect(DevicesService.patchDigitalTwinInterfaceProperties(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes patchDigitalTwinInterfaceProperties when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.patchDigitalTwinInterfaceProperties({
+
+            // tslint:disable
+            const responseBody = {
+                ...payload
+            };
+            const response = {
+                json: () => {
+                    return {
+                        body: responseBody,
+                        headers:{}
+                        }
+                    },
+                status: 200
+            } as any;
+            // tslint:enable
+            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+            const result = await DevicesService.patchDigitalTwinInterfaceProperties({
                 ...parameters,
                 digitalTwinId: deviceId
             });
@@ -395,50 +349,16 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes patchDigitalTwinInterfaceProperties when response is 200', async done => {
-            // tslint:disable
-            const responseBody = {
-                ...payload
-            };
-            const response = {
-                json: () => {
-                    return {
-                        body: responseBody,
-                        headers:{}
-                        }
-                    },
-                status: 200
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            const result = await DevicesService.patchDigitalTwinInterfaceProperties({
-                ...parameters,
-                digitalTwinId: deviceId
-            });
             expect(result).toEqual(responseBody);
-            done();
         });
 
-        it('throws Error when response status is 501', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {},
-                    headers:{}
-                    }},
-                status: 501
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error());
 
             await expect(DevicesService.patchDigitalTwinInterfaceProperties({
                 ...parameters,
                 digitalTwinId: deviceId
             })).rejects.toThrow(new Error());
-            done();
         });
     });
 
@@ -452,10 +372,25 @@ describe('deviceTwinService', () => {
             expect(DevicesService.updateDeviceTwin(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes updateDeviceTwin when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.updateDeviceTwin({
+
+            // tslint:disable
+            const responseBody = twin;
+            const response = {
+                json: () => {
+                    return {
+                        body: responseBody,
+                        headers:{}
+                        }
+                    },
+                status: 200
+            } as any;
+            // tslint:enable
+            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+            const result = await DevicesService.updateDeviceTwin({
                 ...parameters,
                 deviceId
             });
@@ -480,48 +415,15 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes updateDeviceTwin when response is 200', async done => {
-            // tslint:disable
-            const responseBody = twin;
-            const response = {
-                json: () => {
-                    return {
-                        body: responseBody,
-                        headers:{}
-                        }
-                    },
-                status: 200
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            const result = await DevicesService.updateDeviceTwin({
-                ...parameters,
-                deviceId
-            });
             expect(result).toEqual(responseBody);
-            done();
         });
 
-        it('throws Error when response status is 501', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {},
-                    headers:{}
-                    }},
-                status: 501
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error());
             await expect(DevicesService.updateDeviceTwin({
                 ...parameters,
                 deviceId
             })).rejects.toThrow(new Error());
-            done();
         });
     });
 
@@ -538,10 +440,25 @@ describe('deviceTwinService', () => {
             expect(DevicesService.invokeDirectMethod(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes invokeDirectMethod when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.invokeDirectMethod({
+
+            // tslint:disable
+            const responseBody = {description: 'invoked'};
+            const response = {
+                json: () => {
+                    return {
+                        body: responseBody,
+                        headers:{}
+                        }
+                    },
+                status: 200
+            } as any;
+            // tslint:enable
+            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+            const result = await DevicesService.invokeDirectMethod({
                 ...parameters,
                 deviceId
             });
@@ -570,48 +487,15 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes invokeDirectMethod when response is 200', async done => {
-            // tslint:disable
-            const responseBody = {description: 'invoked'};
-            const response = {
-                json: () => {
-                    return {
-                        body: responseBody,
-                        headers:{}
-                        }
-                    },
-                status: 200
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            const result = await DevicesService.invokeDirectMethod({
-                ...parameters,
-                deviceId
-            });
             expect(result).toEqual(responseBody);
-            done();
         });
 
-        it('throws Error when response status is 409', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {},
-                    headers:{}
-                    }},
-                status: 409
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error());
             await expect(DevicesService.invokeDirectMethod({
                 ...parameters,
                 deviceId
             })).rejects.toThrow(new Error());
-            done();
         });
     });
 
@@ -623,7 +507,7 @@ describe('deviceTwinService', () => {
             properties: undefined
         };
 
-        it('calls fetch with specified parameters', async done => {
+        it('calls fetch with specified parameters', async () => {
             // tslint:disable
             const responseBody = {description: 'invoked'};
             const response = {
@@ -656,26 +540,14 @@ describe('deviceTwinService', () => {
                 method: HTTP_OPERATION_TYPES.Post,
                 mode: 'cors',
             });
-            done();
         });
 
-        it('throws Error when response status is 409', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    message: 'error',
-                    headers:{}
-                    }},
-                status: 409
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error('error'));
             await expect(DevicesService.cloudToDeviceMessage({
                 ...parameters,
                 deviceId
             })).rejects.toThrow(new Error('error'));
-            done();
         });
     });
 
@@ -688,36 +560,9 @@ describe('deviceTwinService', () => {
             expect(DevicesService.addDevice(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes addDevice when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.addDevice({
-                ...parameters,
-                deviceIdentity
-            });
-
-            const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
-            const dataPlaneRequest: DevicesService.DataPlaneRequest = {
-                body: JSON.stringify(deviceIdentity),
-                hostName: connectionInformation.connectionInfo.hostName,
-                httpMethod: HTTP_OPERATION_TYPES.Put,
-                path: `devices/${deviceId}`,
-                sharedAccessSignature: connectionInformation.sasToken
-            };
-
-            const serviceRequestParams = {
-                body: JSON.stringify(dataPlaneRequest),
-                cache: 'no-cache',
-                credentials: 'include',
-                headers,
-                method: HTTP_OPERATION_TYPES.Post,
-                mode: 'cors',
-            };
-
-            expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes addDevice when response is 200', async done => {
             // tslint:disable
             const responseBody = deviceIdentity;
             const response = {
@@ -736,27 +581,35 @@ describe('deviceTwinService', () => {
                 ...parameters,
                 deviceIdentity
             });
+
+            const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
+            const dataPlaneRequest: DevicesService.DataPlaneRequest = {
+                body: JSON.stringify(deviceIdentity),
+                hostName: connectionInformation.connectionInfo.hostName,
+                httpMethod: HTTP_OPERATION_TYPES.Put,
+                path: `devices/${deviceId}`,
+                sharedAccessSignature: connectionInformation.sasToken
+            };
+
+            const serviceRequestParams = {
+                body: JSON.stringify(dataPlaneRequest),
+                cache: 'no-cache',
+                credentials: 'include',
+                headers,
+                method: HTTP_OPERATION_TYPES.Post,
+                mode: 'cors',
+            };
+
+            expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
             expect(result).toEqual(responseBody);
-            done();
         });
 
-        it('throws Error when response status is 409', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {},
-                    headers:{}
-                    }},
-                status: 409
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error());
             await expect(DevicesService.addDevice({
                 ...parameters,
                 deviceIdentity
             })).rejects.toThrow(new Error());
-            done();
         });
     });
 
@@ -769,10 +622,24 @@ describe('deviceTwinService', () => {
             expect(DevicesService.updateDevice(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes updateDevice when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.updateDevice({
+            // tslint:disable
+            const responseBody = deviceIdentity;
+            const response = {
+                json: () => {
+                    return {
+                        body: responseBody,
+                        headers:{}
+                        }
+                    },
+                status: 200
+            } as any;
+            // tslint:enable
+            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+            const result = await DevicesService.updateDevice({
                 ...parameters,
                 deviceIdentity
             });
@@ -796,9 +663,30 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
+            expect(result).toEqual(responseBody);
         });
 
-        it('invokes updateDevice when response is 200', async done => {
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error());
+            await expect(DevicesService.updateDevice({
+                ...parameters,
+                deviceIdentity
+            })).rejects.toThrow(new Error());
+        });
+    });
+
+    context('fetchDevice', () => {
+        const parameters = {
+            connectionString,
+            deviceId: undefined
+        };
+        it ('returns if deviceId is not specified', () => {
+            expect(DevicesService.fetchDevice(parameters)).toEqual(emptyPromise);
+        });
+
+        it('calls fetch with specified parameters and invokes fetchDevice when response is 200', async () => {
+            jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
+                connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
             // tslint:disable
             const responseBody = deviceIdentity;
             const response = {
@@ -813,47 +701,7 @@ describe('deviceTwinService', () => {
             // tslint:enable
             jest.spyOn(window, 'fetch').mockResolvedValue(response);
 
-            const result = await DevicesService.updateDevice({
-                ...parameters,
-                deviceIdentity
-            });
-            expect(result).toEqual(responseBody);
-            done();
-        });
-
-        it('throws Error when response status is 500', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {},
-                    headers:{}
-                    }},
-                status: 500
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            await expect(DevicesService.updateDevice({
-                ...parameters,
-                deviceIdentity
-            })).rejects.toThrow(new Error());
-            done();
-        });
-    });
-
-    context('fetchDevice', () => {
-        const parameters = {
-            connectionString,
-            deviceId: undefined
-        };
-        it ('returns if deviceId is not specified', () => {
-            expect(DevicesService.fetchDevice(parameters)).toEqual(emptyPromise);
-        });
-
-        it('calls fetch with specified parameters', () => {
-            jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
-                connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.fetchDevice({
+            const result = await DevicesService.fetchDevice({
                 ...parameters,
                 deviceId
             });
@@ -876,48 +724,15 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes fetchDevice when response is 200', async done => {
-            // tslint:disable
-            const responseBody = deviceIdentity;
-            const response = {
-                json: () => {
-                    return {
-                        body: responseBody,
-                        headers:{}
-                        }
-                    },
-                status: 200
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            const result = await DevicesService.fetchDevice({
-                ...parameters,
-                deviceId
-            });
             expect(result).toEqual(responseBody);
-            done();
         });
 
-        it('throws Error when response status is 500', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {},
-                    headers:{}
-                    }},
-                status: 500
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error());
             await expect(DevicesService.fetchDevice({
                 ...parameters,
                 deviceId
-            })).rejects.toThrow(new Error());
-            done();
+            })).rejects.toThrowError();
         });
     });
 
@@ -932,10 +747,24 @@ describe('deviceTwinService', () => {
             }
         };
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes fetchDevices when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
-            DevicesService.fetchDevices(parameters);
+            // tslint:disable
+            const responseBody = deviceIdentity;
+            const response = {
+                json: () => {
+                    return {
+                        body: [responseBody],
+                        headers:{foo: 'bar'}
+                        }
+                    },
+                status: 200
+            } as any;
+            // tslint:enable
+            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
+            const result = await DevicesService.fetchDevices(parameters);
 
             const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
             const queryString = buildQueryString(parameters.query);
@@ -961,42 +790,12 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes fetchDevices when response is 200', async done => {
-            // tslint:disable
-            const responseBody = deviceIdentity;
-            const response = {
-                json: () => {
-                    return {
-                        body: [responseBody],
-                        headers:{foo: 'bar'}
-                        }
-                    },
-                status: 200
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            const result = await DevicesService.fetchDevices(parameters);
             expect(result).toEqual({body: [responseBody], headers: {foo: 'bar'}});
-            done();
         });
 
-        it('throws Error when response status is 500', async done => {
-            // tslint:disable
-            const response = {
-                json: () => {return {
-                    body: {},
-                    headers:{}
-                    }},
-                status: 500
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            await expect(DevicesService.fetchDevices(parameters)).rejects.toThrow(new Error());
-            done();
+        it('throws Error when promise rejects', async () => {
+            window.fetch = jest.fn().mockRejectedValueOnce(new Error());
+            await expect(DevicesService.fetchDevices(parameters)).rejects.toThrow(new Error()).catch();
         });
     });
 
@@ -1009,14 +808,30 @@ describe('deviceTwinService', () => {
             expect(DevicesService.deleteDevices(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes deleteDevices when response is 200', async () => {
             jest.spyOn(DevicesService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
+
+             // tslint:disable
+             const responseBody = {isSuccessful:true, errors:[], warnings:[]};
+             const response = {
+                 json: () => {
+                     return {
+                         body: responseBody,
+                         headers:{}
+                         }
+                     },
+                 status: 200
+             } as any;
+             // tslint:enable
+            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
             parameters = {
                 ...parameters,
                 deviceIds: [deviceId]
             };
-            DevicesService.deleteDevices(parameters);
+
+            const result = await DevicesService.deleteDevices(parameters);
 
             const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
             const deviceDeletionInstructions = parameters.deviceIds.map(id => {
@@ -1044,32 +859,10 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.DATAPLANE_CONTROLLER_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes deleteDevices when response is 200', async done => {
-            // tslint:disable
-            const responseBody = {isSuccessful:true, errors:[], warnings:[]};
-            const response = {
-                json: () => {
-                    return {
-                        body: responseBody,
-                        headers:{}
-                        }
-                    },
-                status: 200
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            const result = await DevicesService.deleteDevices({
-                ...parameters,
-                deviceIds: [deviceId]
-            });
             expect(result).toEqual(responseBody);
-            done();
         });
 
-        it('throws Error when response status is 500', async done => {
+        it('throws Error when response status is 500', async () => {
             // tslint:disable
             const response = {
                 json: () => {return {
@@ -1084,8 +877,7 @@ describe('deviceTwinService', () => {
             await expect(DevicesService.deleteDevices({
                 ...parameters,
                 deviceIds: [deviceId]
-            })).rejects.toThrow(new Error());
-            done();
+            })).rejects.toThrow(new Error()).catch();
         });
     });
 
@@ -1101,12 +893,21 @@ describe('deviceTwinService', () => {
             expect(DevicesService.monitorEvents(parameters)).toEqual(emptyPromise);
         });
 
-        it('calls fetch with specified parameters', () => {
+        it('calls fetch with specified parameters and invokes monitorEvents when response is 200', async () => {
+            // tslint:disable
+            const responseBody = [{'body':{'temp':0},'enqueuedTime':'2019-09-06T17:47:11.334Z','properties':{'iothub-message-schema':'temp'}}];
+            const response = {
+                json: () => responseBody,
+                status: 200
+            } as any;
+            // tslint:enable
+            jest.spyOn(window, 'fetch').mockResolvedValue(response);
+
             parameters = {
                 ...parameters,
                 hubConnectionString: connectionString
             };
-            DevicesService.monitorEvents(parameters);
+            const result = await DevicesService.monitorEvents(parameters);
 
             const eventHubRequestParameters = {
                 connectionString,
@@ -1126,24 +927,7 @@ describe('deviceTwinService', () => {
             };
 
             expect(fetch).toBeCalledWith(DevicesService.EVENTHUB_MONITOR_ENDPOINT, serviceRequestParams);
-        });
-
-        it('invokes monitorEvents when response is 200', async done => {
-            // tslint:disable
-            const responseBody = [{'body':{'temp':0},'enqueuedTime':'2019-09-06T17:47:11.334Z','properties':{'iothub-message-schema':'temp'}}];
-            const response = {
-                json: () => responseBody,
-                status: 200
-            } as any;
-            // tslint:enable
-            jest.spyOn(window, 'fetch').mockResolvedValue(response);
-
-            const result = await DevicesService.monitorEvents({
-                ...parameters,
-                hubConnectionString: connectionString
-            });
             expect(result).toEqual(responseBody);
-            done();
         });
     });
 

--- a/src/app/api/services/devicesService.ts
+++ b/src/app/api/services/devicesService.ts
@@ -95,7 +95,14 @@ export const dataPlaneConnectionHelper = (parameters: DataPlaneParameters) => {
 // tslint:disable-next-line:cyclomatic-complexity
 const dataPlaneResponseHelper = async (response: Response) => {
     const dataPlaneResponse = await response;
-    const result = await response.json();
+
+    let result;
+    try {
+        result = await response.json();
+    }
+    catch {
+        throw new Error();
+    }
 
     // success case
     if (DataPlaneStatusCode.SuccessLowerBound <= dataPlaneResponse.status && dataPlaneResponse.status <= DataPlaneStatusCode.SuccessUpperBound) {

--- a/src/app/api/services/devicesService.ts
+++ b/src/app/api/services/devicesService.ts
@@ -434,7 +434,7 @@ export const monitorEvents = async (parameters: MonitorEventsParameters): Promis
 
         const response = await request(EVENTHUB_MONITOR_ENDPOINT, requestParameters);
         const messages = await response.json() as Message[];
-        return  messages.map(message => parseEventHubMessage(message));
+        return  messages && messages.map(message => parseEventHubMessage(message));
     } catch (error) {
         throw error;
     }

--- a/src/app/api/services/digitalTwinsModelService.spec.ts
+++ b/src/app/api/services/digitalTwinsModelService.spec.ts
@@ -17,41 +17,7 @@ describe('digitalTwinsModelService', () => {
             token: 'SharedAccessSignature sr=canary-repo.azureiotrepository.com&sig=123&rid=repositoryId'
         };
 
-        it('calls fetch with specified parameters', () => {
-            DigitalTwinsModelService.fetchModel(parameters);
-
-            const expandQueryString = parameters.expand ? `&expand=true` : ``;
-            const repositoryQueryString = parameters.repositoryId ? `&repositoryId=${parameters.repositoryId}` : '';
-            const apiVersionQuerySTring = `?${API_VERSION}${DIGITAL_TWIN_API_VERSION}`;
-            const queryString = `${apiVersionQuerySTring}${expandQueryString}${repositoryQueryString}`;
-            const modelIdentifier = encodeURIComponent(parameters.id);
-            const resourceUrl = `https://${parameters.repoServiceHostName}/models/${modelIdentifier}${queryString}`;
-
-            const controllerRequest = {
-                headers: {
-                    'Accept': 'application/json',
-                    'Authorization': parameters.token || '',
-                    'Content-Type': 'application/json'
-                },
-                method: HTTP_OPERATION_TYPES.Get,
-                uri: resourceUrl
-            };
-
-            const fetchModelParameters = {
-                body: JSON.stringify(controllerRequest),
-                cache: 'no-cache',
-                credentials: 'include',
-                headers: new Headers({
-                    'Accept': 'application/json',
-                    'Content-Type': 'application/json'
-                }),
-                method: HTTP_OPERATION_TYPES.Post
-            };
-
-            expect(fetch).toBeCalledWith(DigitalTwinsModelService.CONTROLLER_ENDPOINT, fetchModelParameters);
-        });
-
-        it('returns model when response is 200', async done => {
+        it('calls fetch with specified parameters and returns model when response is 200', async () => {
             // tslint:disable
             const model = {
                 '@id': 'urn:azureiot:Client:SDKInformation:1',
@@ -91,6 +57,36 @@ describe('digitalTwinsModelService', () => {
             jest.spyOn(window, 'fetch').mockResolvedValue(response);
 
             const result = await DigitalTwinsModelService.fetchModel(parameters);
+
+            const expandQueryString = parameters.expand ? `&expand=true` : ``;
+            const repositoryQueryString = parameters.repositoryId ? `&repositoryId=${parameters.repositoryId}` : '';
+            const apiVersionQuerySTring = `?${API_VERSION}${DIGITAL_TWIN_API_VERSION}`;
+            const queryString = `${apiVersionQuerySTring}${expandQueryString}${repositoryQueryString}`;
+            const modelIdentifier = encodeURIComponent(parameters.id);
+            const resourceUrl = `https://${parameters.repoServiceHostName}/models/${modelIdentifier}${queryString}`;
+
+            const controllerRequest = {
+                headers: {
+                    'Accept': 'application/json',
+                    'Authorization': parameters.token || '',
+                    'Content-Type': 'application/json'
+                },
+                method: HTTP_OPERATION_TYPES.Get,
+                uri: resourceUrl
+            };
+
+            const fetchModelParameters = {
+                body: JSON.stringify(controllerRequest),
+                cache: 'no-cache',
+                credentials: 'include',
+                headers: new Headers({
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                }),
+                method: HTTP_OPERATION_TYPES.Post
+            };
+
+            expect(fetch).toBeCalledWith(DigitalTwinsModelService.CONTROLLER_ENDPOINT, fetchModelParameters);
             expect(result).toEqual({
                 createdOn: '',
                 etag: '',
@@ -100,7 +96,6 @@ describe('digitalTwinsModelService', () => {
                 publisherId: '',
                 publisherName: ''
             });
-            done();
         });
 
         it('throws Error when response is not OK', async done => {

--- a/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEvents.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEvents.spec.tsx.snap
@@ -82,7 +82,7 @@ exports[`components/devices/deviceEvents matches snapshot 1`] = `
     useWindow={true}
   >
     <div
-      className="scrollable"
+      className="scrollable-sm"
     />
   </InfiniteScroll>
 </div>

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEvents.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEvents.tsx
@@ -211,7 +211,7 @@ export default class DeviceEventsComponent extends React.Component<DeviceEventsD
         const { events } = this.state;
 
         return (
-            <div className="scrollable">
+            <div className="scrollable-sm">
             {
                 events && events.map((event: Message, index) => {
                     return (

--- a/src/app/devices/deviceList/sagas/listDeviceSaga.spec.ts
+++ b/src/app/devices/deviceList/sagas/listDeviceSaga.spec.ts
@@ -24,7 +24,7 @@ describe('listDeviceSaga', () => {
             {
             authentication: null,
             capabilities: null,
-            cloudToDeviceMessageCount: '',
+            cloudToDeviceMessageCount: 0,
             deviceId,
             etag: 'etag',
             lastActivityTime: '',
@@ -78,14 +78,14 @@ describe('listDeviceSaga', () => {
 
     it('fails on error', () => {
         const failure = listDevicesSagaGenerator.clone();
-        const error = { code: -1 };
+        const error = { message: 'failed' };
         expect(failure.throw(error)).toEqual({
             done: false,
             value: put(addNotificationAction.started({
                 text: {
                     translationKey: ResourceKeys.notifications.getDeviceListOnError,
                     translationOptions: {
-                      error,
+                      error: error.message,
                   },
                 },
                 type: NotificationType.error,

--- a/src/app/devices/deviceList/sagas/listDeviceSaga.ts
+++ b/src/app/devices/deviceList/sagas/listDeviceSaga.ts
@@ -21,13 +21,17 @@ export function* listDevicesSaga(action: Action<DeviceQuery>) {
         const response = yield call(fetchDevices, parameters);
         yield put(listDevicesAction.done({params: action.payload, result: response}));
     } catch (error) {
+        const text = error.message ? {
+            translationKey: ResourceKeys.notifications.getDeviceListOnError,
+            translationOptions: {
+              error: error.message || ResourceKeys.notifications.getDeviceListGenericErrorHelp,
+          },
+        } :
+        {
+            translationKey: ResourceKeys.notifications.getDeviceListGenericErrorHelp
+        };
         yield put(addNotificationAction.started({
-            text: {
-                translationKey: ResourceKeys.notifications.getDeviceListOnError,
-                translationOptions: {
-                  error,
-              },
-            },
+            text,
             type: NotificationType.error,
         }));
 

--- a/src/app/devices/deviceList/sagas/listDeviceSaga.ts
+++ b/src/app/devices/deviceList/sagas/listDeviceSaga.ts
@@ -21,10 +21,10 @@ export function* listDevicesSaga(action: Action<DeviceQuery>) {
         const response = yield call(fetchDevices, parameters);
         yield put(listDevicesAction.done({params: action.payload, result: response}));
     } catch (error) {
-        const text = error.message ? {
+        const text = error && error.message ? {
             translationKey: ResourceKeys.notifications.getDeviceListOnError,
             translationOptions: {
-              error: error.message || ResourceKeys.notifications.getDeviceListGenericErrorHelp,
+              error: error.message,
           },
         } :
         {

--- a/src/app/login/components/connectivityPane.tsx
+++ b/src/app/login/components/connectivityPane.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../localization/resourceKeys';
-import { validateConnectionString } from '../../shared/utils/hubConnectionStringHelper';
+import { generateConnectionStringValidationError } from '../../shared/utils/hubConnectionStringHelper';
 import { SetConnectionStringActionParameter } from '../actions';
 import HubConnectionStringSection from './hubConnectionStringSection';
 import AppVersionMessageBar from './appVersionMessageBar';
@@ -86,7 +86,7 @@ export default class ConnectivityPane extends React.Component<RouteComponentProp
     }
 
     private readonly onConnectionStringChanged = (connectionString: string)  => {
-        const error = validateConnectionString(connectionString);
+        const error = generateConnectionStringValidationError(connectionString);
         this.setState({
             connectionString,
             error,

--- a/src/app/settings/components/settingsPane.tsx
+++ b/src/app/settings/components/settingsPane.tsx
@@ -11,7 +11,7 @@ import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button'
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../localization/resourceKeys';
-import { validateConnectionString } from '../../shared/utils/hubConnectionStringHelper';
+import { generateConnectionStringValidationError } from '../../shared/utils/hubConnectionStringHelper';
 import RepositoryLocationList from './repositoryLocationList';
 import { REPOSITORY_LOCATION_TYPE } from '../../constants/repositoryLocationTypes';
 import { ConfirmationDialog } from './confirmationDialog';
@@ -183,7 +183,7 @@ export default class SettingsPane extends React.Component<SettingsPaneProps & Se
 
     private readonly onConnectionStringChangedFromTextField = (hubConnectionString: string)  => {
         this.setState({
-            error: validateConnectionString(hubConnectionString),
+            error: generateConnectionStringValidationError(hubConnectionString),
             hubConnectionString,
             isDirty: true
         });

--- a/src/app/shared/utils/hubConnectionStringHelper.spec.ts
+++ b/src/app/shared/utils/hubConnectionStringHelper.spec.ts
@@ -1,0 +1,30 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import 'jest';
+import { generateConnectionStringValidationError } from './hubConnectionStringHelper';
+import { ResourceKeys } from '../../../localization/resourceKeys';
+
+describe('hubConnectionStringHelper', () => {
+
+    it('generates error when value is not provided', () => {
+        expect(generateConnectionStringValidationError('')).toEqual(ResourceKeys.connectivityPane.connectionStringTextBox.errorMessages.required);
+    });
+
+    it('generates error when value is repo connection string', () => {
+        expect(
+            generateConnectionStringValidationError('HostName=repo.azureiotrepository.com;RepositoryId=123;SharedAccessKeyName=456;SharedAccessKey=789'))
+            .toEqual(ResourceKeys.connectivityPane.connectionStringTextBox.errorMessages.invalid);
+    });
+
+    it('generates error when value does not contain expected property', () => {
+        expect(
+            generateConnectionStringValidationError('HostName=testhub.azure-devices.net;SharedAccessKey=123'))
+            .toEqual(ResourceKeys.connectivityPane.connectionStringTextBox.errorMessages.invalid);
+    });
+
+    it('does not generate error when value is in right format', () => {
+        expect(generateConnectionStringValidationError('HostName=testhub.azure-devices.net;SharedAccessKeyName=123;SharedAccessKey=456')).toEqual(null);
+    });
+});

--- a/src/app/shared/utils/hubConnectionStringHelper.ts
+++ b/src/app/shared/utils/hubConnectionStringHelper.ts
@@ -3,19 +3,32 @@
  * Licensed under the MIT License
  **********************************************************/
 import { ResourceKeys } from '../../../localization/resourceKeys';
-import { getConnectionInfoFromConnectionString } from './../../api/shared/utils';
+import { getConnectionInfoFromConnectionString, getRepoConnectionInfoFromConnectionString } from './../../api/shared/utils';
 
-export const validateConnectionString = (value: string): string => {
+export const generateConnectionStringValidationError  = (value: string): string => {
     if (!value) {
         return ResourceKeys.connectivityPane.connectionStringTextBox.errorMessages.required;
     }
 
+    if (isRepoConnectionString(value)) {
+        return ResourceKeys.connectivityPane.connectionStringTextBox.errorMessages.invalid;
+    }
+
+    return isHubConnectionString(value) ? null : ResourceKeys.connectivityPane.connectionStringTextBox.errorMessages.invalid;
+};
+
+const isRepoConnectionString = (value: string) => {
+    const connectionObject = getRepoConnectionInfoFromConnectionString(value);
+    return connectionObject.repositoryId;
+};
+
+const isHubConnectionString = (value: string) => {
     const connectionObject = getConnectionInfoFromConnectionString(value);
     const { hostName, sharedAccessKey, sharedAccessKeyName } = connectionObject;
 
     if (hostName && sharedAccessKeyName && sharedAccessKey) {
-        return;
+        return true;
     }
 
-    return ResourceKeys.connectivityPane.connectionStringTextBox.errorMessages.invalid;
+    return false;
 };

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -492,6 +492,7 @@
         "savedToIotHubConnectionString": "Successfully saved connection string for IoT hub {{hostName}}",
         "getDeviceIdentityOnError": "Failed to get device {{deviceId}}'s identity: {{error}}",
         "getDeviceListOnError": "Failed to retrieve device list: {{error}}",
+        "getDeviceListGenericErrorHelp": "Failed to retrieve device list. Please double check if you have entered the correct IoT hub connection string",
         "getDeviceTwinOnError": "Failed to get device {{deviceId}}'s twin: {{error}}",
         "getDigitalTwinInterfacePropertiesOnError": "Failed to get properties of digital twin interfaces on device {{deviceId}}: {{error}}",
         "getInterfaceModelOnError": "Failed to get interface model definition {{interfaceId}}",

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -492,7 +492,7 @@
         "savedToIotHubConnectionString": "Successfully saved connection string for IoT hub {{hostName}}",
         "getDeviceIdentityOnError": "Failed to get device {{deviceId}}'s identity: {{error}}",
         "getDeviceListOnError": "Failed to retrieve device list: {{error}}",
-        "getDeviceListGenericErrorHelp": "Failed to retrieve device list. Please double check if you have entered the correct IoT hub connection string",
+        "getDeviceListGenericErrorHelp": "Failed to retrieve device list. It is possibly due an invalid IoT hub connection string",
         "getDeviceTwinOnError": "Failed to get device {{deviceId}}'s twin: {{error}}",
         "getDigitalTwinInterfacePropertiesOnError": "Failed to get properties of digital twin interfaces on device {{deviceId}}: {{error}}",
         "getInterfaceModelOnError": "Failed to get interface model definition {{interfaceId}}",

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -450,6 +450,7 @@ export class ResourceKeys {
       deleteDeviceOnError : "notifications.deleteDeviceOnError",
       deleteDeviceOnSucceed : "notifications.deleteDeviceOnSucceed",
       getDeviceIdentityOnError : "notifications.getDeviceIdentityOnError",
+      getDeviceListGenericErrorHelp : "notifications.getDeviceListGenericErrorHelp",
       getDeviceListOnError : "notifications.getDeviceListOnError",
       getDeviceTwinOnError : "notifications.getDeviceTwinOnError",
       getDigitalTwinInterfacePropertiesOnError : "notifications.getDigitalTwinInterfacePropertiesOnError",


### PR DESCRIPTION
When response is not json, it throws error that looks like bug in the code: an example here: https://github.com/Azure/azure-iot-explorer/issues/138

Added a try catch with a bit of generic hep text
![image](https://user-images.githubusercontent.com/5489222/67808583-2ff08700-fa54-11e9-9690-cce8e03d831f.png)

Some tests start to fail possibly due to the deprecation warnings start to become errors. Fixed in second commit.
