### PR TITLE
render error when properties has no interface info

### DIFF
--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.spec.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.spec.tsx
@@ -130,6 +130,25 @@ describe('components/devices/deviceEventsPerInterface', () => {
         expect(errorBoundary.children().at(4).props().children.props.children[1].props['aria-label']).toEqual('deviceEvents.columns.error.key.label'); // tslint:disable-line:no-magic-numbers
     });
 
+    it('renders events which body\'s key name is not populated', () => {
+        const wrapper = mountWithLocalization(getComponent({isLoading: false, telemetrySchema}));
+        const events = [{
+            body: {
+                'non-matching-key': 0
+            },
+            enqueuedTime: '2019-10-14T21:44:58.397Z',
+            properties: {}
+        }];
+        wrapper.setState({events});
+        wrapper.update();
+        const errorBoundary = wrapper.find(ErrorBoundary);
+        expect(errorBoundary.children().at(1).props().children.props.children).toEqual('--');
+        expect(errorBoundary.children().at(2).props().children.props.children).toEqual('--'); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(3).props().children.props.children).toEqual('--'); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(4).props().children.props.children[0]).toEqual(JSON.stringify(events[0].body, undefined, 2)); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(4).props().children.props.children[1].props['aria-label']).toEqual('deviceEvents.columns.error.key.label'); // tslint:disable-line:no-magic-numbers
+    });
+
     it('changes state accordingly when command bar buttons are clicked', () => {
         const wrapper = mountWithLocalization(getComponent({isLoading: false, telemetrySchema}));
         const commandBar = wrapper.find(CommandBar).first();

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
@@ -361,10 +361,6 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
 
     // tslint:disable-next-line:cyclomatic-complexity
     private readonly renderMessageBody = (event: Message, context: LocalizationContextInterface, key: string, schema: ParsedJsonSchema) => {
-        if (!key) {
-            return;
-        }
-
         const validator = new Validator();
         if (Object.keys(event.body) && Object.keys(event.body)[0] !== key) { // validate telemetry's property name
             return(
@@ -374,7 +370,9 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                         <section className="value-validation-error" aria-label={context.t(ResourceKeys.deviceEvents.columns.error.key.label)}>
                             <span>{context.t(ResourceKeys.deviceEvents.columns.error.key.label)}</span>
                             <ul>
-                                <li key={key}>{context.t(ResourceKeys.deviceEvents.columns.error.key.errorContent, {keyName: key})}</li>
+                                <li key={key}>{key ?
+                                    context.t(ResourceKeys.deviceEvents.columns.error.key.doesNotMatch, {keyName: key}) :
+                                    context.t(ResourceKeys.deviceEvents.columns.error.key.notSpecified)}</li>
                             </ul>
                         </section>
                     </Label>

--- a/src/app/login/components/connectivityPaneContainer.tsx
+++ b/src/app/login/components/connectivityPaneContainer.tsx
@@ -12,11 +12,11 @@ import { addNotificationAction } from '../../notifications/actions';
 import { setActiveAzureResourceByConnectionStringAction, SetActiveAzureResourceByConnectionStringActionParameters } from '../../azureResource/actions';
 import { Notification } from '../../api/models/notification';
 import { setConnectionStringsAction } from '../../connectionStrings/actions';
-import { getActiveAzureResourceHostNameSelector } from '../../azureResource/selectors';
+import { getActiveAzureResourceConnectionStringSelector } from '../../azureResource/selectors';
 
 const mapStateToProps = (state: StateType): ConnectivityPaneDataProps => {
     return {
-        connectionString: getActiveAzureResourceHostNameSelector(state),
+        connectionString: getActiveAzureResourceConnectionStringSelector(state),
         connectionStringList: state.connectionStringsState.connectionStrings
     };
 };

--- a/src/app/settings/components/settingsPaneContainer.tsx
+++ b/src/app/settings/components/settingsPaneContainer.tsx
@@ -17,11 +17,11 @@ import DeviceQuery from '../../api/models/deviceQuery';
 import { addNotificationAction } from '../../notifications/actions';
 import { Notification } from '../../api/models/notification';
 import { setConnectionStringsAction } from '../../connectionStrings/actions';
-import { getActiveAzureResourceHostNameSelector } from '../../azureResource/selectors';
+import { getActiveAzureResourceConnectionStringSelector } from '../../azureResource/selectors';
 
 const mapStateToProps = (state: StateType): SettingsPaneProps => {
     return {
-        hubConnectionString: getActiveAzureResourceHostNameSelector(state),
+        hubConnectionString: getActiveAzureResourceConnectionStringSelector(state),
         hubConnectionStringList: state.connectionStringsState.connectionStrings,
         isOpen: getSettingsVisibleSelector(state),
         repositoryLocations: getRepositoryLocationSettingsSelector(state)

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -483,7 +483,8 @@
             "error": {
                 "key": {
                     "label": "value does not match schema",
-                    "errorContent": "key is not {{keyName}}"
+                    "doesNotMatch": "key is not {{keyName}}",
+                    "notSpecified": "key is not specified in telemetry's properties"
                 },
                 "value": {
                     "label": "value does not match schema"

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -168,8 +168,9 @@ export class ResourceKeys {
          displayName : "deviceEvents.columns.displayName",
          error : {
             key : {
-               errorContent : "deviceEvents.columns.error.key.errorContent",
+               doesNotMatch : "deviceEvents.columns.error.key.doesNotMatch",
                label : "deviceEvents.columns.error.key.label",
+               notSpecified : "deviceEvents.columns.error.key.notSpecified",
             },
             value : {
                label : "deviceEvents.columns.error.value.label",


### PR DESCRIPTION
Addressing open issue [https://github.com/Azure/azure-iot-explorer/issues/176](url)
When device event does not send interface info in events' properties, give users detailed error other than blank event body.