### PR TITLE
Rkessler/factor connection strings easy (#3)

### DIFF
--- a/src/app/api/parameters/deviceParameters.ts
+++ b/src/app/api/parameters/deviceParameters.ts
@@ -6,6 +6,7 @@ import { Twin } from '../models/device';
 import { DeviceIdentity } from '../models/deviceIdentity';
 import DeviceQuery from '../models/deviceQuery';
 import { DigitalTwinInterfaces } from '../models/digitalTwinModels';
+import { CloudToDeviceMessageActionParameters, InvokeMethodActionParameters } from '../../devices/deviceContent/actions';
 
 export interface DataPlaneParameters {
     connectionString: string;
@@ -19,19 +20,9 @@ export interface UpdateDeviceTwinParameters extends FetchDeviceTwinParameters {
     deviceTwin: Twin;
 }
 
-export interface InvokeMethodParameters extends DataPlaneParameters {
-    connectTimeoutInSeconds: number;
-    deviceId: string;
-    methodName: string;
-    payload?: object;
-    responseTimeoutInSeconds: number;
-}
+export type InvokeMethodParameters = InvokeMethodActionParameters & DataPlaneParameters;
 
-export interface CloudToDeviceMessageParameters extends DataPlaneParameters {
-    deviceId: string;
-    body: string;
-    properties?: Array<{key: string, value: string, isSystemProperty: boolean}>;
-}
+export type CloudToDeviceMessageParameters = CloudToDeviceMessageActionParameters & DataPlaneParameters;
 
 export interface FetchDeviceParameters extends DataPlaneParameters {
     deviceId: string;

--- a/src/app/devices/deviceContent/actions.ts
+++ b/src/app/devices/deviceContent/actions.ts
@@ -6,7 +6,6 @@ import actionCreatorFactory from 'typescript-fsa';
 import * as actionPrefixes from '../../constants/actionPrefixes';
 import * as actionTypes from '../../constants/actionTypes';
 import { ModelDefinition } from '../../api/models/modelDefinition';
-import { InvokeMethodParameters, CloudToDeviceMessageParameters } from '../../api/parameters/deviceParameters';
 import { Twin } from '../../api/models/device';
 import { DeviceIdentity } from '../../api/models/deviceIdentity';
 import { DigitalTwinInterfaces } from './../../api/models/digitalTwinModels';
@@ -14,12 +13,12 @@ import { REPOSITORY_LOCATION_TYPE } from './../../constants/repositoryLocationTy
 
 const deviceContentCreator = actionCreatorFactory(actionPrefixes.DEVICECONTENT);
 const clearModelDefinitionsAction = deviceContentCreator(actionTypes.CLEAR_MODEL_DEFINITIONS);
-const cloudToDeviceMessageAction = deviceContentCreator.async<CloudToDeviceMessageParameters, string>(actionTypes.CLOUD_TO_DEVICE_MESSAGE);
+const cloudToDeviceMessageAction = deviceContentCreator.async<CloudToDeviceMessageActionParameters, string>(actionTypes.CLOUD_TO_DEVICE_MESSAGE);
 const getDeviceIdentityAction = deviceContentCreator.async<string, DeviceIdentity> (actionTypes.GET_DEVICE_IDENTITY);
 const getDigitalTwinInterfacePropertiesAction = deviceContentCreator.async<string, DigitalTwinInterfaces>(actionTypes.GET_DIGITAL_TWIN_INTERFACE_PROPERTIES);
 const getTwinAction = deviceContentCreator.async<string, Twin>(actionTypes.GET_TWIN);
 const getModelDefinitionAction = deviceContentCreator.async<GetModelDefinitionActionParameters, ModelDefinitionActionResult>(actionTypes.FETCH_MODEL_DEFINITION);
-const invokeDirectMethodAction = deviceContentCreator.async<InvokeMethodParameters, string>(actionTypes.INVOKE_DEVICE_METHOD);
+const invokeDirectMethodAction = deviceContentCreator.async<InvokeMethodActionParameters, string>(actionTypes.INVOKE_DEVICE_METHOD);
 const invokeDigitalTwinInterfaceCommandAction = deviceContentCreator.async<InvokeDigitalTwinInterfaceCommandActionParameters, string>(actionTypes.INVOKE_DIGITAL_TWIN_INTERFACE_COMMAND);
 const patchDigitalTwinInterfacePropertiesAction = deviceContentCreator.async<PatchDigitalTwinInterfacePropertiesActionParameters, DigitalTwinInterfaces>(actionTypes.PATCH_DIGITAL_TWIN_INTERFACE_PROPERTIES);
 const setInterfaceIdAction = deviceContentCreator<string>(actionTypes.SET_INTERFACE_ID);
@@ -40,6 +39,12 @@ export {
     updateDeviceIdentityAction
 };
 
+export interface CloudToDeviceMessageActionParameters {
+    deviceId: string;
+    body: string;
+    properties?: Array<{key: string, value: string, isSystemProperty: boolean}>;
+}
+
 export interface PatchDigitalTwinInterfacePropertiesActionParameters {
     digitalTwinId: string;
     interfacesPatchData: any; // tslint:disable-line:no-any
@@ -51,6 +56,14 @@ export interface InvokeDigitalTwinInterfaceCommandActionParameters {
     commandName: string;
     commandPayload: any; // tslint:disable-line:no-any
     propertyKey?: string;
+}
+
+export interface InvokeMethodActionParameters {
+    connectTimeoutInSeconds: number;
+    deviceId: string;
+    methodName: string;
+    payload?: object;
+    responseTimeoutInSeconds: number;
 }
 
 export interface UpdateTwinActionParameters {

--- a/src/app/devices/deviceContent/components/cloudToDeviceMessage/cloudToDeviceMessage.spec.tsx
+++ b/src/app/devices/deviceContent/components/cloudToDeviceMessage/cloudToDeviceMessage.spec.tsx
@@ -14,7 +14,6 @@ import { testSnapshot, mountWithLocalization } from '../../../../shared/utils/te
 describe('cloudToDeviceMessage', () => {
     const mockSendCloudToDeviceMessage = jest.fn();
     const cloudToDeviceMessageProps: CloudToDeviceMessageProps = {
-        connectionString: 'testString',
         onSendCloudToDeviceMessage: mockSendCloudToDeviceMessage
     };
 

--- a/src/app/devices/deviceContent/components/cloudToDeviceMessage/cloudToDeviceMessage.tsx
+++ b/src/app/devices/deviceContent/components/cloudToDeviceMessage/cloudToDeviceMessage.tsx
@@ -20,7 +20,7 @@ import { ResourceKeys } from '../../../../../localization/resourceKeys';
 import { getDeviceIdFromQueryString } from '../../../../shared/utils/queryStringHelper';
 import { CLOUD_TO_DEVICE_MESSAGE, ArrayOperation, ITEM, CIRCLE_ADD, CIRCLE_ADD_SOLID } from '../../../../constants/iconNames';
 import LabelWithTooltip from '../../../../shared/components/labelWithTooltip';
-import { CloudToDeviceMessageParameters } from '../../../../api/parameters/deviceParameters';
+import { CloudToDeviceMessageActionParameters } from '../../actions';
 import CollapsibleSection from '../../../../shared/components/collapsibleSection';
 import { MEDIUM_COLUMN_WIDTH } from '../../../../constants/columnWidth';
 import '../../../../css/_deviceDetail.scss';
@@ -60,8 +60,7 @@ export interface CloudToDeviceMessageState {
 }
 
 export interface CloudToDeviceMessageProps {
-    connectionString: string;
-    onSendCloudToDeviceMessage: (parameters: CloudToDeviceMessageParameters) => void;
+    onSendCloudToDeviceMessage: (parameters: CloudToDeviceMessageActionParameters) => void;
 }
 
 export default class CloudToDeviceMessage extends React.Component<CloudToDeviceMessageProps & RouteComponentProps, CloudToDeviceMessageState> {
@@ -429,7 +428,6 @@ export default class CloudToDeviceMessage extends React.Component<CloudToDeviceM
         const timeStamp = new Date().toLocaleString();
         this.props.onSendCloudToDeviceMessage({
             body: this.state.addTimestamp && this.state.body ? `${timeStamp} - ${this.state.body}` : (this.state.addTimestamp ? timeStamp : this.state.body),
-            connectionString: this.props.connectionString,
             deviceId: getDeviceIdFromQueryString(this.props),
             properties
         });

--- a/src/app/devices/deviceContent/components/cloudToDeviceMessage/cloudToDeviceMessageContainer.tsx
+++ b/src/app/devices/deviceContent/components/cloudToDeviceMessage/cloudToDeviceMessageContainer.tsx
@@ -6,22 +6,13 @@ import { compose, Dispatch } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import CloudToDeviceMessage, { CloudToDeviceMessageProps } from './cloudToDeviceMessage';
-import { StateType } from '../../../../shared/redux/state';
-import { NonFunctionProperties, FunctionProperties } from '../../../../shared/types/types';
-import { CloudToDeviceMessageParameters } from '../../../../api/parameters/deviceParameters';
-import { cloudToDeviceMessageAction } from '../../actions';
-import { getActiveAzureResourceConnectionStringSelector } from '../../../../azureResource/selectors';
-
-const mapStateToProps = (state: StateType): NonFunctionProperties<CloudToDeviceMessageProps> => {
-    return {
-        connectionString: getActiveAzureResourceConnectionStringSelector(state)
-    };
-};
+import { FunctionProperties } from '../../../../shared/types/types';
+import { cloudToDeviceMessageAction, CloudToDeviceMessageActionParameters } from '../../actions';
 
 const mapDispatchToProps = (dispatch: Dispatch): FunctionProperties<CloudToDeviceMessageProps> => {
     return {
-        onSendCloudToDeviceMessage: (parameters: CloudToDeviceMessageParameters) => dispatch(cloudToDeviceMessageAction.started(parameters))
+        onSendCloudToDeviceMessage: (parameters: CloudToDeviceMessageActionParameters) => dispatch(cloudToDeviceMessageAction.started(parameters))
     };
 };
 
-export default compose(withRouter, connect(mapStateToProps, mapDispatchToProps))(CloudToDeviceMessage);
+export default compose(withRouter, connect(undefined, mapDispatchToProps))(CloudToDeviceMessage);

--- a/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentity.spec.tsx
+++ b/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentity.spec.tsx
@@ -31,9 +31,9 @@ const dispatchProps = {
 };
 
 const getComponent = (overrides = {}) => {
-    const connectionString = 'HostName=test-string.azure-devices.net;SharedAccessKeyName=owner;SharedAccessKey=fakeKey=';
+    const activeAzureResourceHostName = 'test-string.azure-devices.net';
     const props = {
-        connectionString,
+        activeAzureResourceHostName,
         ...routerprops,
         ...overrides,
         ...dispatchProps

--- a/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentity.tsx
+++ b/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentity.tsx
@@ -32,8 +32,8 @@ export interface DeviceIdentityDispatchProps {
 }
 
 export interface DeviceIdentityDataProps {
+    activeAzureResourceHostName: string;
     identityWrapper: DeviceIdentityWrapper;
-    connectionString: string;
 }
 
 export interface DeviceIdentityState {
@@ -186,11 +186,11 @@ export default class DeviceIdentityInformation
     }
 
     private readonly onGenerateSASClicked = () => {
-        const { connectionString } = this.props;
+        const { activeAzureResourceHostName } = this.props;
         const { identity, sasTokenExpiration, sasTokenSelectedKey } = this.state;
 
         const sasTokenConnectionString = generateSASTokenConnectionString(
-            connectionString,
+            activeAzureResourceHostName,
             identity.deviceId,
             sasTokenExpiration,
             sasTokenSelectedKey
@@ -263,7 +263,7 @@ export default class DeviceIdentityInformation
     }
 
     private readonly renderDeviceAuthProperties = (context: LocalizationContextInterface) => {
-        const { connectionString } = this.props;
+        const { activeAzureResourceHostName } = this.props;
         const { identity } = this.state;
         const authType = getDeviceAuthenticationType(identity);
         switch (authType) {
@@ -292,7 +292,7 @@ export default class DeviceIdentityInformation
                         <MaskedCopyableTextFieldContainer
                             ariaLabel={context.t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.connectionString)}
                             label={context.t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.connectionString)}
-                            value={generateX509ConnectionString(connectionString, identity.deviceId)}
+                            value={generateX509ConnectionString(activeAzureResourceHostName, identity.deviceId)}
                             allowMask={true}
                             t={context.t}
                             readOnly={true}
@@ -307,7 +307,7 @@ export default class DeviceIdentityInformation
                         <MaskedCopyableTextFieldContainer
                             ariaLabel={context.t(ResourceKeys.deviceIdentity.authenticationType.ca.connectionString)}
                             label={context.t(ResourceKeys.deviceIdentity.authenticationType.ca.connectionString)}
-                            value={generateX509ConnectionString(connectionString, identity.deviceId)}
+                            value={generateX509ConnectionString(activeAzureResourceHostName, identity.deviceId)}
                             allowMask={true}
                             t={context.t}
                             readOnly={true}
@@ -343,7 +343,7 @@ export default class DeviceIdentityInformation
                         <MaskedCopyableTextFieldContainer
                             ariaLabel={context.t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryConnectionString)}
                             label={context.t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryConnectionString)}
-                            value={generateConnectionString(connectionString, identity.deviceId, identity.authentication.symmetricKey.primaryKey)}
+                            value={generateConnectionString(activeAzureResourceHostName, identity.deviceId, identity.authentication.symmetricKey.primaryKey)}
                             allowMask={true}
                             t={context.t}
                             readOnly={true}
@@ -353,7 +353,7 @@ export default class DeviceIdentityInformation
                         <MaskedCopyableTextFieldContainer
                             ariaLabel={context.t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryConnectionString)}
                             label={context.t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryConnectionString)}
-                            value={generateConnectionString(connectionString, identity.deviceId, identity.authentication.symmetricKey.secondaryKey)}
+                            value={generateConnectionString(activeAzureResourceHostName, identity.deviceId, identity.authentication.symmetricKey.secondaryKey)}
                             allowMask={true}
                             t={context.t}
                             readOnly={true}

--- a/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentityContainer.tsx
+++ b/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentityContainer.tsx
@@ -10,11 +10,11 @@ import DeviceIdentityInformation, { DeviceIdentityDataProps, DeviceIdentityDispa
 import { getDeviceIdentityWrapperSelector } from '../../selectors';
 import { DeviceIdentity } from '../../../../api/models/deviceIdentity';
 import { updateDeviceIdentityAction } from '../../actions';
-import { getActiveAzureResourceConnectionStringSelector } from '../../../../azureResource/selectors';
+import { getActiveAzureResourceHostNameSelector } from '../../../../azureResource/selectors';
 
 const mapStateToProps = (state: StateType): DeviceIdentityDataProps => {
     return {
-        connectionString: getActiveAzureResourceConnectionStringSelector(state),
+        activeAzureResourceHostName: getActiveAzureResourceHostNameSelector(state),
         identityWrapper: getDeviceIdentityWrapperSelector(state)
     };
 };

--- a/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentityHelper.spec.ts
+++ b/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentityHelper.spec.ts
@@ -10,12 +10,12 @@ import { DeviceAuthenticationType } from '../../../../api/models/deviceAuthentic
 describe('deviceIdentityHelper', () => {
     describe('generateConnectionString', () => {
         it('generates a symmetric key connection string', () => {
-            expect(generateConnectionString("HostName=test.azure-devices.net;SharedAccessKeyName=test;SharedAccessKey=test;", "testDevice", "testKey")).toEqual("HostName=test.azure-devices.net;DeviceId=testDevice;SharedAccessKey=testKey");
+            expect(generateConnectionString('test.azure-devices.net', 'testDevice', 'testKey')).toEqual('HostName=test.azure-devices.net;DeviceId=testDevice;SharedAccessKey=testKey');
         });
     });
     describe('generateX509ConnectionString', () => {
         it('generates a connection string for CA/self-signed certs', () => {
-            expect(generateX509ConnectionString("HostName=test.azure-devices.net;SharedAccessKeyName=test;SharedAccessKey=test;", "testDevice")).toEqual("HostName=test.azure-devices.net;DeviceId=testDevice;x509=true");
+            expect(generateX509ConnectionString('test.azure-devices.net', 'testDevice')).toEqual('HostName=test.azure-devices.net;DeviceId=testDevice;x509=true');
         });
     });
     describe('getDeviceAuthenticationType', () => {

--- a/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentityHelper.ts
+++ b/src/app/devices/deviceContent/components/deviceIdentity/deviceIdentityHelper.ts
@@ -27,23 +27,19 @@ export const getDeviceAuthenticationType = (identity: DeviceIdentity): DeviceAut
     }
 };
 
-export const generateX509ConnectionString = (connectionString: string, deviceId: string): string => {
-    const connectionObject = getConnectionInfoFromConnectionString(connectionString);
-    return connectionObject.hostName && deviceId ?
-        `HostName=${connectionObject.hostName};DeviceId=${deviceId};x509=true` : '';
+export const generateX509ConnectionString = (hostName: string, deviceId: string): string => {
+    return hostName && deviceId ?
+        `HostName=${hostName};DeviceId=${deviceId};x509=true` : '';
 };
 
-export const generateConnectionString = (connectionString: string, deviceId: string, key: string): string => {
-    const connectionObject = getConnectionInfoFromConnectionString(connectionString);
-    return connectionObject.hostName && deviceId && key ?
-        `HostName=${connectionObject.hostName};DeviceId=${deviceId};SharedAccessKey=${key}` : '';
+export const generateConnectionString = (hostName: string, deviceId: string, key: string): string => {
+    return hostName && deviceId && key ?
+        `HostName=${hostName};DeviceId=${deviceId};SharedAccessKey=${key}` : '';
 };
 
-export const generateSASTokenConnectionString = (connectionString: string, deviceId: string, expiration: number, key: string): string => {
-    const connectionObject = getConnectionInfoFromConnectionString(connectionString);
-
-    const resourceUri = connectionObject.hostName && deviceId ?
-        `${connectionObject.hostName}/devices/${deviceId}` : '';
+export const generateSASTokenConnectionString = (hostName: string, deviceId: string, expiration: number, key: string): string => {
+    const resourceUri = hostName && deviceId ?
+        `${hostName}/devices/${deviceId}` : '';
 
     const sasToken = generateSasToken({
         expiration,
@@ -51,6 +47,6 @@ export const generateSASTokenConnectionString = (connectionString: string, devic
         resourceUri
     });
 
-    return connectionObject.hostName && sasToken ?
-        `HostName=${connectionObject.hostName};DeviceId=${deviceId};SharedAccessSignature=${sasToken}` : '';
+    return hostName && sasToken ?
+        `HostName=${hostName};DeviceId=${deviceId};SharedAccessSignature=${sasToken}` : '';
 };

--- a/src/app/devices/deviceContent/components/directMethod/directMethod.spec.tsx
+++ b/src/app/devices/deviceContent/components/directMethod/directMethod.spec.tsx
@@ -10,7 +10,6 @@ import { testSnapshot } from '../../../../shared/utils/testHelpers';
 describe('directMethod', () => {
     const mockInvokeMethodClick = jest.fn();
     const directMethodProps: DirectMethodProps = {
-        connectionString: 'testString',
         onInvokeMethodClick: mockInvokeMethodClick
     };
 

--- a/src/app/devices/deviceContent/components/directMethod/directMethod.tsx
+++ b/src/app/devices/deviceContent/components/directMethod/directMethod.tsx
@@ -10,7 +10,7 @@ import { Slider, SliderBase } from 'office-ui-fabric-react/lib/Slider';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../../../localization/resourceKeys';
-import { InvokeMethodParameters } from '../../../../api/parameters/deviceParameters';
+import { InvokeMethodActionParameters } from '../../actions';
 import { getDeviceIdFromQueryString } from '../../../../shared/utils/queryStringHelper';
 import { DIRECT_METHOD } from '../../../../constants/iconNames';
 import LabelWithTooltip from '../../../../shared/components/labelWithTooltip';
@@ -29,8 +29,7 @@ export interface DirectMethodState {
 }
 
 export interface DirectMethodProps {
-    connectionString: string;
-    onInvokeMethodClick: (properties: InvokeMethodParameters) => void;
+    onInvokeMethodClick: (properties: InvokeMethodActionParameters) => void;
 }
 
 export default class DirectMethod extends React.Component<DirectMethodProps & RouteComponentProps, DirectMethodState> {
@@ -98,11 +97,9 @@ export default class DirectMethod extends React.Component<DirectMethodProps & Ro
 
     private readonly onInvokeMethodClick = () => {
         const { connectionTimeout, methodName, responseTimeout, payload } = this.state;
-        const { connectionString } = this.props;
 
         this.props.onInvokeMethodClick({
             connectTimeoutInSeconds: connectionTimeout,
-            connectionString,
             deviceId: getDeviceIdFromQueryString(this.props),
             methodName,
             payload: payload ? JSON.parse(payload) : {},

--- a/src/app/devices/deviceContent/components/directMethod/directMethodContainer.tsx
+++ b/src/app/devices/deviceContent/components/directMethod/directMethodContainer.tsx
@@ -6,17 +6,10 @@ import { compose, Dispatch } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import DirectMethod, { DirectMethodProps } from './directMethod';
-import { StateType } from '../../../../shared/redux/state';
-import { NonFunctionProperties, FunctionProperties } from '../../../../shared/types/types';
+import { FunctionProperties } from '../../../../shared/types/types';
 import { InvokeMethodParameters } from '../../../../api/parameters/deviceParameters';
 import { invokeDirectMethodAction } from '../../actions';
 import { getActiveAzureResourceConnectionStringSelector } from '../../../../azureResource/selectors';
-
-const mapStateToProps = (state: StateType): NonFunctionProperties<DirectMethodProps> => {
-    return {
-        connectionString: getActiveAzureResourceConnectionStringSelector(state)
-    };
-};
 
 const mapDispatchToProps = (dispatch: Dispatch): FunctionProperties<DirectMethodProps> => {
     return {
@@ -24,4 +17,4 @@ const mapDispatchToProps = (dispatch: Dispatch): FunctionProperties<DirectMethod
     };
 };
 
-export default compose(withRouter, connect(mapStateToProps, mapDispatchToProps))(DirectMethod);
+export default compose(withRouter, connect(undefined, mapDispatchToProps))(DirectMethod);

--- a/src/app/devices/deviceContent/sagas/cloudToDeviceMessageSaga.spec.ts
+++ b/src/app/devices/deviceContent/sagas/cloudToDeviceMessageSaga.spec.ts
@@ -8,6 +8,7 @@ import { cloneableGenerator, SagaIteratorClone } from 'redux-saga/utils';
 import { call, put } from 'redux-saga/effects';
 import * as DevicesService from '../../../api/services/devicesService';
 import { cloudToDeviceMessageSaga } from './cloudToDeviceMessageSaga';
+import { getActiveAzureResourceConnectionStringSaga } from '../../../azureResource/sagas/getActiveAzureResourceConnectionStringSaga';
 import { cloudToDeviceMessageAction } from '../actions';
 import { addNotificationAction } from '../../../notifications/actions';
 import { ResourceKeys } from '../../../../localization/resourceKeys';
@@ -58,10 +59,17 @@ describe('directMethodSaga', () => {
             });
         });
 
+        it('yields call to get active azure connection string', () => {
+            expect(cloudToDeviceMessageSagaGenerator.next()).toEqual({
+                done: false,
+                value: call(getActiveAzureResourceConnectionStringSaga)
+            });
+        });
+
         it('successfully send cloud to device message', () => {
             const success = cloudToDeviceMessageSagaGenerator.clone();
 
-            expect(success.next()).toEqual({
+            expect(success.next(connectionString)).toEqual({
                 done: false,
                 value: call(mockCloudToDeviceMessage, cloudToDeviceMessageParameters)
             });

--- a/src/app/devices/deviceContent/sagas/cloudToDeviceMessageSaga.ts
+++ b/src/app/devices/deviceContent/sagas/cloudToDeviceMessageSaga.ts
@@ -4,14 +4,15 @@
  **********************************************************/
 import { call, put } from 'redux-saga/effects';
 import { Action } from 'typescript-fsa';
-import { cloudToDeviceMessageAction } from '../actions';
+import { cloudToDeviceMessageAction, CloudToDeviceMessageActionParameters } from '../actions';
+import { getActiveAzureResourceConnectionStringSaga } from '../../../azureResource/sagas/getActiveAzureResourceConnectionStringSaga';
 import { cloudToDeviceMessage } from '../../../api/services/devicesService';
 import { addNotificationAction } from '../../../notifications/actions';
 import { NotificationType } from '../../../api/models/notification';
 import { ResourceKeys } from '../../../../localization/resourceKeys';
 import { CloudToDeviceMessageParameters } from '../../../api/parameters/deviceParameters';
 
-export function* cloudToDeviceMessageSaga(action: Action<CloudToDeviceMessageParameters>) {
+export function* cloudToDeviceMessageSaga(action: Action<CloudToDeviceMessageActionParameters>) {
     const toastId: number = Math.random();
 
     try {
@@ -26,9 +27,14 @@ export function* cloudToDeviceMessageSaga(action: Action<CloudToDeviceMessagePar
             },
             type: NotificationType.info,
         }));
-        const response = yield call(cloudToDeviceMessage, {
-            ...action.payload
-        });
+
+        const connectionString: string = yield call(getActiveAzureResourceConnectionStringSaga);
+        const cloudToDeviceMessageParameters: CloudToDeviceMessageParameters = {
+            ...action.payload,
+            connectionString
+        };
+
+        const response = yield call(cloudToDeviceMessage, cloudToDeviceMessageParameters);
 
         yield put(addNotificationAction.started({
             id: toastId,

--- a/src/app/devices/deviceContent/sagas/directMethodSaga.spec.ts
+++ b/src/app/devices/deviceContent/sagas/directMethodSaga.spec.ts
@@ -7,6 +7,7 @@ import { cloneableGenerator, SagaIteratorClone } from 'redux-saga/utils';
 import { call, put } from 'redux-saga/effects';
 import * as DevicesService from '../../../api/services/devicesService';
 import { invokeDirectMethodSaga, notifyMethodInvoked } from './directMethodSaga';
+import { getActiveAzureResourceConnectionStringSaga } from '../../../azureResource/sagas/getActiveAzureResourceConnectionStringSaga';
 import { invokeDirectMethodAction } from '../actions';
 import { InvokeMethodParameters } from '../../../api/parameters/deviceParameters';
 import { addNotificationAction } from '../../../notifications/actions';
@@ -108,10 +109,17 @@ describe('directMethodSaga', () => {
             });
         });
 
+        it('yields call to get active azure connection string', () => {
+            expect(invokeDirectMethodSagaGenerator.next()).toEqual({
+                done: false,
+                value: call(getActiveAzureResourceConnectionStringSaga)
+            });
+        });
+
         it('successfully invokes the method', () => {
             const success = invokeDirectMethodSagaGenerator.clone();
 
-            expect(success.next(payload)).toEqual({
+            expect(success.next(connectionString)).toEqual({
                 done: false,
                 value: call(mockInvokeDirectMethod, invokeMethodParameters)
             });

--- a/src/app/devices/deviceList/components/__snapshots__/deviceList.spec.tsx.snap
+++ b/src/app/devices/deviceList/components/__snapshots__/deviceList.spec.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`components/devices/DeviceList matches snapshot 1`] = `
 <DeviceListComponent
-  connectionString="connectionString"
   deleteDevices={[MockFunction]}
   devices={
     Array [

--- a/src/app/devices/deviceList/components/deviceList.spec.tsx
+++ b/src/app/devices/deviceList/components/deviceList.spec.tsx
@@ -37,7 +37,7 @@ const devices: DeviceSummary[] = [
 ];
 
 const deviceListDataProps: DeviceListDataProps = {
-    connectionString: 'connectionString',
+
     devices,
     isFetching: false
 };
@@ -75,11 +75,5 @@ describe('components/devices/DeviceList', () => {
 
         // delete button is disabled by default
         expect(commandBar.props().items[2].disabled).toBeTruthy(); // tslint:disable-line:no-magic-numbers
-    });
-
-    it('redirects on missing ConnectionString', () => {
-        const wrapper = shallow(getComponent({connectionString: ''}));
-        const child = shallow(wrapper.props().children());
-        expect(child.find('Redirect').first().prop('to')).toBe('/');
     });
 });

--- a/src/app/devices/deviceList/components/deviceList.tsx
+++ b/src/app/devices/deviceList/components/deviceList.tsx
@@ -27,7 +27,6 @@ import '../../../css/_deviceList.scss';
 import '../../../css/_layouts.scss';
 
 export interface DeviceListDataProps {
-    connectionString: string;
     devices?: DeviceSummary[];
     isFetching: boolean;
     query?: DeviceQuery;
@@ -67,10 +66,6 @@ class DeviceListComponent extends React.Component<DeviceListDataProps & DeviceLi
     private selection: Selection;
 
     public render() {
-        if (!this.props.connectionString) {
-            return (<Redirect to="/" />);
-        }
-
         return (
             <LocalizationContextConsumer>
                 {(context: LocalizationContextInterface) => (

--- a/src/app/devices/deviceList/components/deviceListContainer.tsx
+++ b/src/app/devices/deviceList/components/deviceListContainer.tsx
@@ -16,7 +16,6 @@ const mapStateToProps = (state: StateType): DeviceListDataProps => {
     const deviceListSyncStatus = getDeviceSummaryListStatus(state);
     const isFetching = deviceListSyncStatus && deviceListSyncStatus === SynchronizationStatus.working ||  deviceListSyncStatus === SynchronizationStatus.updating;
     return {
-        connectionString: getActiveAzureResourceConnectionStringSelector(state),
         devices: deviceSummaryListWrapperNoPNPSelector(state),
         isFetching,
         query: deviceQuerySelector(state)


### PR DESCRIPTION
Removes connection string dependencies from the following components:
	1. DeviceIdentity / DeviceIdentityContainer
	2. DeviceEvents / DeviceEventsContainer (moves string lookup to saga)
	3. DirectMethod / DirectMethodContainer (moves string lookup to saga)
        4. DeviceList / DeviceListContainer (the connection string check is redundant with  new permission hcecks on azureresource)