### PR TITLE
get model from device

### DIFF
--- a/src/app/constants/modelDefinitionConstants.ts
+++ b/src/app/constants/modelDefinitionConstants.ts
@@ -4,5 +4,4 @@
  **********************************************************/
 export const modelDiscoveryInterfaceName = 'urn_azureiot_ModelDiscovery_DigitalTwin';
 export const modelDefinitionInterfaceId = 'urn:azureiot:ModelDiscovery:ModelDefinition:1';
-export const modelDefinitionInterfaceName = 'urn_azureiot_ModelDiscovery_ModelDefinition';
 export const modelDefinitionCommandName = 'getModelDefinition';

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.spec.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.spec.tsx
@@ -95,7 +95,7 @@ describe('components/devices/deviceEventsPerInterface', () => {
                 humid: '123' // intentionally set a value which type is double
             },
             enqueuedTime: '2019-10-14T21:44:58.397Z',
-            properties: {
+            systemProperties: {
               'iothub-message-schema': 'humid'
             }
         }];
@@ -116,7 +116,7 @@ describe('components/devices/deviceEventsPerInterface', () => {
                 'non-matching-key': 0
             },
             enqueuedTime: '2019-10-14T21:44:58.397Z',
-            properties: {
+            systemProperties: {
               'iothub-message-schema': 'humid'
             }
         }];

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
@@ -289,7 +289,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                     <section role="feed">
                     {
                         events.map((event: Message, index) => {
-                            return event.properties ? this.renderSingleEvents(event, index, context) : this.renderCombinedEvents(event, index, context);
+                            return event.systemProperties ? this.renderSingleEvents(event, index, context) : this.renderCombinedEvents(event, index, context);
                         })
                     }
                     </section>
@@ -300,7 +300,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
 
     private readonly renderSingleEvents = (event: Message, index: number, context: LocalizationContextInterface) => {
         const matchingSchema = this.props.telemetrySchema.filter(schema => schema.telemetryModelDefinition.name ===
-            event.properties[TELEMETRY_SCHEMA_PROP]);
+            event.systemProperties[TELEMETRY_SCHEMA_PROP]);
         const telemetryModelDefinition =  matchingSchema && matchingSchema.length !== 0 && matchingSchema[0].telemetryModelDefinition;
         const parsedSchema = matchingSchema && matchingSchema.length !== 0 && matchingSchema[0].parsedSchema;
 
@@ -384,7 +384,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
 
     // tslint:disable-next-line:cyclomatic-complexity
     private readonly renderMessageBody = (event: Message, context: LocalizationContextInterface, schema?: ParsedJsonSchema) => {
-        const key = event.properties ? event.properties[TELEMETRY_SCHEMA_PROP] : null;
+        const key = event.systemProperties ? event.systemProperties[TELEMETRY_SCHEMA_PROP] : null;
         const validator = new Validator();
 
         if (!key) {

--- a/src/app/devices/deviceContent/sagas/modelDefinitionSaga.spec.ts
+++ b/src/app/devices/deviceContent/sagas/modelDefinitionSaga.spec.ts
@@ -13,10 +13,10 @@ import { ResourceKeys } from '../../../../localization/resourceKeys';
 import { getModelDefinitionAction, getDigitalTwinInterfacePropertiesAction } from '../actions';
 import { getRepositoryLocationSettingsSelector, getPublicRepositoryHostName } from '../../../settings/selectors';
 import { REPOSITORY_LOCATION_TYPE } from '../../../constants/repositoryLocationTypes';
-import { getDigitalTwinInterfaceIdsSelector } from '../selectors';
+import { getDigitalTwinInterfaceIdsSelector, getDigitalTwinInterfaceIdToNameMapSelector } from '../selectors';
 import { getRepoTokenSaga } from '../../../settings/sagas/getRepoTokenSaga';
 import { getActiveAzureResourceConnectionStringSaga } from '../../../azureResource/sagas/getActiveAzureResourceConnectionStringSaga';
-import { modelDefinitionInterfaceId, modelDefinitionInterfaceName, modelDefinitionCommandName } from '../../../constants/modelDefinitionConstants';
+import { modelDefinitionInterfaceId, modelDefinitionCommandName } from '../../../constants/modelDefinitionConstants';
 import { fetchModelDefinition } from '../../../api/services/digitalTwinsModelService';
 import { PUBLIC_REPO_HOSTNAME } from '../../../constants/shared';
 
@@ -146,6 +146,7 @@ describe('modelDefinitionSaga', () => {
         const mockFetchDigitalTwinInterfaceProperties = jest.spyOn(DevicesService, 'fetchDigitalTwinInterfaceProperties').mockImplementationOnce(parameters => {
             return null;
         });
+        const modelDefinitionInterfaceName = 'model_discovery';
 
         expect(getModelDefinitionFromDeviceGenerator.next()).toEqual({
             done: false,
@@ -175,6 +176,13 @@ describe('modelDefinitionSaga', () => {
         });
 
         expect(getModelDefinitionFromDeviceGenerator.next([modelDefinitionInterfaceId])).toEqual({
+            done: false,
+            value: select(getDigitalTwinInterfaceIdToNameMapSelector)
+        });
+
+        const idToNameMap = new Map<string, string>();
+        idToNameMap.set(modelDefinitionInterfaceId, modelDefinitionInterfaceName);
+        expect(getModelDefinitionFromDeviceGenerator.next(idToNameMap)).toEqual({
             done: false,
             value: call(getActiveAzureResourceConnectionStringSaga)
         });

--- a/src/app/devices/deviceContent/sagas/modelDefinitionSaga.ts
+++ b/src/app/devices/deviceContent/sagas/modelDefinitionSaga.ts
@@ -17,9 +17,9 @@ import { REPOSITORY_LOCATION_TYPE } from './../../../constants/repositoryLocatio
 import { getRepoConnectionInfoFromConnectionString } from '../../../api/shared/utils';
 import { invokeDigitalTwinInterfaceCommand, fetchDigitalTwinInterfaceProperties } from '../../../api/services/devicesService';
 import { getActiveAzureResourceConnectionStringSaga } from '../../../azureResource/sagas/getActiveAzureResourceConnectionStringSaga';
-import { getDigitalTwinInterfaceIdsSelector } from '../selectors';
+import { getDigitalTwinInterfaceIdsSelector, getDigitalTwinInterfaceIdToNameMapSelector } from '../selectors';
 import { InterfaceNotImplementedException } from './../../../shared/utils/exceptions/interfaceNotImplementedException';
-import { modelDefinitionInterfaceId, modelDefinitionInterfaceName, modelDefinitionCommandName } from '../../../constants/modelDefinitionConstants';
+import { modelDefinitionInterfaceId, modelDefinitionCommandName } from '../../../constants/modelDefinitionConstants';
 import { FetchDigitalTwinInterfacePropertiesParameters } from '../../../api/parameters/deviceParameters';
 
 export function* getModelDefinitionSaga(action: Action<GetModelDefinitionActionParameters>) {
@@ -107,6 +107,10 @@ export function* getModelDefinitionFromDevice(action: Action<GetModelDefinitionA
     if (interfaceIds.filter(id => id === modelDefinitionInterfaceId).length === 0) {
         throw new InterfaceNotImplementedException();
     }
+
+    // then get the name of ${modelDefinitionInterfaceId} interface.
+    const interfaceIdToNameMap: Map<string, string> = yield select(getDigitalTwinInterfaceIdToNameMapSelector);
+    const modelDefinitionInterfaceName = interfaceIdToNameMap.get(modelDefinitionInterfaceId);
 
     // if interface is implemented, invoke command on device
     return yield call(invokeDigitalTwinInterfaceCommand, {

--- a/src/app/devices/deviceContent/selectors.ts
+++ b/src/app/devices/deviceContent/selectors.ts
@@ -77,7 +77,7 @@ export const getReportedInterfacesFromDigitalTwin = (properties: DigitalTwinInte
         properties.interfaces[modelDiscoveryInterfaceName].properties.modelInformation.reported.value.interfaces;
 };
 
-const getDigitalTwinInterfaceIdToNameMapSelector = createSelector(
+export const getDigitalTwinInterfaceIdToNameMapSelector = createSelector(
     getDigitalTwinInterfaceNameAndIdsSelector,
     nameAndIds => {
         const idToNameMap = new Map<string, string>();


### PR DESCRIPTION
System component name (interface name) doesn't always confront to the convention. So 'urn_azureiot_ModelDiscovery_ModelDefinition' is not always the right name for interface ''urn:azureiot:ModelDiscovery:ModelDefinition:1'.
Call the selector to get the real name of this interface is the right way going forward. 