### PR TITLE
ensure interfaces are populated before trying to get model definition from device

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "public/electron.js",
   "build": {


### PR DESCRIPTION
The issue here is, when user click refresh on wraitable or non writable properties page, the interface definition shows not found. It only happens when interface definition is store on device itself.
The reason it is happening is because, we are checking if a device implemented interface 'urn:azureiot:ModelDiscovery:ModelDefinition:1' before fetching definition from the device, while another indepandent 'fetchDigitalTwinInterfaceProperties' call is happening (which can happen either in a full page reload when we are loading the left nav bar, or on writable or non writable properties page when users are trying to fetch updated digital twin), which is setting the interface id list in the store to be an empty array, so the following logic is skipped.
Fixed the issue by making a fetchDigitalTwinInterfaceProperties call in the saga.