### PR TITLE
adding annouced to pnp telemetry page; move buttons to commandbar

### DIFF
--- a/src/app/css/_addDevice.scss
+++ b/src/app/css/_addDevice.scss
@@ -21,14 +21,5 @@
         .connectivity {
             padding-top: 30px;
         }
-        .button-groups {
-            position: fixed;
-            bottom: 30px;
-            width: 100%;
-            .ms-Button {
-                padding: 0 10px 0 10px;
-                margin-right: 20px;
-            }
-        }
     }
 }

--- a/src/app/css/_layouts.scss
+++ b/src/app/css/_layouts.scss
@@ -58,9 +58,9 @@
 }
 
 .edit-content {
-    grid-row: 2;
+    grid-row: 3;
     grid-column: 1;
-    -ms-grid-row: 2;
+    -ms-grid-row: 3;
     -ms-grid-column: 1;
     @include themify($themes) {
         border-top: 1px solid themed('editContentBorderColor');

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
@@ -8,6 +8,7 @@ import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/Com
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { Spinner } from 'office-ui-fabric-react/lib/Spinner';
 import { TextField, ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
+import { Announced } from 'office-ui-fabric-react/lib/Announced';
 import { RouteComponentProps } from 'react-router-dom';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../../../localization/resourceKeys';
@@ -56,6 +57,7 @@ export interface DeviceEventsState {
     hasMore: boolean;
     startTime?: Date; // todo: add a datetime picker
     loading?: boolean;
+    loadingAnnounced?: JSX.Element;
     synchronizationStatus: SynchronizationStatus;
     monitoringData: boolean;
 }
@@ -107,7 +109,9 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                             />}
                         {this.props.telemetrySchema  ?
                             this.props.telemetrySchema.length !== 0 && this.renderInfiniteScroll(context) :
-                            <InterfaceNotFoundMessageBoxContainer/>}
+                            <InterfaceNotFoundMessageBoxContainer/>
+                        }
+                        {this.state.loadingAnnounced}
                     </div>
                 )}
             </LocalizationContextConsumer>
@@ -206,6 +210,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
             this.setState({
                 hasMore: true,
                 loading: false,
+                loadingAnnounced: undefined,
                 monitoringData: true
             });
         }
@@ -235,7 +240,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                 key="scroll"
                 className="device-events-container"
                 pageStart={0}
-                loadMore={this.fetchData}
+                loadMore={this.fetchData(context)}
                 hasMore={hasMore}
                 loader={this.renderLoader(context)}
                 isReverse={true}
@@ -398,11 +403,12 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
         );
     }
 
-    private readonly fetchData = () => {
+    private readonly fetchData = (context: LocalizationContextInterface) => () => {
         const { loading, monitoringData } = this.state;
         if (!loading && monitoringData) {
             this.setState({
                 loading: true,
+                loadingAnnounced: <Announced message={context.t(ResourceKeys.deviceEvents.infiniteScroll.loading)}/>
             });
             this.timerID = setTimeout(
                 () => {

--- a/src/app/devices/deviceList/components/addDevice/components/__snapshots__/addDevice.spec.tsx.snap
+++ b/src/app/devices/deviceList/components/addDevice/components/__snapshots__/addDevice.spec.tsx.snap
@@ -13,6 +13,36 @@ exports[`components/devices/addDevice matches snapshot 1`] = `
     />
   </div>
   <div
+    className="view-command"
+  >
+    <StyledCommandBarBase
+      items={
+        Array [
+          Object {
+            "ariaLabel": "deviceLists.commands.save",
+            "disabled": true,
+            "iconProps": Object {
+              "iconName": "Save",
+            },
+            "key": "Save",
+            "name": "deviceLists.commands.save",
+            "type": "submit",
+          },
+          Object {
+            "ariaLabel": "deviceLists.commands.close",
+            "disabled": false,
+            "iconProps": Object {
+              "iconName": "Cancel",
+            },
+            "key": "Cancel",
+            "name": "deviceLists.commands.close",
+            "onClick": [Function],
+          },
+        ]
+      }
+    />
+  </div>
+  <div
     className="edit-content view-scroll"
   >
     <div
@@ -31,6 +61,18 @@ exports[`components/devices/addDevice matches snapshot 1`] = `
         t={
           [MockFunction] {
             "calls": Array [
+              Array [
+                "deviceLists.commands.save",
+              ],
+              Array [
+                "deviceLists.commands.save",
+              ],
+              Array [
+                "deviceLists.commands.close",
+              ],
+              Array [
+                "deviceLists.commands.close",
+              ],
               Array [
                 "deviceIdentity.deviceID",
               ],
@@ -70,20 +112,24 @@ exports[`components/devices/addDevice matches snapshot 1`] = `
               Array [
                 "deviceIdentity.hubConnectivity.disable",
               ],
-              Array [
-                "deviceLists.commands.save",
-              ],
-              Array [
-                "deviceLists.commands.save",
-              ],
-              Array [
-                "deviceLists.commands.close",
-              ],
-              Array [
-                "deviceLists.commands.close",
-              ],
             ],
             "results": Array [
+              Object {
+                "type": "return",
+                "value": "deviceLists.commands.save",
+              },
+              Object {
+                "type": "return",
+                "value": "deviceLists.commands.save",
+              },
+              Object {
+                "type": "return",
+                "value": "deviceLists.commands.close",
+              },
+              Object {
+                "type": "return",
+                "value": "deviceLists.commands.close",
+              },
               Object {
                 "type": "return",
                 "value": "deviceIdentity.deviceID",
@@ -136,22 +182,6 @@ exports[`components/devices/addDevice matches snapshot 1`] = `
                 "type": "return",
                 "value": "deviceIdentity.hubConnectivity.disable",
               },
-              Object {
-                "type": "return",
-                "value": "deviceLists.commands.save",
-              },
-              Object {
-                "type": "return",
-                "value": "deviceLists.commands.save",
-              },
-              Object {
-                "type": "return",
-                "value": "deviceLists.commands.close",
-              },
-              Object {
-                "type": "return",
-                "value": "deviceLists.commands.close",
-              },
             ],
           }
         }
@@ -203,23 +233,6 @@ exports[`components/devices/addDevice matches snapshot 1`] = `
           offText="deviceIdentity.hubConnectivity.disable"
           onChange={[Function]}
           onText="deviceIdentity.hubConnectivity.enable"
-        />
-      </div>
-      <div
-        className="button-groups"
-      >
-        <CustomizedPrimaryButton
-          ariaDescription="deviceLists.commands.save"
-          className="submit-button"
-          disabled={true}
-          text="deviceLists.commands.save"
-          type="submit"
-        />
-        <CustomizedDefaultButton
-          ariaDescription="deviceLists.commands.close"
-          className="submit-button"
-          onClick={[Function]}
-          text="deviceLists.commands.close"
         />
       </div>
     </div>

--- a/src/app/devices/deviceList/components/addDevice/components/addDevice.spec.tsx
+++ b/src/app/devices/deviceList/components/addDevice/components/addDevice.spec.tsx
@@ -6,7 +6,7 @@ import 'jest';
 import * as React from 'react';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { CommandBar } from 'office-ui-fabric-react/lib/CommandBar';
 import AddDeviceComponent, { AddDeviceDataProps, AddDeviceActionProps, AddDeviceState } from './addDevice';
 import { testSnapshot, mountWithLocalization } from '../../../../../shared/utils/testHelpers';
 import { MaskedCopyableTextField } from '../../../../../shared/components/maskedCopyableTextField';
@@ -116,8 +116,9 @@ describe('components/devices/addDevice', () => {
         const addDeviceState = addDevice.state() as AddDeviceState;
         expect(addDeviceState.deviceId).toEqual('test-device');
         expect(addDeviceState.status).toEqual(DeviceStatus.Disabled);
-        const saveButton = addDevice.find(PrimaryButton).first();
-        expect(saveButton.props().disabled).toBeFalsy();
+        const commandBar = wrapper.find(CommandBar).first();
+        const saveButton = commandBar.props().items[0];
+        expect(saveButton.disabled).toBeFalsy();
 
         const form = addDevice.find('form');
         form.simulate('submit');

--- a/src/app/devices/deviceList/components/addDevice/components/addDevice.tsx
+++ b/src/app/devices/deviceList/components/addDevice/components/addDevice.tsx
@@ -4,11 +4,11 @@
  **********************************************************/
 import * as React from 'react';
 import { RouteComponentProps, Route } from 'react-router-dom';
-import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Overlay } from 'office-ui-fabric-react/lib/Overlay';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+import { CommandBar } from 'office-ui-fabric-react/lib/CommandBar';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../../../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../../../../localization/resourceKeys';
 import { DeviceAuthenticationType } from '../../../../../api/models/deviceAuthenticationType';
@@ -22,6 +22,7 @@ import { SynchronizationStatus } from '../../../../../api/models/synchronization
 import { ROUTE_PARTS } from '../../../../../constants/routes';
 import '../../../../../css/_addDevice.scss';
 import '../../../../../css/_layouts.scss';
+import { SAVE, CANCEL } from '../../../../../constants/iconNames';
 
 export interface AddDeviceActionProps {
     handleSave: (deviceIdentity: DeviceIdentity) => void;
@@ -73,13 +74,14 @@ export default class AddDevice extends React.Component<AddDeviceActionProps & Ad
                         <div className="view-header">
                             <Route component={BreadcrumbContainer} />
                         </div>
-
+                        <div className="view-command">
+                            {this.showCommandBar(context)}
+                        </div>
                         <div className="edit-content view-scroll">
                             <div className="form">
                                 {this.showDeviceId(context)}
                                 {this.showAuthentication(context)}
                                 {this.showConnectivity(context)}
-                                {this.showCommands(context)}
                             </div>
                         </div>
                         {this.props.deviceListSyncStatus === SynchronizationStatus.updating && <Overlay/>}
@@ -246,23 +248,32 @@ export default class AddDevice extends React.Component<AddDeviceActionProps & Ad
         );
     }
 
-    private readonly showCommands = (context: LocalizationContextInterface) => {
+    private readonly showCommandBar = (context: LocalizationContextInterface) => {
         return (
-            <div className="button-groups">
-                <PrimaryButton
-                    className="submit-button"
-                    disabled={this.disableSaveButton()}
-                    text={context.t(ResourceKeys.deviceLists.commands.save)}
-                    ariaDescription={context.t(ResourceKeys.deviceLists.commands.save)}
-                    type={'submit'}
-                />
-                <DefaultButton
-                    className="submit-button"
-                    onClick={this.handleCancel}
-                    text={context.t(ResourceKeys.deviceLists.commands.close)}
-                    ariaDescription={context.t(ResourceKeys.deviceLists.commands.close)}
-                />
-            </div>
+            <CommandBar
+                items={[
+                    {
+                        ariaLabel: context.t(ResourceKeys.deviceLists.commands.save),
+                        disabled: this.disableSaveButton(),
+                        iconProps: {
+                            iconName: SAVE
+                        },
+                        key: SAVE,
+                        name: context.t(ResourceKeys.deviceLists.commands.save),
+                        type: 'submit'
+                    },
+                    {
+                        ariaLabel: context.t(ResourceKeys.deviceLists.commands.close),
+                        disabled: false,
+                        iconProps: {
+                            iconName: CANCEL
+                        },
+                        key: CANCEL,
+                        name: context.t(ResourceKeys.deviceLists.commands.close),
+                        onClick: this.handleCancel
+                    },
+                ]}
+            />
         );
     }
 


### PR DESCRIPTION
adding annouced to pnp telemetry page: bug 5812237 (same logic as non pnp telemetry page)
move buttons on add device page from the bottom to commandbar so it is consistent with other pages which also resolves the accessbility bug when zooming in 200%: bug 5812260