### PR TITLE
Tooltip host

### DIFF
--- a/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettingsPerInterface.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettingsPerInterface.spec.tsx.snap
@@ -160,6 +160,7 @@ exports[`components/devices/deviceSettingsPerInterface matches snapshot 1`] = `
           }
         }
         content="deviceSettings.columns.reportedValueTooltip"
+        id="tooltipHost12"
         styles={
           Object {
             "root": Object {
@@ -169,7 +170,7 @@ exports[`components/devices/deviceSettingsPerInterface matches snapshot 1`] = `
         }
       >
         <CustomizedIconButton
-          ariaLabel="Info"
+          aria-labelledby="tooltipHost12"
           iconProps={
             Object {
               "iconName": "Info",

--- a/src/app/devices/deviceContent/components/deviceSettings/deviceSettingsPerInterface.tsx
+++ b/src/app/devices/deviceContent/components/deviceSettings/deviceSettingsPerInterface.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Overlay } from 'office-ui-fabric-react/lib/Overlay';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import DeviceSettingPerInterfacePerSetting, { TwinWithSchema } from './deviceSettingsPerInterfacePerSetting';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../../../localization/resourceKeys';
@@ -47,6 +48,8 @@ export default class DeviceSettingsPerInterface
         };
     }
 
+    private tooltipHostId = getId('tooltipHost');
+
     public render(): JSX.Element {
         const { twinWithSchema} = this.props;
 
@@ -75,10 +78,11 @@ export default class DeviceSettingsPerInterface
                                     content={context.t(ResourceKeys.deviceSettings.columns.reportedValueTooltip)}
                                     calloutProps={{ gapSpace: 0 }}
                                     styles={{ root: { display: 'inline-flex'} }}
+                                    id={this.tooltipHostId}
                                 >
                                     <IconButton
                                         iconProps={{ iconName: INFO }}
-                                        ariaLabel={INFO}
+                                        aria-labelledby={this.tooltipHostId}
                                     />
                                 </TooltipHost>
                             </span>

--- a/src/app/devices/deviceList/components/__snapshots__/deviceQueryClause.spec.tsx.snap
+++ b/src/app/devices/deviceList/components/__snapshots__/deviceQueryClause.spec.tsx.snap
@@ -40,10 +40,12 @@ exports[`components/devices/DeviceQueryClause matches snapshot 1`] = `
     options={
       Array [
         Object {
+          "ariaLabel": "deviceLists.query.searchPills.clause.operationType.options.equal",
           "key": "=",
           "text": "=",
         },
         Object {
+          "ariaLabel": "deviceLists.query.searchPills.clause.operationType.options.notEqual",
           "key": "!=",
           "text": "!=",
         },

--- a/src/app/devices/deviceList/components/deviceQueryClause.tsx
+++ b/src/app/devices/deviceList/components/deviceQueryClause.tsx
@@ -147,6 +147,17 @@ export default class DeviceQueryClause extends React.PureComponent<DeviceQueryCl
         }
     }
 
+    private readonly getAriaLabelValueOfOperationType = (key: string, t: (value: string) => string) => {
+        switch (key.toLowerCase()) {
+            case OperationType.equals.toLowerCase():
+                return t(ResourceKeys.deviceLists.query.searchPills.clause.operationType.options.equal);
+            case OperationType.notEquals.toLowerCase():
+                return t(ResourceKeys.deviceLists.query.searchPills.clause.operationType.options.notEqual);
+            default:
+                return '';
+        }
+    }
+
     public componentDidMount() {
         // set focus to parameter type dropdown
         const node = this.parameterTypeRef.current;
@@ -179,8 +190,12 @@ export default class DeviceQueryClause extends React.PureComponent<DeviceQueryCl
                         {
                             this.shouldShowOperator(this.props.parameterType) && <Dropdown
                                 className="operation-type"
-                                // tslint:disable-next-line: no-any
-                                options={Object.keys(OperationType).map(operationType => ({ key: (OperationType as any)[operationType], text: (OperationType as any)[operationType] }))}
+                                options={Object.keys(OperationType).map
+                                    (operationType => ({
+                                        ariaLabel: this.getAriaLabelValueOfOperationType((OperationType as any)[operationType], context.t), // tslint:disable-line: no-any
+                                        key: (OperationType as any)[operationType], // tslint:disable-line: no-any
+                                        text: (OperationType as any)[operationType] // tslint:disable-line: no-any
+                                    }))}
                                 onChange={this.onOperationChange}
                                 defaultSelectedKey={this.props.operation}
                                 title={context.t(ResourceKeys.deviceLists.query.searchPills.clause.operationType.title)}

--- a/src/app/jsonSchemaFormFabricPlugin/fields/arrayFieldTemplate.tsx
+++ b/src/app/jsonSchemaFormFabricPlugin/fields/arrayFieldTemplate.tsx
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
+import * as React from 'react';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { Label } from 'office-ui-fabric-react/lib/Label';
-import * as React from 'react';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import { ArrayFieldTemplateProps } from 'react-jsonschema-form';
 import Collapsible from 'react-collapsible';
 import { INFO, Accordion, ArrayOperation } from '../../constants/iconNames';
@@ -54,6 +55,7 @@ export const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
 };
 
 const generateTriggerContent = (props: ArrayFieldTemplateProps, open: boolean) => {
+    const hostId = getId('hostId');
     return (
         <>
         <div className="content">
@@ -71,12 +73,13 @@ const generateTriggerContent = (props: ArrayFieldTemplateProps, open: boolean) =
                 {props.uiSchema[uiDescriptionKey] && (
                     <TooltipHost
                         content={props.uiSchema[uiDescriptionKey]}
-                        id={props.uiSchema[uiDescriptionKey]}
+                        id={hostId}
                         calloutProps={{ gapSpace: 0 }}
                         directionalHint={DirectionalHint.rightCenter}
                     >
                         <IconButton
                             iconProps={{ iconName: INFO }}
+                            aria-labelledby={hostId}
                         />
                     </TooltipHost>
                 )}

--- a/src/app/jsonSchemaFormFabricPlugin/fields/fieldTemplate.tsx
+++ b/src/app/jsonSchemaFormFabricPlugin/fields/fieldTemplate.tsx
@@ -2,11 +2,11 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
+import * as React from 'react';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
-import * as React from 'react';
 import { FieldTemplateProps } from 'react-jsonschema-form';
 import { INFO } from '../../constants/iconNames';
 import '../css/_fieldTemplate.scss';
@@ -33,12 +33,13 @@ export const FieldTemplate = (props: FieldTemplateProps) => {
                 {displayLabel && description && description.props.description && (
                     <TooltipHost
                         content={description.props.description}
-                        id={description.props.description}
+                        id={id}
                         calloutProps={{ gapSpace: 0 }}
                         directionalHint={DirectionalHint.rightCenter}
                     >
                         <IconButton
                             iconProps={{ iconName: INFO }}
+                            aria-labelledby={id}
                         />
                     </TooltipHost>
                     )}

--- a/src/app/jsonSchemaFormFabricPlugin/fields/objectTemplate.tsx
+++ b/src/app/jsonSchemaFormFabricPlugin/fields/objectTemplate.tsx
@@ -7,22 +7,24 @@ import { ObjectFieldTemplateProps } from 'react-jsonschema-form';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import { INFO } from '../../constants/iconNames';
 import '../css/_objectTemplate.scss';
 
 export const ObjectTemplate = (props: ObjectFieldTemplateProps) => {
+    const hostId = getId('hostId');
     return (
         <section key={props.title} className="objectField">
             {props.description && (
                 <TooltipHost
                     content={props.description}
-                    id={props.description}
+                    id={hostId}
                     calloutProps={{ gapSpace: 0 }}
                     directionalHint={DirectionalHint.rightCenter}
                 >
                     <IconButton
                         iconProps={{ iconName: INFO }}
-                        ariaLabel={props.description}
+                        aria-labelledby={hostId}
                     />
                 </TooltipHost>
             )}

--- a/src/app/login/components/hubConnectionStringSection.tsx
+++ b/src/app/login/components/hubConnectionStringSection.tsx
@@ -9,6 +9,8 @@ import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Dropdown, IDropdownOption, IDropdown } from 'office-ui-fabric-react/lib/Dropdown';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { Stack } from 'office-ui-fabric-react';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../localization/resourceKeys';
 import { MaskedCopyableTextField } from '../../shared/components/maskedCopyableTextField';
@@ -48,6 +50,7 @@ export default class HubConnectionStringSection extends React.Component<HubConne
 
     private hiddenInputRef = React.createRef<HTMLInputElement>();
     private dropDownRef = React.createRef<IDropdown>();
+    private copyButtonTooltipHostId = getId('copyButtonTooltipHost');
 
     public render(): JSX.Element {
         return (
@@ -89,12 +92,16 @@ export default class HubConnectionStringSection extends React.Component<HubConne
                         />
                         </Stack.Item>
                     <Stack.Item align="end">
-                        <IconButton
-                            iconProps={{ iconName: COPY }}
-                            title={t(ResourceKeys.connectivityPane.dropDown.copyButton)}
-                            ariaLabel={t(ResourceKeys.connectivityPane.dropDown.copyButton)}
-                            onClick={this.copyToClipboard}
-                        />
+                        <TooltipHost
+                            content={t(ResourceKeys.connectivityPane.dropDown.copyButton)}
+                            id={this.copyButtonTooltipHostId}
+                        >
+                            <IconButton
+                                iconProps={{ iconName: COPY }}
+                                aria-labelledby={this.copyButtonTooltipHostId}
+                                onClick={this.copyToClipboard}
+                            />
+                        </TooltipHost>
                     </Stack.Item>
                 </Stack>
                 <input

--- a/src/app/shared/components/__snapshots__/labelWithTooltip.spec.tsx.snap
+++ b/src/app/shared/components/__snapshots__/labelWithTooltip.spec.tsx.snap
@@ -32,7 +32,6 @@ exports[`components/shared/labelWithTooltip matches snapshot when tooltip specif
   >
     <CustomizedIconButton
       aria-labelledby="tooltip2"
-      ariaLabel="Info"
       iconProps={
         Object {
           "iconName": "Info",

--- a/src/app/shared/components/__snapshots__/maskedCopyableTextField.spec.tsx.snap
+++ b/src/app/shared/components/__snapshots__/maskedCopyableTextField.spec.tsx.snap
@@ -57,12 +57,10 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
             Object {
               "iconName": "copy",
             }
-
           }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.copy.label"
-      />
+          onClick={[Function]}
+        />
+      </StyledTooltipHostBase>
     </div>
   </div>
 </div>
@@ -111,13 +109,6 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
         tabIndex={-1}
         value="value1"
       />
-<<<<<<< HEAD
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.toggleMask.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "RedEye",
-=======
       <StyledTooltipHostBase
         content="common.maskedCopyableTextField.toggleMask.label"
         id="toggleMaskButtonTooltipHost5"
@@ -128,23 +119,14 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
             Object {
               "iconName": "RedEye",
             }
->>>>>>> use ids in all tooltiphost
           }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.toggleMask.label"
-      />
+          onClick={[Function]}
+        />
+      </StyledTooltipHostBase>
     </div>
     <div
       className="copySection"
     >
-<<<<<<< HEAD
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "copy",
-=======
       <StyledTooltipHostBase
         content="common.maskedCopyableTextField.copy.label"
         id="copyButtonTooltipHost6"
@@ -155,12 +137,10 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
             Object {
               "iconName": "copy",
             }
->>>>>>> use ids in all tooltiphost
           }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.copy.label"
-      />
+          onClick={[Function]}
+        />
+      </StyledTooltipHostBase>
     </div>
   </div>
 </div>
@@ -209,13 +189,6 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
         tabIndex={-1}
         value="value1"
       />
-<<<<<<< HEAD
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.toggleMask.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "RedEye",
-=======
       <StyledTooltipHostBase
         content="common.maskedCopyableTextField.toggleMask.label"
         id="toggleMaskButtonTooltipHost8"
@@ -226,23 +199,14 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
             Object {
               "iconName": "RedEye",
             }
->>>>>>> use ids in all tooltiphost
           }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.toggleMask.label"
-      />
+          onClick={[Function]}
+        />
+      </StyledTooltipHostBase>
     </div>
     <div
       className="copySection"
     >
-<<<<<<< HEAD
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "copy",
-=======
       <StyledTooltipHostBase
         content="common.maskedCopyableTextField.copy.label"
         id="copyButtonTooltipHost9"
@@ -253,12 +217,10 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
             Object {
               "iconName": "copy",
             }
->>>>>>> use ids in all tooltiphost
           }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.copy.label"
-      />
+          onClick={[Function]}
+        />
+      </StyledTooltipHostBase>
     </div>
   </div>
 </div>
@@ -307,13 +269,6 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
         tabIndex={-1}
         value="value1"
       />
-<<<<<<< HEAD
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.toggleMask.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "RedEye",
-=======
       <StyledTooltipHostBase
         content="common.maskedCopyableTextField.toggleMask.label"
         id="toggleMaskButtonTooltipHost11"
@@ -324,23 +279,14 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
             Object {
               "iconName": "RedEye",
             }
->>>>>>> use ids in all tooltiphost
           }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.toggleMask.label"
-      />
+          onClick={[Function]}
+        />
+      </StyledTooltipHostBase>
     </div>
     <div
       className="copySection"
     >
-<<<<<<< HEAD
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "copy",
-=======
       <StyledTooltipHostBase
         content="common.maskedCopyableTextField.copy.label"
         id="copyButtonTooltipHost12"
@@ -351,12 +297,10 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
             Object {
               "iconName": "copy",
             }
->>>>>>> use ids in all tooltiphost
           }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.copy.label"
-      />
+          onClick={[Function]}
+        />
+      </StyledTooltipHostBase>
     </div>
   </div>
   <div

--- a/src/app/shared/components/__snapshots__/maskedCopyableTextField.spec.tsx.snap
+++ b/src/app/shared/components/__snapshots__/maskedCopyableTextField.spec.tsx.snap
@@ -47,11 +47,17 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
     <div
       className="copySection"
     >
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "copy",
+      <StyledTooltipHostBase
+        content="common.maskedCopyableTextField.copy.label"
+        id="copyButtonTooltipHost3"
+      >
+        <CustomizedIconButton
+          aria-labelledby="copyButtonTooltipHost3"
+          iconProps={
+            Object {
+              "iconName": "copy",
+            }
+
           }
         }
         onClick={[Function]}
@@ -70,150 +76,6 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
     className="labelSection"
   >
     <Component
-      htmlFor="maskedCopyableTextField2"
-    >
-      label1
-    </Component>
-  </div>
-  <div
-    className="controlSection"
-  >
-    <div
-      className="borderedSection  readOnly"
-    >
-      <input
-        aria-label="ariaLabel1"
-        className="input"
-        id="maskedCopyableTextField2"
-        onChange={[Function]}
-        readOnly={true}
-        type="password"
-        value="value1"
-      />
-      <input
-        aria-hidden={true}
-        className="input"
-        readOnly={true}
-        style={
-          Object {
-            "height": "1px",
-            "opacity": 0,
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-        tabIndex={-1}
-        value="value1"
-      />
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.toggleMask.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "RedEye",
-          }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.toggleMask.label"
-      />
-    </div>
-    <div
-      className="copySection"
-    >
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "copy",
-          }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.copy.label"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = true 2`] = `
-<div
-  className="maskedCopyableTextField"
->
-  <div
-    className="labelSection"
-  >
-    <Component
-      htmlFor="maskedCopyableTextField3"
-    >
-      label1
-    </Component>
-  </div>
-  <div
-    className="controlSection"
-  >
-    <div
-      className="borderedSection  readOnly"
-    >
-      <input
-        aria-label="ariaLabel1"
-        className="input"
-        id="maskedCopyableTextField3"
-        onChange={[Function]}
-        readOnly={true}
-        type="password"
-        value="value1"
-      />
-      <input
-        aria-hidden={true}
-        className="input"
-        readOnly={true}
-        style={
-          Object {
-            "height": "1px",
-            "opacity": 0,
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-        tabIndex={-1}
-        value="value1"
-      />
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.toggleMask.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "RedEye",
-          }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.toggleMask.label"
-      />
-    </div>
-    <div
-      className="copySection"
-    >
-      <CustomizedIconButton
-        ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
-        iconProps={
-          Object {
-            "iconName": "copy",
-          }
-        }
-        onClick={[Function]}
-        title="common.maskedCopyableTextField.copy.label"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`MaskedCopyableTextField snapshots it matches snapshot when error message specified 1`] = `
-<div
-  className="maskedCopyableTextField"
->
-  <div
-    className="labelSection"
-  >
-    <Component
       htmlFor="maskedCopyableTextField4"
     >
       label1
@@ -223,7 +85,7 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
     className="controlSection"
   >
     <div
-      className="borderedSection error readOnly"
+      className="borderedSection  readOnly"
     >
       <input
         aria-label="ariaLabel1"
@@ -249,11 +111,24 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
         tabIndex={-1}
         value="value1"
       />
+<<<<<<< HEAD
       <CustomizedIconButton
         ariaLabel="common.maskedCopyableTextField.toggleMask.ariaLabel"
         iconProps={
           Object {
             "iconName": "RedEye",
+=======
+      <StyledTooltipHostBase
+        content="common.maskedCopyableTextField.toggleMask.label"
+        id="toggleMaskButtonTooltipHost5"
+      >
+        <CustomizedIconButton
+          aria-labelledby="toggleMaskButtonTooltipHost5"
+          iconProps={
+            Object {
+              "iconName": "RedEye",
+            }
+>>>>>>> use ids in all tooltiphost
           }
         }
         onClick={[Function]}
@@ -263,11 +138,220 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
     <div
       className="copySection"
     >
+<<<<<<< HEAD
       <CustomizedIconButton
         ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
         iconProps={
           Object {
             "iconName": "copy",
+=======
+      <StyledTooltipHostBase
+        content="common.maskedCopyableTextField.copy.label"
+        id="copyButtonTooltipHost6"
+      >
+        <CustomizedIconButton
+          aria-labelledby="copyButtonTooltipHost6"
+          iconProps={
+            Object {
+              "iconName": "copy",
+            }
+>>>>>>> use ids in all tooltiphost
+          }
+        }
+        onClick={[Function]}
+        title="common.maskedCopyableTextField.copy.label"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = true 2`] = `
+<div
+  className="maskedCopyableTextField"
+>
+  <div
+    className="labelSection"
+  >
+    <Component
+      htmlFor="maskedCopyableTextField7"
+    >
+      label1
+    </Component>
+  </div>
+  <div
+    className="controlSection"
+  >
+    <div
+      className="borderedSection  readOnly"
+    >
+      <input
+        aria-label="ariaLabel1"
+        className="input"
+        id="maskedCopyableTextField7"
+        onChange={[Function]}
+        readOnly={true}
+        type="password"
+        value="value1"
+      />
+      <input
+        aria-hidden={true}
+        className="input"
+        readOnly={true}
+        style={
+          Object {
+            "height": "1px",
+            "opacity": 0,
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+        tabIndex={-1}
+        value="value1"
+      />
+<<<<<<< HEAD
+      <CustomizedIconButton
+        ariaLabel="common.maskedCopyableTextField.toggleMask.ariaLabel"
+        iconProps={
+          Object {
+            "iconName": "RedEye",
+=======
+      <StyledTooltipHostBase
+        content="common.maskedCopyableTextField.toggleMask.label"
+        id="toggleMaskButtonTooltipHost8"
+      >
+        <CustomizedIconButton
+          aria-labelledby="toggleMaskButtonTooltipHost8"
+          iconProps={
+            Object {
+              "iconName": "RedEye",
+            }
+>>>>>>> use ids in all tooltiphost
+          }
+        }
+        onClick={[Function]}
+        title="common.maskedCopyableTextField.toggleMask.label"
+      />
+    </div>
+    <div
+      className="copySection"
+    >
+<<<<<<< HEAD
+      <CustomizedIconButton
+        ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
+        iconProps={
+          Object {
+            "iconName": "copy",
+=======
+      <StyledTooltipHostBase
+        content="common.maskedCopyableTextField.copy.label"
+        id="copyButtonTooltipHost9"
+      >
+        <CustomizedIconButton
+          aria-labelledby="copyButtonTooltipHost9"
+          iconProps={
+            Object {
+              "iconName": "copy",
+            }
+>>>>>>> use ids in all tooltiphost
+          }
+        }
+        onClick={[Function]}
+        title="common.maskedCopyableTextField.copy.label"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MaskedCopyableTextField snapshots it matches snapshot when error message specified 1`] = `
+<div
+  className="maskedCopyableTextField"
+>
+  <div
+    className="labelSection"
+  >
+    <Component
+      htmlFor="maskedCopyableTextField10"
+    >
+      label1
+    </Component>
+  </div>
+  <div
+    className="controlSection"
+  >
+    <div
+      className="borderedSection error readOnly"
+    >
+      <input
+        aria-label="ariaLabel1"
+        className="input"
+        id="maskedCopyableTextField10"
+        onChange={[Function]}
+        readOnly={true}
+        type="password"
+        value="value1"
+      />
+      <input
+        aria-hidden={true}
+        className="input"
+        readOnly={true}
+        style={
+          Object {
+            "height": "1px",
+            "opacity": 0,
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+        tabIndex={-1}
+        value="value1"
+      />
+<<<<<<< HEAD
+      <CustomizedIconButton
+        ariaLabel="common.maskedCopyableTextField.toggleMask.ariaLabel"
+        iconProps={
+          Object {
+            "iconName": "RedEye",
+=======
+      <StyledTooltipHostBase
+        content="common.maskedCopyableTextField.toggleMask.label"
+        id="toggleMaskButtonTooltipHost11"
+      >
+        <CustomizedIconButton
+          aria-labelledby="toggleMaskButtonTooltipHost11"
+          iconProps={
+            Object {
+              "iconName": "RedEye",
+            }
+>>>>>>> use ids in all tooltiphost
+          }
+        }
+        onClick={[Function]}
+        title="common.maskedCopyableTextField.toggleMask.label"
+      />
+    </div>
+    <div
+      className="copySection"
+    >
+<<<<<<< HEAD
+      <CustomizedIconButton
+        ariaLabel="common.maskedCopyableTextField.copy.ariaLabel"
+        iconProps={
+          Object {
+            "iconName": "copy",
+=======
+      <StyledTooltipHostBase
+        content="common.maskedCopyableTextField.copy.label"
+        id="copyButtonTooltipHost12"
+      >
+        <CustomizedIconButton
+          aria-labelledby="copyButtonTooltipHost12"
+          iconProps={
+            Object {
+              "iconName": "copy",
+            }
+>>>>>>> use ids in all tooltiphost
           }
         }
         onClick={[Function]}

--- a/src/app/shared/components/labelWithTooltip.tsx
+++ b/src/app/shared/components/labelWithTooltip.tsx
@@ -40,7 +40,6 @@ export default (props: LabelWithTooltipProps) => {
                 >
                     <IconButton
                         iconProps={{ iconName: INFO }}
-                        ariaLabel={INFO}
                         aria-labelledby={hostId}
                         id={buttonId}
                     />

--- a/src/app/shared/components/maskedCopyableTextField.tsx
+++ b/src/app/shared/components/maskedCopyableTextField.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { TranslationFunction } from 'i18next';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { getId } from 'office-ui-fabric-react/lib/Utilities';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { ResourceKeys } from '../../../localization/resourceKeys';
 import LabelWithTooltip from './labelWithTooltip';
 import LabelWithRichCallout from './labelWithRichCallout';
@@ -32,7 +33,7 @@ export interface MaskedCopyableTextFieldState {
 
 export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextFieldProps, MaskedCopyableTextFieldState> {
     private hiddenInputRef = React.createRef<HTMLInputElement>();
-    private visibileInputRef = React.createRef<HTMLInputElement>();
+    private visibleInputRef = React.createRef<HTMLInputElement>();
     private labelIdentifier = getId('maskedCopyableTextField');
 
     constructor(props: MaskedCopyableTextFieldProps) {
@@ -57,7 +58,7 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
                         <input
                             aria-label={ariaLabel}
                             id={this.labelIdentifier}
-                            ref={this.visibileInputRef}
+                            ref={this.visibleInputRef}
                             value={value}
                             type={(allowMask && hideContents) ? 'password' : 'text'}
                             className="input"
@@ -76,22 +77,24 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
                         />
 
                         {allowMask &&
-                            <IconButton
-                                iconProps={hideContents ? { iconName: 'RedEye' } : { iconName: 'Hide' }}
-                                title={t(ResourceKeys.common.maskedCopyableTextField.toggleMask.label)}
-                                ariaLabel={t(ResourceKeys.common.maskedCopyableTextField.toggleMask.ariaLabel)}
-                                onClick={this.toggleDisplay}
-                            />
+                            <TooltipHost content={t(ResourceKeys.common.maskedCopyableTextField.toggleMask.label)}>
+                                <IconButton
+                                    iconProps={hideContents ? { iconName: 'RedEye' } : { iconName: 'Hide' }}
+                                    ariaLabel={t(ResourceKeys.common.maskedCopyableTextField.toggleMask.ariaLabel)}
+                                    onClick={this.toggleDisplay}
+                                />
+                            </TooltipHost>
                         }
                     </div>
 
                     <div className="copySection">
-                        <IconButton
-                            iconProps={{ iconName: 'copy' }}
-                            title={t(ResourceKeys.common.maskedCopyableTextField.copy.label)}
-                            ariaLabel={t(ResourceKeys.common.maskedCopyableTextField.copy.ariaLabel)}
-                            onClick={this.copyToClipboard}
-                        />
+                        <TooltipHost  content={t(ResourceKeys.common.maskedCopyableTextField.copy.label)}>
+                            <IconButton
+                                iconProps={{ iconName: 'copy' }}
+                                ariaLabel={t(ResourceKeys.common.maskedCopyableTextField.copy.ariaLabel)}
+                                onClick={this.copyToClipboard}
+                            />
+                        </TooltipHost>
                     </div>
                 </div>
 
@@ -137,7 +140,7 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
     }
 
     public focus = () => {
-        const node = this.visibileInputRef.current;
+        const node = this.visibleInputRef.current;
         if (node) {
             node.focus();
         }

--- a/src/app/shared/components/maskedCopyableTextField.tsx
+++ b/src/app/shared/components/maskedCopyableTextField.tsx
@@ -35,6 +35,8 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
     private hiddenInputRef = React.createRef<HTMLInputElement>();
     private visibleInputRef = React.createRef<HTMLInputElement>();
     private labelIdentifier = getId('maskedCopyableTextField');
+    private toggleMaskButtonTooltipHostId = getId('toggleMaskButtonTooltipHost');
+    private copyButtonTooltipHostId = getId('copyButtonTooltipHost');
 
     constructor(props: MaskedCopyableTextFieldProps) {
         super(props);
@@ -77,10 +79,13 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
                         />
 
                         {allowMask &&
-                            <TooltipHost content={t(ResourceKeys.common.maskedCopyableTextField.toggleMask.label)}>
+                            <TooltipHost
+                                content={t(ResourceKeys.common.maskedCopyableTextField.toggleMask.label)}
+                                id={this.toggleMaskButtonTooltipHostId}
+                            >
                                 <IconButton
                                     iconProps={hideContents ? { iconName: 'RedEye' } : { iconName: 'Hide' }}
-                                    ariaLabel={t(ResourceKeys.common.maskedCopyableTextField.toggleMask.ariaLabel)}
+                                    aria-labelledby={this.toggleMaskButtonTooltipHostId}
                                     onClick={this.toggleDisplay}
                                 />
                             </TooltipHost>
@@ -88,10 +93,13 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
                     </div>
 
                     <div className="copySection">
-                        <TooltipHost  content={t(ResourceKeys.common.maskedCopyableTextField.copy.label)}>
+                        <TooltipHost
+                            content={t(ResourceKeys.common.maskedCopyableTextField.copy.label)}
+                            id={this.copyButtonTooltipHostId}
+                        >
                             <IconButton
                                 iconProps={{ iconName: 'copy' }}
-                                ariaLabel={t(ResourceKeys.common.maskedCopyableTextField.copy.ariaLabel)}
+                                aria-labelledby={this.copyButtonTooltipHostId}
                                 onClick={this.copyToClipboard}
                             />
                         </TooltipHost>

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -5,12 +5,10 @@
         "loading": "Loading...",
         "maskedCopyableTextField": {
             "toggleMask": {
-                "label": "Toggle Mask",
-                "ariaLabel": "Toggle mask"
+                "label": "Toggle Mask"
             },
             "copy": {
-                "label": "Copy Contents",
-                "ariaLabel": "Copy contents"
+                "label": "Copy Contents"
             }
         },
         "confirmationDialog": {

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -301,7 +301,11 @@
                     },
                     "operationType": {
                         "title": "Operation type",
-                        "ariaLabel": "Choose a comparison type for this clause"
+                        "ariaLabel": "Choose a comparison type for this clause",
+                        "options": {
+                            "equal": "equal",
+                            "notEqual": "not equal"
+                        }
                     },
                     "value": {
                         "placeholder": "Enter value...",

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -317,6 +317,10 @@ export class ResourceKeys {
             clause : {
                operationType : {
                   ariaLabel : "deviceLists.query.searchPills.clause.operationType.ariaLabel",
+                  options : {
+                     equal : "deviceLists.query.searchPills.clause.operationType.options.equal",
+                     notEqual : "deviceLists.query.searchPills.clause.operationType.options.notEqual",
+                  },
                   title : "deviceLists.query.searchPills.clause.operationType.title",
                },
                parameterType : {

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -43,11 +43,9 @@ export class ResourceKeys {
       loading : "common.loading",
       maskedCopyableTextField : {
          copy : {
-            ariaLabel : "common.maskedCopyableTextField.copy.ariaLabel",
             label : "common.maskedCopyableTextField.copy.label",
          },
          toggleMask : {
-            ariaLabel : "common.maskedCopyableTextField.toggleMask.ariaLabel",
             label : "common.maskedCopyableTextField.toggleMask.label",
          },
       },


### PR DESCRIPTION
Couple key navigation related accessbility fixes:
1. Update office version. The previous version has a regression on dialog initial focus
2. Move mashead to layout.ts, as settings and notification was able to be discovered by tabbing
3. Use TooltipHost to wrap icon tooltips where tooltip needs to be shown while tabbing
4. Change callout icon's event from mouse event to onclick so it can be opened from keyboard 'space' key, and change focus back to icon when it is closed
5. A few text update

The above fixes address bug: 5660487 5659998 5652306 5660790 5660019 5660571