### PR TITLE
Disabled input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "public/electron.js",
   "build": {

--- a/src/app/css/_maskedCopyableTextField.scss
+++ b/src/app/css/_maskedCopyableTextField.scss
@@ -50,7 +50,7 @@
         }
     }
 
-    .readOnly {
+    .disabled {
         @include themify($themes) {
             background-color: themed('maskedCopyableReadonlyBackground');
         }

--- a/src/app/devices/deviceContent/components/deviceIdentity/__snapshots__/deviceIdentity.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceIdentity/__snapshots__/deviceIdentity.spec.tsx.snap
@@ -21,8 +21,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with CA aut
     <MaskedCopyableTextField
       allowMask={false}
       ariaLabel="deviceIdentity.deviceID"
+      disabled={true}
       label="deviceIdentity.deviceID"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -101,8 +101,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with CA aut
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.primaryConnectionString"
+      disabled={true}
       label="deviceIdentity.authenticationType.symmetricKey.primaryConnectionString"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -201,8 +201,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with SelfSi
     <MaskedCopyableTextField
       allowMask={false}
       ariaLabel="deviceIdentity.deviceID"
+      disabled={true}
       label="deviceIdentity.deviceID"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -281,8 +281,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with SelfSi
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.primaryConnectionString"
+      disabled={true}
       label="deviceIdentity.authenticationType.symmetricKey.primaryConnectionString"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -384,8 +384,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Symmet
     <MaskedCopyableTextField
       allowMask={false}
       ariaLabel="deviceIdentity.deviceID"
+      disabled={true}
       label="deviceIdentity.deviceID"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -567,9 +567,9 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Symmet
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.primaryKey"
+      disabled={false}
       label="deviceIdentity.authenticationType.symmetricKey.primaryKey"
       onTextChange={[Function]}
-      readOnly={false}
       t={
         [MockFunction] {
           "calls": Array [
@@ -751,9 +751,9 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Symmet
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.secondaryKey"
+      disabled={false}
       label="deviceIdentity.authenticationType.symmetricKey.secondaryKey"
       onTextChange={[Function]}
-      readOnly={false}
       t={
         [MockFunction] {
           "calls": Array [
@@ -934,8 +934,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Symmet
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.primaryConnectionString"
+      disabled={true}
       label="deviceIdentity.authenticationType.symmetricKey.primaryConnectionString"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -1117,8 +1117,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Symmet
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.secondaryConnectionString"
+      disabled={true}
       label="deviceIdentity.authenticationType.symmetricKey.secondaryConnectionString"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -1322,6 +1322,7 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Symmet
               },
             ]
           }
+          required={true}
         />
         <CustomizedSpinButton
           className="sas-token-expiration-field"
@@ -1349,8 +1350,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Symmet
         <MaskedCopyableTextField
           allowMask={true}
           ariaLabel="deviceIdentity.authenticationType.sasToken.textField.ariaLabel"
+          disabled={true}
           label="deviceIdentity.authenticationType.sasToken.textField.label"
-          readOnly={true}
           t={
             [MockFunction] {
               "calls": Array [
@@ -1565,8 +1566,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Synchr
     <MaskedCopyableTextField
       allowMask={false}
       ariaLabel="deviceIdentity.deviceID"
+      disabled={true}
       label="deviceIdentity.deviceID"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -1747,9 +1748,9 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Synchr
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.primaryKey"
+      disabled={false}
       label="deviceIdentity.authenticationType.symmetricKey.primaryKey"
       onTextChange={[Function]}
-      readOnly={false}
       t={
         [MockFunction] {
           "calls": Array [
@@ -1931,9 +1932,9 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Synchr
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.secondaryKey"
+      disabled={false}
       label="deviceIdentity.authenticationType.symmetricKey.secondaryKey"
       onTextChange={[Function]}
-      readOnly={false}
       t={
         [MockFunction] {
           "calls": Array [
@@ -2114,8 +2115,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Synchr
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.primaryConnectionString"
+      disabled={true}
       label="deviceIdentity.authenticationType.symmetricKey.primaryConnectionString"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -2297,8 +2298,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Synchr
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.symmetricKey.secondaryConnectionString"
+      disabled={true}
       label="deviceIdentity.authenticationType.symmetricKey.secondaryConnectionString"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -2502,6 +2503,7 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Synchr
               },
             ]
           }
+          required={true}
         />
         <CustomizedSpinButton
           className="sas-token-expiration-field"
@@ -2529,8 +2531,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with Synchr
         <MaskedCopyableTextField
           allowMask={true}
           ariaLabel="deviceIdentity.authenticationType.sasToken.textField.ariaLabel"
+          disabled={true}
           label="deviceIdentity.authenticationType.sasToken.textField.label"
-          readOnly={true}
           t={
             [MockFunction] {
               "calls": Array [
@@ -2760,8 +2762,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with auth t
     <MaskedCopyableTextField
       allowMask={false}
       ariaLabel="deviceIdentity.deviceID"
+      disabled={true}
       label="deviceIdentity.deviceID"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [
@@ -2839,8 +2841,8 @@ exports[`devices/components/deviceIdentity snapshot matches snapshot with identi
     <MaskedCopyableTextField
       allowMask={false}
       ariaLabel="deviceIdentity.deviceID"
+      disabled={true}
       label="deviceIdentity.deviceID"
-      readOnly={true}
       t={
         [MockFunction] {
           "calls": Array [

--- a/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentity.tsx
+++ b/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentity.tsx
@@ -138,7 +138,7 @@ export default class DeviceIdentityInformation
                             value={this.state.identity && this.state.identity.deviceId}
                             allowMask={false}
                             t={context.t}
-                            readOnly={true}
+                            disabled={true}
                         />
                         {this.renderDeviceAuthProperties(context)}
                         <br/>
@@ -228,6 +228,7 @@ export default class DeviceIdentityInformation
                         selectedKey={sasTokenSelectedKey || undefined}
                         options={options}
                         onChange={this.onSelectedKeyChanged}
+                        required={true}
                     />
                     <SpinButton
                         className={'sas-token-expiration-field'}
@@ -246,7 +247,7 @@ export default class DeviceIdentityInformation
                         value={this.state.sasTokenConnectionString}
                         allowMask={true}
                         t={context.t}
-                        readOnly={true}
+                        disabled={true}
                     />
                     <PrimaryButton
                         className={'sas-token-generate-button'}
@@ -275,7 +276,7 @@ export default class DeviceIdentityInformation
                             value={generateX509ConnectionString(connectionString, identity.deviceId)}
                             allowMask={true}
                             t={context.t}
-                            readOnly={true}
+                            disabled={true}
                         />
                     </>
                 );
@@ -289,7 +290,7 @@ export default class DeviceIdentityInformation
                             value={generateX509ConnectionString(connectionString, identity.deviceId)}
                             allowMask={true}
                             t={context.t}
-                            readOnly={true}
+                            disabled={true}
                         />
                     </>
                 );
@@ -302,7 +303,7 @@ export default class DeviceIdentityInformation
                             value={this.state.identity.authentication.symmetricKey.primaryKey}
                             allowMask={true}
                             t={context.t}
-                            readOnly={false}
+                            disabled={false}
                             onTextChange={this.changePrimaryKey}
                         />
 
@@ -312,7 +313,7 @@ export default class DeviceIdentityInformation
                             value={this.state.identity.authentication.symmetricKey.secondaryKey}
                             allowMask={true}
                             t={context.t}
-                            readOnly={false}
+                            disabled={false}
                             onTextChange={this.changeSecondaryKey}
                         />
 
@@ -322,7 +323,7 @@ export default class DeviceIdentityInformation
                             value={generateConnectionString(connectionString, identity.deviceId, identity.authentication.symmetricKey.primaryKey)}
                             allowMask={true}
                             t={context.t}
-                            readOnly={true}
+                            disabled={true}
                         />
 
                         <MaskedCopyableTextField
@@ -331,7 +332,7 @@ export default class DeviceIdentityInformation
                             value={generateConnectionString(connectionString, identity.deviceId, identity.authentication.symmetricKey.secondaryKey)}
                             allowMask={true}
                             t={context.t}
-                            readOnly={true}
+                            disabled={true}
                         />
                     </>
                 );

--- a/src/app/devices/deviceList/components/addDevice/components/__snapshots__/addDevice.spec.tsx.snap
+++ b/src/app/devices/deviceList/components/addDevice/components/__snapshots__/addDevice.spec.tsx.snap
@@ -21,11 +21,11 @@ exports[`components/devices/addDevice matches snapshot 1`] = `
       <MaskedCopyableTextField
         allowMask={false}
         ariaLabel="deviceIdentity.deviceID"
+        disabled={false}
         error=""
         label="deviceIdentity.deviceID"
         labelCallout="deviceIdentity.deviceIDTooltip"
         onTextChange={[Function]}
-        readOnly={false}
         required={true}
         t={
           [MockFunction] {

--- a/src/app/devices/deviceList/components/addDevice/components/addDevice.tsx
+++ b/src/app/devices/deviceList/components/addDevice/components/addDevice.tsx
@@ -115,7 +115,7 @@ export default class AddDevice extends React.Component<AddDeviceActionProps & Ad
                 onTextChange={this.changeDeviceId}
                 allowMask={false}
                 t={context.t}
-                readOnly={false}
+                disabled={false}
                 error={!!this.state.deviceIdError ? context.t(this.state.deviceIdError) : ''}
                 labelCallout={context.t(ResourceKeys.deviceIdentity.deviceIDTooltip)}
             />
@@ -160,7 +160,7 @@ export default class AddDevice extends React.Component<AddDeviceActionProps & Ad
                     onTextChange={this.changePrimaryKey}
                     allowMask={true}
                     t={context.t}
-                    readOnly={false}
+                    disabled={false}
                     error={!!this.state.primaryKeyError ? context.t(this.state.primaryKeyError) : ''}
                     labelCallout={context.t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryConnectionStringTooltip)}
                 />
@@ -172,7 +172,7 @@ export default class AddDevice extends React.Component<AddDeviceActionProps & Ad
                     onTextChange={this.changeSecondaryKey}
                     allowMask={true}
                     t={context.t}
-                    readOnly={false}
+                    disabled={false}
                     error={!!this.state.secondaryKeyError ? context.t(this.state.secondaryKeyError) : ''}
                     labelCallout={context.t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryConnectionStringTooltip)}
                 />
@@ -191,7 +191,7 @@ export default class AddDevice extends React.Component<AddDeviceActionProps & Ad
                     onTextChange={this.changePrimaryThumbprint}
                     allowMask={true}
                     t={context.t}
-                    readOnly={false}
+                    disabled={false}
                     error={!!this.state.primaryThumbprintError ? context.t(this.state.primaryThumbprintError) : ''}
                     labelCallout={context.t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprintTooltip)}
                 />
@@ -203,7 +203,7 @@ export default class AddDevice extends React.Component<AddDeviceActionProps & Ad
                     onTextChange={this.changeSecondaryThumbprint}
                     allowMask={true}
                     t={context.t}
-                    readOnly={false}
+                    disabled={false}
                     error={!!this.state.secondaryThumbprintError ? context.t(this.state.secondaryThumbprintError) : ''}
                     labelCallout={context.t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip)}
                 />

--- a/src/app/login/components/__snapshots__/hubConnectionStringSection.spec.tsx.snap
+++ b/src/app/login/components/__snapshots__/hubConnectionStringSection.spec.tsx.snap
@@ -26,10 +26,10 @@ exports[`login/components/connectivityPane matches snapshot 1`] = `
         </div>
       </div>
     }
+    disabled={false}
     error=""
     label="connectivityPane.connectionStringTextBox.label"
     onTextChange={[Function]}
-    readOnly={false}
     required={true}
     t={
       [MockFunction] {

--- a/src/app/login/components/hubConnectionStringSection.tsx
+++ b/src/app/login/components/hubConnectionStringSection.tsx
@@ -127,7 +127,7 @@ export default class HubConnectionStringSection extends React.Component<HubConne
                     value={this.state.newConnectionString}
                     allowMask={true}
                     onTextChange={this.onConnectionStringChangedFromTextField}
-                    readOnly={false}
+                    disabled={false}
                     required={true}
                     t={t}
                     calloutContent={(

--- a/src/app/notifications/components/notificationList.tsx
+++ b/src/app/notifications/components/notificationList.tsx
@@ -89,7 +89,7 @@ export class NotificationList extends React.Component<NotificationListProps, Not
                                 {notifications.map((notification, index) => {
                                         return (
                                             <div key={index}>
-                                                <NotificationListEntry notification={notification} />
+                                                <NotificationListEntry notification={notification} showAnnoucement={false} />
                                                 <hr className="notification-list-divider" />
                                             </div>);
                                     })

--- a/src/app/notifications/components/notificationListEntry.tsx
+++ b/src/app/notifications/components/notificationListEntry.tsx
@@ -5,12 +5,14 @@
 import * as React from 'react';
 import * as moment from 'moment';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Announced } from 'office-ui-fabric-react/lib/Announced';
 import { Notification, NotificationType } from '../../api/models/notification';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../shared/contexts/localizationContext';
 import '../../css/_notification.scss';
 
 export interface NotificationListEntryProps {
     notification: Notification;
+    showAnnoucement: boolean;
 }
 
 export const NotificationListEntry: React.SFC<NotificationListEntryProps> = (props: NotificationListEntryProps) => {
@@ -22,6 +24,7 @@ export const NotificationListEntry: React.SFC<NotificationListEntryProps> = (pro
         <LocalizationContextConsumer>
             {(context: LocalizationContextInterface) => (
                 <div className="notification-list-entry">
+                    {props.showAnnoucement && <Announced message={context.t(notification.text.translationKey, notification.text.translationOptions)}/>}
                     <div className={iconColor}>
                         <Icon style={{fontSize: 18}} iconName={iconName} />
                     </div>

--- a/src/app/notifications/components/notificationToast.tsx
+++ b/src/app/notifications/components/notificationToast.tsx
@@ -36,7 +36,7 @@ export const CloseButton = (props: CloseButtonProps): JSX.Element => {
 };
 
 const fetchComponent = (notification: Notification) => {
-    return <NotificationListEntry notification={notification} />;
+    return <NotificationListEntry notification={notification} showAnnoucement={true}/>;
 };
 
 export const raiseNotificationToast = (notification: Notification) => {

--- a/src/app/settings/components/__snapshots__/repositoryLocationListItem.spec.tsx.snap
+++ b/src/app/settings/components/__snapshots__/repositoryLocationListItem.spec.tsx.snap
@@ -54,10 +54,10 @@ exports[`components/settings/repositoryLocationListItem matches snapshot for pri
       <MaskedCopyableTextField
         allowMask={true}
         ariaLabel="settings.modelDefinitions.repositoryTypes.private.textBoxLabel"
+        disabled={false}
         label="settings.modelDefinitions.repositoryTypes.private.textBoxLabel"
         onTextChange={[Function]}
         placeholder="settings.modelDefinitions.repositoryTypes.private.placeholder"
-        readOnly={false}
         required={true}
         t={
           [MockFunction] {

--- a/src/app/settings/components/repositoryLocationListItem.tsx
+++ b/src/app/settings/components/repositoryLocationListItem.tsx
@@ -56,7 +56,7 @@ export default class RepositoryLocationListItem extends React.Component<Reposito
                                     label={context.t(ResourceKeys.settings.modelDefinitions.repositoryTypes.private.textBoxLabel)}
                                     value={item.connectionString}
                                     allowMask={true}
-                                    readOnly={false}
+                                    disabled={false}
                                     required={true}
                                     onTextChange={this.onConnectionStringChanged}
                                     placeholder={context.t(ResourceKeys.settings.modelDefinitions.repositoryTypes.private.placeholder)}

--- a/src/app/shared/components/__snapshots__/maskedCopyableTextField.spec.tsx.snap
+++ b/src/app/shared/components/__snapshots__/maskedCopyableTextField.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
     className="controlSection"
   >
     <div
-      className="borderedSection  readOnly"
+      className="borderedSection  "
     >
       <input
         aria-invalid={false}
@@ -25,7 +25,6 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
         className="input"
         id="maskedCopyableTextField1"
         onChange={[Function]}
-        readOnly={true}
         type="text"
         value="value1"
       />
@@ -54,6 +53,11 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
       >
         <CustomizedIconButton
           aria-labelledby="copyButtonTooltipHost3"
+          componentRef={
+            Object {
+              "current": null,
+            }
+          }
           iconProps={
             Object {
               "iconName": "copy",
@@ -84,7 +88,7 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
     className="controlSection"
   >
     <div
-      className="borderedSection  readOnly"
+      className="borderedSection  "
     >
       <input
         aria-invalid={false}
@@ -92,7 +96,6 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
         className="input"
         id="maskedCopyableTextField4"
         onChange={[Function]}
-        readOnly={true}
         type="password"
         value="value1"
       />
@@ -135,6 +138,11 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
       >
         <CustomizedIconButton
           aria-labelledby="copyButtonTooltipHost6"
+          componentRef={
+            Object {
+              "current": null,
+            }
+          }
           iconProps={
             Object {
               "iconName": "copy",
@@ -165,7 +173,7 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
     className="controlSection"
   >
     <div
-      className="borderedSection  readOnly"
+      className="borderedSection  "
     >
       <input
         aria-invalid={false}
@@ -173,7 +181,6 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
         className="input"
         id="maskedCopyableTextField7"
         onChange={[Function]}
-        readOnly={true}
         type="password"
         value="value1"
       />
@@ -216,6 +223,11 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
       >
         <CustomizedIconButton
           aria-labelledby="copyButtonTooltipHost9"
+          componentRef={
+            Object {
+              "current": null,
+            }
+          }
           iconProps={
             Object {
               "iconName": "copy",
@@ -246,7 +258,7 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
     className="controlSection"
   >
     <div
-      className="borderedSection error readOnly"
+      className="borderedSection error "
     >
       <input
         aria-invalid={true}
@@ -254,7 +266,6 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
         className="input"
         id="maskedCopyableTextField10"
         onChange={[Function]}
-        readOnly={true}
         type="password"
         value="value1"
       />
@@ -297,6 +308,11 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when error messag
       >
         <CustomizedIconButton
           aria-labelledby="copyButtonTooltipHost12"
+          componentRef={
+            Object {
+              "current": null,
+            }
+          }
           iconProps={
             Object {
               "iconName": "copy",

--- a/src/app/shared/components/groupedList/__snapshots__/groupedList.spec.tsx.snap
+++ b/src/app/shared/components/groupedList/__snapshots__/groupedList.spec.tsx.snap
@@ -348,6 +348,9 @@ exports[`components/GroupedList render GroupedList matches snapshot when no item
   <h3>
     No Items
   </h3>
+  <StyledAnnouncedBase
+    message="No Items"
+  />
 </div>
 `;
 
@@ -399,5 +402,8 @@ exports[`components/GroupedList render GroupedList matches snapshot with undefin
   <h3>
     No Items
   </h3>
+  <StyledAnnouncedBase
+    message="No Items"
+  />
 </div>
 `;

--- a/src/app/shared/components/groupedList/groupedList.tsx
+++ b/src/app/shared/components/groupedList/groupedList.tsx
@@ -9,6 +9,7 @@ import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { IconButton, BaseButton, Button } from 'office-ui-fabric-react/lib/Button';
 import { ISelection, SelectionMode, Selection, SelectionZone } from 'office-ui-fabric-react/lib/Selection';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { Announced } from 'office-ui-fabric-react/lib/Announced';
 import LabelWithTooltip from '../labelWithTooltip';
 import { GroupedList as GroupedListIconNames } from '../../../constants/iconNames';
 import { CHECKBOX_WIDTH_PERCENTAGE, GRID_STYLE_CONSTANTS, CHECKBOX_WIDTH_PIXELS, LABEL_FONT_SIZE } from './groupedListStyleConstants';
@@ -62,7 +63,12 @@ export default class GroupedListWrapper<T> extends React.Component<GroupedListPr
                 {!!isLoading ?
                     <MultiLineShimmer shimmerCount={SHIMMER_COUNT}/>
                     : !items || items.length === 0 ? (
-                        <h3>{noItemsMessage}</h3>
+                        <>
+                            <h3>{noItemsMessage}</h3>
+                            <Announced
+                                message={noItemsMessage}
+                            />
+                        </>
                     ) : (
                         <MarqueeSelection selection={selection} isEnabled={selection.mode === SelectionMode.multiple}>
                             <SelectionZone selection={selection}>

--- a/src/app/shared/components/maskedCopyableTextField.tsx
+++ b/src/app/shared/components/maskedCopyableTextField.tsx
@@ -4,7 +4,7 @@
  **********************************************************/
 import * as React from 'react';
 import { TranslationFunction } from 'i18next';
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { IconButton, IButton } from 'office-ui-fabric-react/lib/Button';
 import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { ResourceKeys } from '../../../localization/resourceKeys';
@@ -21,7 +21,7 @@ export interface MaskedCopyableTextFieldProps {
     value: string;
     allowMask: boolean;
     t: TranslationFunction;
-    readOnly: boolean;
+    disabled: boolean;
     required?: boolean;
     onTextChange?(text: string): void;
     placeholder?: string;
@@ -34,6 +34,7 @@ export interface MaskedCopyableTextFieldState {
 export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextFieldProps, MaskedCopyableTextFieldState> {
     private hiddenInputRef = React.createRef<HTMLInputElement>();
     private visibleInputRef = React.createRef<HTMLInputElement>();
+    private copyButtonRef = React.createRef<IButton>();
     private labelIdentifier = getId('maskedCopyableTextField');
     private toggleMaskButtonTooltipHostId = getId('toggleMaskButtonTooltipHost');
     private copyButtonTooltipHostId = getId('copyButtonTooltipHost');
@@ -46,7 +47,7 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
     }
     // tslint:disable-next-line:cyclomatic-complexity
     public render(): JSX.Element {
-        const { ariaLabel, error, value, allowMask, t, readOnly, placeholder } = this.props;
+        const { ariaLabel, error, value, allowMask, t, disabled, placeholder } = this.props;
         const { hideContents } = this.state;
 
         return (
@@ -56,7 +57,7 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
                 </div>
 
                 <div className="controlSection">
-                    <div className={`borderedSection ${error ? 'error' : ''} ${readOnly ? 'readOnly' : ''}`}>
+                    <div className={`borderedSection ${error ? 'error' : ''} ${disabled ? 'disabled' : ''}`}>
                         <input
                             aria-label={ariaLabel}
                             id={this.labelIdentifier}
@@ -64,7 +65,7 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
                             value={value}
                             type={(allowMask && hideContents) ? 'password' : 'text'}
                             className="input"
-                            readOnly={readOnly}
+                            disabled={disabled}
                             onChange={this.onChange}
                             placeholder={placeholder}
                             required={this.props.required}
@@ -103,6 +104,7 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
                                 iconProps={{ iconName: 'copy' }}
                                 aria-labelledby={this.copyButtonTooltipHostId}
                                 onClick={this.copyToClipboard}
+                                componentRef={this.copyButtonRef}
                             />
                         </TooltipHost>
                     </div>
@@ -115,6 +117,7 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
             </div>
         );
     }
+
     private readonly renderLabelSection = () => {
         const { calloutContent, label, labelCallout, required } = this.props;
         if (calloutContent) {
@@ -146,6 +149,11 @@ export class MaskedCopyableTextField extends React.Component<MaskedCopyableTextF
         if (node) {
             node.select();
             document.execCommand('copy');
+
+            const copyButtonNode = this.copyButtonRef.current;
+            if (copyButtonNode) {
+                copyButtonNode.focus();
+            }
         }
     }
 


### PR DESCRIPTION
bug 5660862: Use disabled instead of readOnly to not allow tabbing
bug 5660862: annouce results when there is no devices. aslo added annouced to notifications.
bug 5660790: set focus back to 'copy' button after clicked
bump version