### PR TITLE
format exploded message; move buttons

### DIFF
--- a/src/app/constants/iconNames.ts
+++ b/src/app/constants/iconNames.ts
@@ -27,6 +27,7 @@ export const WARNING = 'Warning';
 export const DIRECT_METHOD = 'Remote';
 export const CLOUD_TO_DEVICE_MESSAGE = 'Mail';
 export const ITEM = 'LocationDot';
+export const NAVIGATE_BACK = 'NavigateBack';
 
 export enum GroupedList {
     OPEN = 'ChevronDown',

--- a/src/app/css/_deviceEvents.scss
+++ b/src/app/css/_deviceEvents.scss
@@ -22,12 +22,6 @@
         }
     }
 
-    .scrollable {
-        overflow: auto;
-        margin-top: 10px;
-        height: calc(100vh - 341px);
-    }
-
     .consumer-group-label {
         font-weight: 600;
         font-size: 14px;
@@ -38,10 +32,15 @@
 
     .consumer-group-text-field {
         display: grid;
-        padding-left: 26px;
+        padding-left: 24px;
+        padding-bottom: 10px;
         @include themify($themes) {
             color: themed('textColor');
         }
         width: 500px;
+    }
+
+    .toggle-button {
+        padding-left: 24px;
     }
 }

--- a/src/app/css/_devicePnpDetailList.scss
+++ b/src/app/css/_devicePnpDetailList.scss
@@ -85,6 +85,10 @@
             border-bottom: none;
         }
 
+        .item-summary-partial {
+            border-bottom: none;
+        }
+
         .item-detail {
             @include themify($themes) {
                 border-bottom-color: 1px solid themed('itemDetailBottomBorderColor');
@@ -183,7 +187,12 @@
     overflow-y: auto;
 }
 
-.scrollable-sm {
-    height: calc(100vh - 392px);
+.scrollable-pnp-telemetry {
+    height: calc(100vh - 400px);
+    overflow-y: auto;
+}
+
+.scrollable-telemetry {
+    height: calc(100vh - 360px);
     overflow-y: auto;
 }

--- a/src/app/css/_digitalTwinHeader.scss
+++ b/src/app/css/_digitalTwinHeader.scss
@@ -9,7 +9,7 @@
         left: 5px;
     }
     .pivot-item {
-        margin: 10px;
+        margin: 12px;
         font-size: 18px;
         a {
             @include themify($themes) {

--- a/src/app/devices/deviceContent/components/deviceCommands/__snapshots__/deviceCommands.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceCommands/__snapshots__/deviceCommands.spec.tsx.snap
@@ -4,6 +4,19 @@ exports[`components/devices/deviceCommands matches snapshot while interface cann
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceCommands.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceCommands.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -13,15 +26,6 @@ exports[`components/devices/deviceCommands matches snapshot while interface cann
           },
           "key": "Refresh",
           "name": "deviceCommands.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceCommands.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceCommands.command.close",
           "onClick": [Function],
         },
       ]
@@ -38,6 +42,19 @@ exports[`components/devices/deviceCommands matches snapshot with a commandSchema
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceCommands.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceCommands.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -47,15 +64,6 @@ exports[`components/devices/deviceCommands matches snapshot with a commandSchema
           },
           "key": "Refresh",
           "name": "deviceCommands.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceCommands.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceCommands.command.close",
           "onClick": [Function],
         },
       ]

--- a/src/app/devices/deviceContent/components/deviceCommands/deviceCommands.tsx
+++ b/src/app/devices/deviceContent/components/deviceCommands/deviceCommands.tsx
@@ -13,7 +13,7 @@ import { InvokeDigitalTwinInterfaceCommandActionParameters } from '../../actions
 import { getDeviceIdFromQueryString, getInterfaceIdFromQueryString, getComponentNameFromQueryString } from '../../../../shared/utils/queryStringHelper';
 import { CommandSchema } from './deviceCommandsPerInterfacePerCommand';
 import InterfaceNotFoundMessageBoxContainer from '../shared/interfaceNotFoundMessageBarContainer';
-import { REFRESH, CLOSE } from '../../../../constants/iconNames';
+import { REFRESH, NAVIGATE_BACK } from '../../../../constants/iconNames';
 import MultiLineShimmer from '../../../../shared/components/multiLineShimmer';
 import { DigitalTwinHeaderContainer } from '../digitalTwin/digitalTwinHeaderView';
 import { ROUTE_PARAMS } from '../../../../constants/routes';
@@ -58,11 +58,13 @@ export default class DeviceCommands
                                     key: REFRESH,
                                     name: context.t(ResourceKeys.deviceCommands.command.refresh),
                                     onClick: this.handleRefresh
-                                },
+                                }
+                            ]}
+                            farItems={[
                                 {
                                     ariaLabel: context.t(ResourceKeys.deviceCommands.command.close),
-                                    iconProps: {iconName: CLOSE},
-                                    key: CLOSE,
+                                    iconProps: {iconName: NAVIGATE_BACK},
+                                    key: NAVIGATE_BACK,
                                     name: context.t(ResourceKeys.deviceCommands.command.close),
                                     onClick: this.handleClose
                                 }

--- a/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEvents.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEvents.spec.tsx.snap
@@ -83,7 +83,7 @@ exports[`components/devices/deviceEvents matches snapshot in electron 1`] = `
     useWindow={true}
   >
     <div
-      className="scrollable-sm"
+      className="scrollable-telemetry"
     />
   </InfiniteScroll>
 </div>
@@ -172,7 +172,7 @@ exports[`components/devices/deviceEvents matches snapshot in hosted environment 
     useWindow={true}
   >
     <div
-      className="scrollable-sm"
+      className="scrollable-telemetry"
     />
   </InfiniteScroll>
 </div>

--- a/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEventsPerInterface.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEventsPerInterface.spec.tsx.snap
@@ -7,6 +7,19 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
 >
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceEvents.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceEvents.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -39,15 +52,6 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
           "name": "deviceEvents.command.clearEvents",
           "onClick": [Function],
         },
-        Object {
-          "ariaLabel": "deviceEvents.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceEvents.command.close",
-          "onClick": [Function],
-        },
       ]
     }
   />
@@ -65,6 +69,19 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
 >
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceEvents.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceEvents.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -97,15 +114,6 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
           "name": "deviceEvents.command.clearEvents",
           "onClick": [Function],
         },
-        Object {
-          "ariaLabel": "deviceEvents.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceEvents.command.close",
-          "onClick": [Function],
-        },
       ]
     }
   />
@@ -121,6 +129,15 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
     onRenderLabel={[Function]}
     underlined={true}
     value="$Default"
+  />
+  <StyledToggleBase
+    ariaLabel="deviceEvents.toggle.label"
+    checked={false}
+    className="toggle-button"
+    label="deviceEvents.toggle.label"
+    offText="deviceEvents.toggle.off"
+    onChange={[Function]}
+    onText="deviceEvents.toggle.on"
   />
   <InfiniteScroll
     className="device-events-container"
@@ -153,42 +170,8 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
       className="list-content"
     >
       <div
-        className="scrollable-sm"
-      >
-        <div
-          className="pnp-detail-list ms-Grid"
-        >
-          <div
-            className="list-header list-header-uncollapsible ms-Grid-row"
-          >
-            <span
-              className="ms-Grid-col ms-sm2"
-            >
-              deviceEvents.columns.timestamp
-            </span>
-            <span
-              className="ms-Grid-col ms-sm2"
-            >
-              deviceEvents.columns.displayName
-            </span>
-            <span
-              className="ms-Grid-col ms-sm2"
-            >
-              deviceEvents.columns.schema
-            </span>
-            <span
-              className="ms-Grid-col ms-sm2"
-            >
-              deviceEvents.columns.unit
-            </span>
-            <span
-              className="ms-Grid-col ms-sm4"
-            >
-              deviceEvents.columns.value
-            </span>
-          </div>
-        </div>
-      </div>
+        className="scrollable-pnp-telemetry"
+      />
     </section>
   </InfiniteScroll>
 </div>
@@ -201,6 +184,19 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
 >
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceEvents.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceEvents.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -233,15 +229,6 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
           "name": "deviceEvents.command.clearEvents",
           "onClick": [Function],
         },
-        Object {
-          "ariaLabel": "deviceEvents.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceEvents.command.close",
-          "onClick": [Function],
-        },
       ]
     }
   />
@@ -257,6 +244,15 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
     onRenderLabel={[Function]}
     underlined={true}
     value="$Default"
+  />
+  <StyledToggleBase
+    ariaLabel="deviceEvents.toggle.label"
+    checked={false}
+    className="toggle-button"
+    label="deviceEvents.toggle.label"
+    offText="deviceEvents.toggle.off"
+    onChange={[Function]}
+    onText="deviceEvents.toggle.on"
   />
   <InfiniteScroll
     className="device-events-container"
@@ -289,42 +285,8 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
       className="list-content"
     >
       <div
-        className="scrollable-sm"
-      >
-        <div
-          className="pnp-detail-list ms-Grid"
-        >
-          <div
-            className="list-header list-header-uncollapsible ms-Grid-row"
-          >
-            <span
-              className="ms-Grid-col ms-sm2"
-            >
-              deviceEvents.columns.timestamp
-            </span>
-            <span
-              className="ms-Grid-col ms-sm2"
-            >
-              deviceEvents.columns.displayName
-            </span>
-            <span
-              className="ms-Grid-col ms-sm2"
-            >
-              deviceEvents.columns.schema
-            </span>
-            <span
-              className="ms-Grid-col ms-sm2"
-            >
-              deviceEvents.columns.unit
-            </span>
-            <span
-              className="ms-Grid-col ms-sm4"
-            >
-              deviceEvents.columns.value
-            </span>
-          </div>
-        </div>
-      </div>
+        className="scrollable-pnp-telemetry"
+      />
     </section>
   </InfiniteScroll>
 </div>

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEvents.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEvents.tsx
@@ -238,7 +238,7 @@ export default class DeviceEventsComponent extends React.Component<DeviceEventsD
         const { events } = this.state;
 
         return (
-            <div className="scrollable-sm">
+            <div className="scrollable-telemetry">
             {
                 events && events.map((event: Message, index) => {
                     return (

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.spec.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.spec.tsx
@@ -12,6 +12,7 @@ import { mountWithLocalization, testSnapshot } from '../../../../shared/utils/te
 import InterfaceNotFoundMessageBoxContainer from '../shared/interfaceNotFoundMessageBarContainer';
 import ErrorBoundary from '../../../errorBoundary';
 import { appConfig, HostMode } from '../../../../../appConfig/appConfig';
+import { ResourceKeys } from '../../../../../localization/resourceKeys';
 
 describe('components/devices/deviceEventsPerInterface', () => {
 
@@ -108,7 +109,7 @@ describe('components/devices/deviceEventsPerInterface', () => {
         expect(errorBoundary.children().at(2).props().children.props.children).toEqual('double'); // tslint:disable-line:no-magic-numbers
         expect(errorBoundary.children().at(3).props().children.props.children).toEqual('--'); // tslint:disable-line:no-magic-numbers
         expect(errorBoundary.children().at(4).props().children.props.children[0]).toEqual(JSON.stringify(events[0].body, undefined, 2)); // tslint:disable-line:no-magic-numbers
-        expect(errorBoundary.children().at(4).props().children.props.children[1].props['aria-label']).toEqual('deviceEvents.columns.error.value.label'); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(4).props().children.props.children[1].props['aria-label']).toEqual(ResourceKeys.deviceEvents.columns.validation.value.label); // tslint:disable-line:no-magic-numbers
     });
 
     it('renders events which body\'s key name is wrong with expected columns', () => {
@@ -131,7 +132,35 @@ describe('components/devices/deviceEventsPerInterface', () => {
         expect(errorBoundary.children().at(2).props().children.props.children).toEqual('double'); // tslint:disable-line:no-magic-numbers
         expect(errorBoundary.children().at(3).props().children.props.children).toEqual('--'); // tslint:disable-line:no-magic-numbers
         expect(errorBoundary.children().at(4).props().children.props.children[0]).toEqual(JSON.stringify(events[0].body, undefined, 2)); // tslint:disable-line:no-magic-numbers
-        expect(errorBoundary.children().at(4).props().children.props.children[1].props['aria-label']).toEqual('deviceEvents.columns.error.key.label'); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(4).props().children.props.children[1].props.className).toEqual('value-validation-error'); // tslint:disable-line:no-magic-numbers
+    });
+
+    it('renders events when body is exploded and schema is not provided in system properties', () => {
+        const wrapper = mountWithLocalization(getComponent({isLoading: false, telemetrySchema}), false, true);
+        const events = [{
+            body: {
+                'humid': 0,
+                'humid-foo': 'test'
+            },
+            enqueuedTime: '2019-10-14T21:44:58.397Z',
+            systemProperties: {}
+        }];
+        let deviceEventsPerInterfaceComponent = wrapper.find(DeviceEventsPerInterfaceComponent);
+        deviceEventsPerInterfaceComponent.setState({events});
+        wrapper.update();
+        deviceEventsPerInterfaceComponent = wrapper.find(DeviceEventsPerInterfaceComponent);
+        let errorBoundary = deviceEventsPerInterfaceComponent.find(ErrorBoundary).first();
+        expect(errorBoundary.children().at(1).props().children.props.children).toEqual('humid (Temperature)');
+        expect(errorBoundary.children().at(2).props().children.props.children).toEqual('double'); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(3).props().children.props.children).toEqual('--'); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(4).props().children.props.children[0]).toEqual(JSON.stringify({humid: 0}, undefined, 2)); // tslint:disable-line:no-magic-numbers
+
+        errorBoundary = deviceEventsPerInterfaceComponent.find(ErrorBoundary).at(1);
+        expect(errorBoundary.children().at(1).props().children.props.children).toEqual('--');
+        expect(errorBoundary.children().at(2).props().children.props.children).toEqual('--'); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(3).props().children.props.children).toEqual('--'); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(4).props().children.props.children[0]).toEqual(JSON.stringify({'humid-foo': 'test'}, undefined, 2)); // tslint:disable-line:no-magic-numbers
+        expect(errorBoundary.children().at(4).props().children.props.children[1].props.className).toEqual('value-validation-error'); // tslint:disable-line:no-magic-numbers
     });
 
     it('renders events which body\'s key name is not populated', () => {

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
@@ -137,7 +137,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                     this.createRefreshCommandItem(context),
                     this.createClearCommandItem(context)
                 ]}
-                farItems={[this.createCloseCommandItem(context)]}
+                farItems={[this.createNavigateBackCommandItem(context)]}
             />
         );
     }
@@ -193,7 +193,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
         }
     }
 
-    private createCloseCommandItem = (context: LocalizationContextInterface): ICommandBarItemProps => {
+    private createNavigateBackCommandItem = (context: LocalizationContextInterface): ICommandBarItemProps => {
         return {
             ariaLabel: context.t(ResourceKeys.deviceEvents.command.close),
             iconProps: {iconName: NAVIGATE_BACK},

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
@@ -9,29 +9,30 @@ import { Label } from 'office-ui-fabric-react/lib/Label';
 import { Spinner } from 'office-ui-fabric-react/lib/Spinner';
 import { TextField, ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
 import { Announced } from 'office-ui-fabric-react/lib/Announced';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { RouteComponentProps, Route } from 'react-router-dom';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../../../localization/resourceKeys';
 import { monitorEvents, stopMonitoringEvents } from '../../../../api/services/devicesService';
 import { Message, MESSAGE_SYSTEM_PROPERTIES, MESSAGE_PROPERTIES } from '../../../../api/models/messages';
 import { parseDateTimeString } from '../../../../api/dataTransforms/transformHelper';
-import { REFRESH, STOP, START, CLOSE, REMOVE } from '../../../../constants/iconNames';
+import { REFRESH, STOP, START, REMOVE, NAVIGATE_BACK } from '../../../../constants/iconNames';
 import { ParsedJsonSchema } from '../../../../api/models/interfaceJsonParserOutput';
 import { TelemetryContent } from '../../../../api/models/modelDefinition';
 import { getInterfaceIdFromQueryString, getDeviceIdFromQueryString, getComponentNameFromQueryString } from '../../../../shared/utils/queryStringHelper';
 import InterfaceNotFoundMessageBoxContainer from '../shared/interfaceNotFoundMessageBarContainer';
 import { getNumberOfMapsInSchema } from '../../../../shared/utils/twinAndJsonSchemaDataConverter';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
-import LabelWithTooltip from '../../../../shared/components/labelWithTooltip';
 import { DEFAULT_CONSUMER_GROUP } from '../../../../constants/apiConstants';
 import ErrorBoundary from '../../../errorBoundary';
 import { getLocalizedData } from '../../../../api/dataTransforms/modelDefinitionTransform';
 import MultiLineShimmer from '../../../../shared/components/multiLineShimmer';
+import LabelWithTooltip from '../../../../shared/components/labelWithTooltip';
 import { MILLISECONDS_IN_MINUTE } from '../../../../constants/shared';
 import { appConfig, HostMode } from '../../../../../appConfig/appConfig';
-import '../../../../css/_deviceEvents.scss';
 import { DigitalTwinHeaderContainer } from '../digitalTwin/digitalTwinHeaderView';
 import { ROUTE_PARAMS } from '../../../../constants/routes';
+import '../../../../css/_deviceEvents.scss';
 
 const JSON_SPACES = 2;
 const LOADING_LOCK = 50;
@@ -59,16 +60,17 @@ export interface DeviceEventsState {
     consumerGroup: string;
     events: Message[];
     hasMore: boolean;
-    startTime: Date; // todo: add a datetime picker
-    loading?: boolean;
-    loadingAnnounced?: JSX.Element;
+    startTime: Date;
     synchronizationStatus: SynchronizationStatus;
     monitoringData: boolean;
+    showRawEvent: boolean;
+
+    loading?: boolean;
+    loadingAnnounced?: JSX.Element;
 }
 
 export default class DeviceEventsPerInterfaceComponent extends React.Component<DeviceEventsDataProps & DeviceEventsDispatchProps & RouteComponentProps, DeviceEventsState> {
-    // tslint:disable-next-line:no-any
-    private timerID: any;
+    private timerID: any; // tslint:disable-line:no-any
     private isComponentMounted: boolean;
     constructor(props: DeviceEventsDataProps & DeviceEventsDispatchProps & RouteComponentProps) {
         super(props);
@@ -77,6 +79,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
             events: [],
             hasMore: false,
             monitoringData: false,
+            showRawEvent: false,
             startTime: new Date(new Date().getTime() - MILLISECONDS_IN_MINUTE), // set start time to one minute ago
             synchronizationStatus: SynchronizationStatus.initialized
         };
@@ -97,10 +100,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
             <LocalizationContextConsumer>
                 {(context: LocalizationContextInterface) => (
                     <div className="device-events" key="device-events">
-                        <CommandBar
-                            className="command"
-                            items={this.createCommandBarItems(context)}
-                        />
+                        {this.renderCommandBar(context)}
                         <Route component={DigitalTwinHeaderContainer} />
                         {telemetrySchema  ?
                             telemetrySchema.length === 0 ?
@@ -108,7 +108,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                                 <>
                                     <TextField
                                         className={'consumer-group-text-field'}
-                                        onRenderLabel={this.renderConsumerGroupLabel}
+                                        onRenderLabel={this.renderConsumerGroupLabel(context)}
                                         label={context.t(ResourceKeys.deviceEvents.consumerGroups.label)}
                                         ariaLabel={context.t(ResourceKeys.deviceEvents.consumerGroups.label)}
                                         underlined={true}
@@ -116,6 +116,7 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                                         disabled={this.state.monitoringData}
                                         onChange={this.consumerGroupChange}
                                     />
+                                    {this.renderRawTelemetryToggle(context)}
                                     {this.renderInfiniteScroll(context)}
                                 </>
                             : <InterfaceNotFoundMessageBoxContainer/>
@@ -127,13 +128,18 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
         );
     }
 
-    private createCommandBarItems = (context: LocalizationContextInterface): ICommandBarItemProps[] => {
-        return [
-            this.createStartMonitoringCommandItem(context),
-            this.createRefreshCommandItem(context),
-            this.createClearCommandItem(context),
-            this.createCloseCommandItem(context)
-        ];
+    private renderCommandBar = (context: LocalizationContextInterface) => {
+        return (
+            <CommandBar
+                className="command"
+                items={[
+                    this.createStartMonitoringCommandItem(context),
+                    this.createRefreshCommandItem(context),
+                    this.createClearCommandItem(context)
+                ]}
+                farItems={[this.createCloseCommandItem(context)]}
+            />
+        );
     }
 
     private createClearCommandItem = (context: LocalizationContextInterface): ICommandBarItemProps => {
@@ -190,8 +196,8 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
     private createCloseCommandItem = (context: LocalizationContextInterface): ICommandBarItemProps => {
         return {
             ariaLabel: context.t(ResourceKeys.deviceEvents.command.close),
-            iconProps: {iconName: CLOSE},
-            key: CLOSE,
+            iconProps: {iconName: NAVIGATE_BACK},
+            key: NAVIGATE_BACK,
             name: context.t(ResourceKeys.deviceEvents.command.close),
             onClick: this.handleClose
         };
@@ -205,19 +211,35 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
         }
     }
 
-    private renderConsumerGroupLabel = (props: ITextFieldProps) => {
+    private renderConsumerGroupLabel = (context: LocalizationContextInterface) => (props: ITextFieldProps) => {
         return (
-            <LocalizationContextConsumer>
-                {(context: LocalizationContextInterface) => (
-                    <LabelWithTooltip
-                        className={'consumer-group-label'}
-                        tooltipText={context.t(ResourceKeys.deviceEvents.consumerGroups.tooltip)}
-                    >
-                        {props.label}
-                    </LabelWithTooltip>
-                )}
-            </LocalizationContextConsumer>
+            <LabelWithTooltip
+                className={'consumer-group-label'}
+                tooltipText={context.t(ResourceKeys.deviceEvents.consumerGroups.tooltip)}
+            >
+                {props.label}
+            </LabelWithTooltip>
         );
+    }
+
+    private renderRawTelemetryToggle = (context: LocalizationContextInterface) => {
+        return (
+            <Toggle
+                className="toggle-button"
+                checked={this.state.showRawEvent}
+                ariaLabel={context.t(ResourceKeys.deviceEvents.toggle.label)}
+                label={context.t(ResourceKeys.deviceEvents.toggle.label)}
+                onText={context.t(ResourceKeys.deviceEvents.toggle.on)}
+                offText={context.t(ResourceKeys.deviceEvents.toggle.off)}
+                onChange={this.changeToggle}
+            />
+        );
+    }
+
+    private readonly changeToggle = () => {
+        this.setState({
+            showRawEvent: !this.state.showRawEvent
+        });
     }
 
     private stopMonitoring = () => {
@@ -268,9 +290,28 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                 isReverse={true}
             >
             <section className="list-content">
-                {this.renderEvents(context)}
+                {this.state.showRawEvent ? this.renderRawEvents() : this.renderEvents(context)}
             </section>
             </InfiniteScroll>
+        );
+    }
+
+    private readonly renderRawEvents = () => {
+        const { events } = this.state;
+
+        return (
+            <div className="scrollable-pnp-telemetry">
+            {
+                events && events.map((event: Message, index) => {
+                    return (
+                        <article key={index} className="device-events-content">
+                            {<h5>{parseDateTimeString(event.enqueuedTime)}:</h5>}
+                            <pre>{JSON.stringify(event, undefined, JSON_SPACES)}</pre>
+                        </article>
+                    );
+                })
+            }
+            </div>
         );
     }
 
@@ -278,72 +319,100 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
         const { events } = this.state;
 
         return (
-            <div className="scrollable-sm">
-                <div className="pnp-detail-list ms-Grid">
-                    <div className="list-header list-header-uncollapsible ms-Grid-row">
-                        <span className="ms-Grid-col ms-sm2">{context.t(ResourceKeys.deviceEvents.columns.timestamp)}</span>
-                        <span className="ms-Grid-col ms-sm2">{context.t(ResourceKeys.deviceEvents.columns.displayName)}</span>
-                        <span className="ms-Grid-col ms-sm2">{context.t(ResourceKeys.deviceEvents.columns.schema)}</span>
-                        <span className="ms-Grid-col ms-sm2">{context.t(ResourceKeys.deviceEvents.columns.unit)}</span>
-                        <span className="ms-Grid-col ms-sm4">{context.t(ResourceKeys.deviceEvents.columns.value)}</span>
-                    </div>
-                </div>
+            <div className="scrollable-pnp-telemetry">
                 {
                     events && events.length > 0 &&
-                    <section role="feed">
-                    {
-                        events.map((event: Message, index) => {
-                            return event.systemProperties ? this.renderSingleEvents(event, index, context) : this.renderCombinedEvents(event, index, context);
-                        })
-                    }
-                    </section>
+                    <>
+                        <div className="pnp-detail-list ms-Grid">
+                            <div className="list-header list-header-uncollapsible ms-Grid-row">
+                                <span className="ms-Grid-col ms-sm2">{context.t(ResourceKeys.deviceEvents.columns.timestamp)}</span>
+                                <span className="ms-Grid-col ms-sm2">{context.t(ResourceKeys.deviceEvents.columns.displayName)}</span>
+                                <span className="ms-Grid-col ms-sm2">{context.t(ResourceKeys.deviceEvents.columns.schema)}</span>
+                                <span className="ms-Grid-col ms-sm2">{context.t(ResourceKeys.deviceEvents.columns.unit)}</span>
+                                <span className="ms-Grid-col ms-sm4">{context.t(ResourceKeys.deviceEvents.columns.value)}</span>
+                            </div>
+                        </div>
+                        <section role="feed">
+                        {
+                            events.map((event: Message, index) => {
+                                return !event.systemProperties ? this.renderEventsWithNoSystemProperties(event, index, context) :
+                                    event.systemProperties[TELEMETRY_SCHEMA_PROP] ?
+                                        this.renderEventsWithSchemaProperty(event, index, context) :
+                                        this.renderEventsWithNoSchemaProperty(event, index, context);
+                            })
+                        }
+                        </section>
+                    </>
                 }
             </div>
         );
     }
 
-    private readonly renderSingleEvents = (event: Message, index: number, context: LocalizationContextInterface) => {
-        const matchingSchema = this.props.telemetrySchema.filter(schema => schema.telemetryModelDefinition.name ===
-            event.systemProperties[TELEMETRY_SCHEMA_PROP]);
-        const telemetryModelDefinition =  matchingSchema && matchingSchema.length !== 0 && matchingSchema[0].telemetryModelDefinition;
-        const parsedSchema = matchingSchema && matchingSchema.length !== 0 && matchingSchema[0].parsedSchema;
+    private readonly renderEventsWithSchemaProperty = (event: Message, index: number, context: LocalizationContextInterface) => {
+        const { telemetryModelDefinition, parsedSchema } = this.getModelDefinitionAndSchema(event.systemProperties[TELEMETRY_SCHEMA_PROP]);
 
         return (
             <article className="list-item" role="article" key={index}>
                 <section className="item-summary">
                     <ErrorBoundary error={context.t(ResourceKeys.errorBoundary.text)}>
-                        {this.renderTimestamp(event, context)}
+                        {this.renderTimestamp(event.enqueuedTime, context)}
                         {this.renderEventName(context, telemetryModelDefinition)}
                         {this.renderEventSchema(context, telemetryModelDefinition)}
                         {this.renderEventUnit(context, telemetryModelDefinition)}
-                        {this.renderMessageBody(event, context, parsedSchema)}
+                        {this.renderMessageBodyWithSchema(event.body, context, parsedSchema, event.systemProperties[TELEMETRY_SCHEMA_PROP])}
                     </ErrorBoundary>
                 </section>
             </article>
         );
     }
 
-    private readonly renderCombinedEvents = (event: Message, index: number, context: LocalizationContextInterface) => {
+    private readonly renderEventsWithNoSchemaProperty = (event: Message, index: number, context: LocalizationContextInterface) => {
+        const telemetryKeys = Object.keys(event.body);
+        if (telemetryKeys && telemetryKeys.length !== 0) {
+            return telemetryKeys.map((key, keyIndex) => {
+                const { telemetryModelDefinition, parsedSchema } = this.getModelDefinitionAndSchema(key);
+                const partialEventBody: any = {}; // tslint:disable-line:no-any
+                partialEventBody[key] = event.body[key];
+                const isNotItemLast = keyIndex !== telemetryKeys.length - 1;
+
+                return (
+                    <article className="list-item" role="article" key={key + index}>
+                        <section className={`item-summary ${isNotItemLast && 'item-summary-partial'}`}>
+                            <ErrorBoundary error={context.t(ResourceKeys.errorBoundary.text)}>
+                                {this.renderTimestamp(keyIndex === 0 ? event.enqueuedTime : null, context)}
+                                {this.renderEventName(context, telemetryModelDefinition)}
+                                {this.renderEventSchema(context, telemetryModelDefinition)}
+                                {this.renderEventUnit(context, telemetryModelDefinition)}
+                                {this.renderMessageBodyWithSchema(partialEventBody, context, parsedSchema, key)}
+                            </ErrorBoundary>
+                        </section>
+                    </article>
+                );
+            });
+        }
+    }
+
+    private readonly renderEventsWithNoSystemProperties = (event: Message, index: number, context: LocalizationContextInterface) => {
         return (
             <article className="list-item" role="article" key={index}>
                 <section className="item-summary">
-                <ErrorBoundary error={context.t(ResourceKeys.errorBoundary.text)}>
-                        {this.renderTimestamp(event, context)}
+                    <ErrorBoundary error={context.t(ResourceKeys.errorBoundary.text)}>
+                        {this.renderTimestamp(event.enqueuedTime, context)}
                         {this.renderEventName(context)}
                         {this.renderEventSchema(context)}
                         {this.renderEventUnit(context)}
-                        {this.renderMessageBody(event, context)}
+                        {this.renderMessageBodyWithNoSchema(event.body, context)}
                     </ErrorBoundary>
                 </section>
             </article>
         );
     }
 
-    private readonly renderTimestamp = (event: Message, context: LocalizationContextInterface) => {
+    private readonly renderTimestamp = (enqueuedTime: string, context: LocalizationContextInterface) => {
         return(
             <div className="ms-Grid-col ms-sm2">
                 <Label aria-label={context.t(ResourceKeys.deviceEvents.columns.timestamp)}>
-                    {parseDateTimeString(event.enqueuedTime)}
+                    {enqueuedTime && parseDateTimeString(enqueuedTime)}
                 </Label>
             </div>
         );
@@ -386,50 +455,57 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
         );
     }
 
+    private readonly renderMessageBodyWithSchema = (eventBody: any, context: LocalizationContextInterface, schema: ParsedJsonSchema, key: string) => { // tslint:disable-line:no-any
+        if (key && !schema) { // DTDL doesn't contain corresponding key
+            const labelContent = context.t(ResourceKeys.deviceEvents.columns.validation.key.isNotSpecified, { key });
+            return(
+                <div className="column-value-text ms-Grid-col ms-sm4">
+                    <span aria-label={context.t(ResourceKeys.deviceEvents.columns.value)}>
+                        {JSON.stringify(eventBody, undefined, JSON_SPACES)}
+                        <Label className="value-validation-error">
+                            {labelContent}
+                        </Label>
+                    </span>
+                </div>
+            );
+        }
+
+        if (Object.keys(eventBody) && Object.keys(eventBody)[0] !== key) { // key in event body doesn't match property name
+            const labelContent = context.t(ResourceKeys.deviceEvents.columns.validation.key.doesNotMatch, {
+                expectedKey: key,
+                receivedKey: Object.keys(eventBody)[0]
+            });
+            return(
+                <div className="column-value-text ms-Grid-col ms-sm4">
+                    <span aria-label={context.t(ResourceKeys.deviceEvents.columns.value)}>
+                        {JSON.stringify(eventBody, undefined, JSON_SPACES)}
+                        <Label className="value-validation-error">
+                            {labelContent}
+                        </Label>
+                    </span>
+                </div>
+            );
+        }
+
+        return this.renderMessageBodyWithValueValidation(eventBody, context, schema, key);
+    }
+
     // tslint:disable-next-line:cyclomatic-complexity
-    private readonly renderMessageBody = (event: Message, context: LocalizationContextInterface, schema?: ParsedJsonSchema) => {
-        const key = event.systemProperties ? event.systemProperties[TELEMETRY_SCHEMA_PROP] : null;
+    private readonly renderMessageBodyWithValueValidation = (eventBody: any, context: LocalizationContextInterface, schema: ParsedJsonSchema, key: string) => { // tslint:disable-line:no-any
         const validator = new Validator();
-
-        if (!key) {
-            return(
-                <div className="column-value-text ms-Grid-col ms-sm4">
-                    <Label aria-label={context.t(ResourceKeys.deviceEvents.columns.value)}>
-                        {JSON.stringify(event.body, undefined, JSON_SPACES)}
-                    </Label>
-                </div>
-            );
-        }
-
-        if (Object.keys(event.body) && Object.keys(event.body)[0] !== key) { // validate telemetry's property name
-            return(
-                <div className="column-value-text ms-Grid-col ms-sm4">
-                    <Label aria-label={context.t(ResourceKeys.deviceEvents.columns.value)}>
-                        {JSON.stringify(event.body, undefined, JSON_SPACES)}
-                        <section className="value-validation-error" aria-label={context.t(ResourceKeys.deviceEvents.columns.error.key.label)}>
-                            <span>{context.t(ResourceKeys.deviceEvents.columns.error.key.label)}</span>
-                            <ul>
-                                <li key={key}>{context.t(ResourceKeys.deviceEvents.columns.error.key.doesNotMatch, {keyName: key})}</li>
-                            </ul>
-                        </section>
-                    </Label>
-                </div>
-            );
-        }
-
         let result: ValidatorResult;
         if (schema && getNumberOfMapsInSchema(schema) <= 0) {
             // only validate telemetry if schema doesn't contain map type
-            result = validator.validate(event.body[key], schema);  // validate telemetry's property value
+            result = validator.validate(eventBody[key], schema);
         }
 
         return(
-            <div className="column-value-text ms-Grid-col s4">
+            <div className="column-value-text ms-Grid-col ms-sm4">
                 <Label aria-label={context.t(ResourceKeys.deviceEvents.columns.value)}>
-                    {JSON.stringify(event.body, undefined, JSON_SPACES)}
+                    {JSON.stringify(eventBody, undefined, JSON_SPACES)}
                     {result && result.errors && result.errors.length !== 0 &&
-                        <section className="value-validation-error" aria-label={context.t(ResourceKeys.deviceEvents.columns.error.value.label)}>
-                            <span>{context.t(ResourceKeys.deviceEvents.columns.error.value.label)}</span>
+                        <section className="value-validation-error" aria-label={context.t(ResourceKeys.deviceEvents.columns.validation.value.label)}>
+                            <span>{context.t(ResourceKeys.deviceEvents.columns.validation.value.label)}</span>
                             <ul>
                             {result.errors.map((element, index) =>
                                 <li key={index}>{element.message}</li>
@@ -437,6 +513,16 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                             </ul>
                         </section>
                     }
+                </Label>
+            </div>
+        );
+    }
+
+    private readonly renderMessageBodyWithNoSchema = (eventBody: any, context: LocalizationContextInterface) => { // tslint:disable-line:no-any
+        return(
+            <div className="column-value-text ms-Grid-col ms-sm4">
+                <Label aria-label={context.t(ResourceKeys.deviceEvents.columns.value)}>
+                    {JSON.stringify(eventBody, undefined, JSON_SPACES)}
                 </Label>
             </div>
         );
@@ -515,5 +601,15 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
         const path = this.props.match.url.replace(/\/digitalTwinsDetail\/events\/.*/, ``);
         const deviceId = getDeviceIdFromQueryString(this.props);
         this.props.history.push(`${path}/?${ROUTE_PARAMS.DEVICE_ID}=${encodeURIComponent(deviceId)}`);
+    }
+
+    private readonly getModelDefinitionAndSchema = (key: string): TelemetrySchema => {
+        const matchingSchema = this.props.telemetrySchema.filter(schema => schema.telemetryModelDefinition.name === key);
+        const telemetryModelDefinition =  matchingSchema && matchingSchema.length !== 0 && matchingSchema[0].telemetryModelDefinition;
+        const parsedSchema = matchingSchema && matchingSchema.length !== 0 && matchingSchema[0].parsedSchema;
+        return {
+            parsedSchema,
+            telemetryModelDefinition
+        };
     }
 }

--- a/src/app/devices/deviceContent/components/deviceInterfaces/__snapshots__/deviceInterfaces.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceInterfaces/__snapshots__/deviceInterfaces.spec.tsx.snap
@@ -6,6 +6,19 @@ exports[`components/devices/deviceInterfaces shows interface information when st
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceInterfaces.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceInterfaces.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -15,15 +28,6 @@ exports[`components/devices/deviceInterfaces shows interface information when st
           },
           "key": "Refresh",
           "name": "deviceProperties.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceInterfaces.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceInterfaces.command.close",
           "onClick": [Function],
         },
       ]
@@ -40,6 +44,19 @@ exports[`components/devices/deviceInterfaces shows interface information when st
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceInterfaces.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceInterfaces.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -49,15 +66,6 @@ exports[`components/devices/deviceInterfaces shows interface information when st
           },
           "key": "Refresh",
           "name": "deviceProperties.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceInterfaces.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceInterfaces.command.close",
           "onClick": [Function],
         },
       ]
@@ -136,6 +144,19 @@ exports[`components/devices/deviceInterfaces shows interface information when st
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceInterfaces.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceInterfaces.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -145,15 +166,6 @@ exports[`components/devices/deviceInterfaces shows interface information when st
           },
           "key": "Refresh",
           "name": "deviceProperties.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceInterfaces.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceInterfaces.command.close",
           "onClick": [Function],
         },
       ]
@@ -232,6 +244,19 @@ exports[`components/devices/deviceInterfaces shows interface information when st
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceInterfaces.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceInterfaces.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -241,15 +266,6 @@ exports[`components/devices/deviceInterfaces shows interface information when st
           },
           "key": "Refresh",
           "name": "deviceProperties.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceInterfaces.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceInterfaces.command.close",
           "onClick": [Function],
         },
       ]
@@ -328,6 +344,19 @@ exports[`components/devices/deviceInterfaces shows interface information when st
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceInterfaces.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceInterfaces.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -337,15 +366,6 @@ exports[`components/devices/deviceInterfaces shows interface information when st
           },
           "key": "Refresh",
           "name": "deviceProperties.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceInterfaces.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceInterfaces.command.close",
           "onClick": [Function],
         },
       ]

--- a/src/app/devices/deviceContent/components/deviceInterfaces/deviceInterfaces.tsx
+++ b/src/app/devices/deviceContent/components/deviceInterfaces/deviceInterfaces.tsx
@@ -15,7 +15,7 @@ import { ModelDefinitionWithSource } from '../../../../api/models/modelDefinitio
 import { SynchronizationWrapper } from '../../../../api/models/synchronizationWrapper';
 import { REPOSITORY_LOCATION_TYPE } from '../../../../constants/repositoryLocationTypes';
 import InterfaceNotFoundMessageBoxContainer from '../shared/interfaceNotFoundMessageBarContainer';
-import { REFRESH, CLOSE } from '../../../../constants/iconNames';
+import { REFRESH, CLOSE, NAVIGATE_BACK } from '../../../../constants/iconNames';
 import ErrorBoundary from '../../../errorBoundary';
 import { getLocalizedData } from '../../../../api/dataTransforms/modelDefinitionTransform';
 import { ThemeContextInterface, ThemeContextConsumer } from '../../../../shared/contexts/themeContext';
@@ -59,11 +59,13 @@ export default class DeviceInterfaces extends React.Component<DeviceInterfacePro
                                     key: REFRESH,
                                     name: context.t(ResourceKeys.deviceProperties.command.refresh),
                                     onClick: this.handleRefresh
-                                },
+                                }
+                            ]}
+                            farItems={[
                                 {
                                     ariaLabel: context.t(ResourceKeys.deviceInterfaces.command.close),
-                                    iconProps: {iconName: CLOSE},
-                                    key: CLOSE,
+                                    iconProps: {iconName: NAVIGATE_BACK},
+                                    key: NAVIGATE_BACK,
                                     name: context.t(ResourceKeys.deviceInterfaces.command.close),
                                     onClick: this.handleClose
                                 }

--- a/src/app/devices/deviceContent/components/deviceProperties/__snapshots__/deviceProperties.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceProperties/__snapshots__/deviceProperties.spec.tsx.snap
@@ -4,6 +4,19 @@ exports[`components/devices/deviceProperties matches snapshot while interface ca
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceProperties.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceProperties.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -13,15 +26,6 @@ exports[`components/devices/deviceProperties matches snapshot while interface ca
           },
           "key": "Refresh",
           "name": "deviceProperties.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceProperties.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceProperties.command.close",
           "onClick": [Function],
         },
       ]
@@ -42,6 +46,19 @@ exports[`components/devices/deviceProperties matches snapshot with one twinWithS
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceProperties.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceProperties.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -51,15 +68,6 @@ exports[`components/devices/deviceProperties matches snapshot with one twinWithS
           },
           "key": "Refresh",
           "name": "deviceProperties.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceProperties.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceProperties.command.close",
           "onClick": [Function],
         },
       ]

--- a/src/app/devices/deviceContent/components/deviceProperties/__snapshots__/devicePropertiesPerInterface.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceProperties/__snapshots__/devicePropertiesPerInterface.spec.tsx.snap
@@ -4,6 +4,19 @@ exports[`components/devices/deviceSettings matches snapshot while interface cann
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceSettings.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceSettings.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -13,15 +26,6 @@ exports[`components/devices/deviceSettings matches snapshot while interface cann
           },
           "key": "Refresh",
           "name": "deviceSettings.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceSettings.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceSettings.command.close",
           "onClick": [Function],
         },
       ]
@@ -38,6 +42,19 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceSettings.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceSettings.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -47,15 +64,6 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
           },
           "key": "Refresh",
           "name": "deviceSettings.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceSettings.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceSettings.command.close",
           "onClick": [Function],
         },
       ]

--- a/src/app/devices/deviceContent/components/deviceProperties/deviceProperties.tsx
+++ b/src/app/devices/deviceContent/components/deviceProperties/deviceProperties.tsx
@@ -11,7 +11,7 @@ import { ResourceKeys } from '../../../../../localization/resourceKeys';
 import { getInterfaceIdFromQueryString, getDeviceIdFromQueryString, getComponentNameFromQueryString } from '../../../../shared/utils/queryStringHelper';
 import DevicePropertiesPerInterface, { TwinWithSchema } from './devicePropertiesPerInterface';
 import InterfaceNotFoundMessageBoxContainer from '../shared/interfaceNotFoundMessageBarContainer';
-import { REFRESH, CLOSE } from '../../../../constants/iconNames';
+import { REFRESH, NAVIGATE_BACK } from '../../../../constants/iconNames';
 import MultiLineShimmer from '../../../../shared/components/multiLineShimmer';
 import { DigitalTwinHeaderContainer } from '../digitalTwin/digitalTwinHeaderView';
 import { ROUTE_PARAMS } from '../../../../constants/routes';
@@ -50,11 +50,13 @@ export default class DeviceProperties
                                         key: REFRESH,
                                         name: context.t(ResourceKeys.deviceProperties.command.refresh),
                                         onClick: this.handleRefresh
-                                    },
+                                    }
+                                ]}
+                                farItems={[
                                     {
                                         ariaLabel: context.t(ResourceKeys.deviceProperties.command.close),
-                                        iconProps: {iconName: CLOSE},
-                                        key: CLOSE,
+                                        iconProps: {iconName: NAVIGATE_BACK},
+                                        key: NAVIGATE_BACK,
                                         name: context.t(ResourceKeys.deviceProperties.command.close),
                                         onClick: this.handleClose
                                     }

--- a/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettings.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettings.spec.tsx.snap
@@ -4,6 +4,19 @@ exports[`components/devices/deviceSettings matches snapshot while interface cann
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceSettings.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceSettings.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -13,15 +26,6 @@ exports[`components/devices/deviceSettings matches snapshot while interface cann
           },
           "key": "Refresh",
           "name": "deviceSettings.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceSettings.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceSettings.command.close",
           "onClick": [Function],
         },
       ]
@@ -38,6 +42,19 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceSettings.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceSettings.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -47,15 +64,6 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
           },
           "key": "Refresh",
           "name": "deviceSettings.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceSettings.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceSettings.command.close",
           "onClick": [Function],
         },
       ]

--- a/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettingsPerInterface.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettingsPerInterface.spec.tsx.snap
@@ -4,6 +4,19 @@ exports[`components/devices/deviceSettings matches snapshot while interface cann
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceSettings.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceSettings.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -13,15 +26,6 @@ exports[`components/devices/deviceSettings matches snapshot while interface cann
           },
           "key": "Refresh",
           "name": "deviceSettings.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceSettings.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceSettings.command.close",
           "onClick": [Function],
         },
       ]
@@ -38,6 +42,19 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "deviceSettings.command.close",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "deviceSettings.command.close",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -47,15 +64,6 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
           },
           "key": "Refresh",
           "name": "deviceSettings.command.refresh",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceSettings.command.close",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "deviceSettings.command.close",
           "onClick": [Function],
         },
       ]

--- a/src/app/devices/deviceContent/components/deviceSettings/deviceSettings.tsx
+++ b/src/app/devices/deviceContent/components/deviceSettings/deviceSettings.tsx
@@ -13,7 +13,7 @@ import { ResourceKeys } from '../../../../../localization/resourceKeys';
 import { getDeviceIdFromQueryString, getInterfaceIdFromQueryString, getComponentNameFromQueryString } from '../../../../shared/utils/queryStringHelper';
 import { PatchDigitalTwinInterfacePropertiesActionParameters } from '../../actions';
 import InterfaceNotFoundMessageBoxContainer from '../shared/interfaceNotFoundMessageBarContainer';
-import { REFRESH, CLOSE } from '../../../../constants/iconNames';
+import { REFRESH, NAVIGATE_BACK } from '../../../../constants/iconNames';
 import MultiLineShimmer from '../../../../shared/components/multiLineShimmer';
 import { DigitalTwinHeaderContainer } from '../digitalTwin/digitalTwinHeaderView';
 import { ROUTE_PARAMS } from '../../../../constants/routes';
@@ -60,11 +60,13 @@ export default class DeviceSettings
                                         key: REFRESH,
                                         name: context.t(ResourceKeys.deviceSettings.command.refresh),
                                         onClick: this.handleRefresh
-                                    },
+                                    }
+                                ]}
+                                farItems={[
                                     {
                                         ariaLabel: context.t(ResourceKeys.deviceSettings.command.close),
-                                        iconProps: {iconName: CLOSE},
-                                        key: CLOSE,
+                                        iconProps: {iconName: NAVIGATE_BACK},
+                                        key: NAVIGATE_BACK,
                                         name: context.t(ResourceKeys.deviceSettings.command.close),
                                         onClick: this.handleClose
                                     }

--- a/src/app/devices/deviceContent/components/digitalTwin/digitalTwinInterfaces.tsx
+++ b/src/app/devices/deviceContent/components/digitalTwin/digitalTwinInterfaces.tsx
@@ -137,7 +137,7 @@ export const DigitalTwinInterfacesContainer: React.FC<DigitalTwinInterfacesConta
     const viewProps = {
         dcm: useSelector(getDigitalTwinDcmNameSelector),
         isLoading: digitalTwinInterfacesWrapper &&
-        digitalTwinInterfacesWrapper.synchronizationStatus === SynchronizationStatus.working,
+            digitalTwinInterfacesWrapper.synchronizationStatus === SynchronizationStatus.working,
         nameToIds: useSelector(getDigitalTwinComponentNameAndIdsSelector),
         refresh: (deviceId: string) => dispatch(getDigitalTwinInterfacePropertiesAction.started(deviceId)),
         ...props

--- a/src/app/devices/deviceContent/selectors.spec.ts
+++ b/src/app/devices/deviceContent/selectors.spec.ts
@@ -10,6 +10,8 @@ import {
     getDigitalTwinInterfaceIdsSelector,
     getIsDevicePnpSelector,
     getComponentNameSelector,
+    getDigitalTwinDcmNameSelector,
+    getDigitalTwinComponentNameAndIdsSelector
 } from './selectors';
 import { getInitialState } from './../../api/shared/testHelper';
 
@@ -69,5 +71,19 @@ describe('getDigitalTwinInterfacePropertiesSelector', () => {
 
     it('returns componentName', () => {
         expect(getComponentNameSelector(state)).toEqual('environmentalsensor');
+    });
+
+    it('returns dcm id', () => {
+        expect(getDigitalTwinDcmNameSelector(state)).toEqual('urn:contoso:com:dcm:2');
+    });
+
+    it('returns component names and interface ids', () => {
+        /* tslint:disable */
+        expect(getDigitalTwinComponentNameAndIdsSelector(state)).toEqual({
+            "environmentalsensor": "urn:contoso:com:environmentalsensor:2",
+            "urn_azureiot_ModelDiscovery_ModelInformation": "urn:azureiot:ModelDiscovery:ModelInformation:1",
+            "urn_azureiot_ModelDiscovery_DigitalTwin": "urn:azureiot:ModelDiscovery:DigitalTwin:1"
+        });
+        /* tslint:enable */
     });
 });

--- a/src/app/devices/module/components/moduleIdentity/__snapshots__/moduleIdentityDetail.spec.tsx.snap
+++ b/src/app/devices/module/components/moduleIdentity/__snapshots__/moduleIdentityDetail.spec.tsx.snap
@@ -4,6 +4,19 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "moduleIdentity.detail.command.back",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "moduleIdentity.detail.command.back",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -24,15 +37,6 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
           },
           "key": "Delete",
           "name": "moduleIdentity.detail.command.delete",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "moduleIdentity.detail.command.back",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "moduleIdentity.detail.command.back",
           "onClick": [Function],
         },
       ]
@@ -65,6 +69,19 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "moduleIdentity.detail.command.back",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "moduleIdentity.detail.command.back",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -85,15 +102,6 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
           },
           "key": "Delete",
           "name": "moduleIdentity.detail.command.delete",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "moduleIdentity.detail.command.back",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "moduleIdentity.detail.command.back",
           "onClick": [Function],
         },
       ]
@@ -156,6 +164,19 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "moduleIdentity.detail.command.back",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "moduleIdentity.detail.command.back",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -176,15 +197,6 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
           },
           "key": "Delete",
           "name": "moduleIdentity.detail.command.delete",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "moduleIdentity.detail.command.back",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "moduleIdentity.detail.command.back",
           "onClick": [Function],
         },
       ]
@@ -236,6 +248,19 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "moduleIdentity.detail.command.back",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "moduleIdentity.detail.command.back",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -256,15 +281,6 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
           },
           "key": "Delete",
           "name": "moduleIdentity.detail.command.delete",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "moduleIdentity.detail.command.back",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "moduleIdentity.detail.command.back",
           "onClick": [Function],
         },
       ]
@@ -318,6 +334,19 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "moduleIdentity.detail.command.back",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "moduleIdentity.detail.command.back",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -338,15 +367,6 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot after
           },
           "key": "Delete",
           "name": "moduleIdentity.detail.command.delete",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "moduleIdentity.detail.command.back",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "moduleIdentity.detail.command.back",
           "onClick": [Function],
         },
       ]
@@ -398,6 +418,19 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot while
 <Fragment>
   <StyledCommandBarBase
     className="command"
+    farItems={
+      Array [
+        Object {
+          "ariaLabel": "moduleIdentity.detail.command.back",
+          "iconProps": Object {
+            "iconName": "NavigateBack",
+          },
+          "key": "NavigateBack",
+          "name": "moduleIdentity.detail.command.back",
+          "onClick": [Function],
+        },
+      ]
+    }
     items={
       Array [
         Object {
@@ -418,15 +451,6 @@ exports[`devices/components/moduleIdentityRoutes snapshot matches snapshot while
           },
           "key": "Delete",
           "name": "moduleIdentity.detail.command.delete",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "moduleIdentity.detail.command.back",
-          "iconProps": Object {
-            "iconName": "ChromeClose",
-          },
-          "key": "ChromeClose",
-          "name": "moduleIdentity.detail.command.back",
           "onClick": [Function],
         },
       ]

--- a/src/app/devices/module/components/moduleIdentity/moduleIdentityDetail.tsx
+++ b/src/app/devices/module/components/moduleIdentity/moduleIdentityDetail.tsx
@@ -13,7 +13,7 @@ import { LocalizationContextConsumer, LocalizationContextInterface } from '../..
 import { ThemeContextConsumer, ThemeContextInterface } from '../../../../shared/contexts/themeContext';
 import { ResourceKeys } from '../../../../../localization/resourceKeys';
 import { getDeviceIdFromQueryString, getModuleIdentityIdFromQueryString } from '../../../../shared/utils/queryStringHelper';
-import { CLOSE, REFRESH, REMOVE } from '../../../../constants/iconNames';
+import { REFRESH, REMOVE, NAVIGATE_BACK } from '../../../../constants/iconNames';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
 import { ROUTE_PARTS, ROUTE_PARAMS } from '../../../../constants/routes';
 import MaskedCopyableTextFieldContainer from '../../../../shared/components/maskedCopyableTextFieldContainer';
@@ -145,14 +145,16 @@ export default class ModuleIdentityDetailComponent
                         key: REMOVE,
                         name: context.t(ResourceKeys.moduleIdentity.detail.command.delete),
                         onClick: this.deleteConfirmation
-                    },
+                    }
+                ]}
+                farItems={[
                     {
                         ariaLabel: context.t(ResourceKeys.moduleIdentity.detail.command.back),
-                        iconProps: {iconName: CLOSE},
-                        key: CLOSE,
+                        iconProps: {iconName: NAVIGATE_BACK},
+                        key: NAVIGATE_BACK,
                         name: context.t(ResourceKeys.moduleIdentity.detail.command.back),
                         onClick: this.navigateToModuleList
-                    },
+                    }
                 ]}
             />
         );

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -380,7 +380,7 @@
         "command" : {
             "refresh": "Refresh",
             "openReportedValuePanel": "Click to view value",
-            "close": "Close"
+            "close": "Back"
         },
         "headerText": "Non-writable properties",
         "noProperties": "ComponentName {{componentName}} contains no non-writable property definitions",
@@ -406,7 +406,7 @@
             "expand": "Expand",
             "collapseAll": "Collapse all",
             "collapse": "Collapse",
-            "close": "Close"
+            "close": "Back"
         },
         "headerText": "Writable properties",
         "noSettings": "ComponentName {{componentName}} contains no writable property definitions",
@@ -442,7 +442,7 @@
             "expand": "Expand",
             "collapseAll": "Collapse all",
             "collapse": "Collapse",
-            "close": "Close"
+            "close": "Back"
         },
         "headerText": "Commands",
         "noCommands": "ComponentName {{componentName}} contains no command definitions",
@@ -459,7 +459,7 @@
         "command" : {
             "refresh": "Refresh",
             "configure": "Configure",
-            "close": "Close"
+            "close": "Back"
         },
         "columns": {
             "id": "Interface Id",
@@ -480,7 +480,7 @@
             "start": "Start",
             "stop": "Stop",
             "fetch": "Retrieve events",
-            "close": "Close"
+            "close": "Back"
         },
         "consumerGroups": {
             "label": "Consumer Group",
@@ -507,15 +507,20 @@
             "schema": "Schema",
             "unit": "Unit",
             "value": "Value",
-            "error": {
+            "validation": {
                 "key": {
-                    "label": "key does not match schema",
-                    "doesNotMatch": "key is not {{keyName}}"
+                    "isNotSpecified": "This telemetry '{{key}}' is not in the model. You may consider modeling it.",
+                    "doesNotMatch": "Key mismatch. Expected key is {{expectedKey}}, but received is {{receivedKey}}"
                 },
                 "value": {
                     "label": "value does not match schema"
                 }
             }
+        },
+        "toggle": {
+            "label": "Show raw telemetry data",
+            "on": "On",
+            "off": "Off"
         }
     },
     "directMethod": {
@@ -647,7 +652,7 @@
         "detail" : {
             "headerText": "Module identity detail",
             "command" : {
-                "back": "Close",
+                "back": "Back",
                 "refresh": "Refresh",
                 "delete": "Delete"
             },

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -180,18 +180,18 @@ export class ResourceKeys {
    public static deviceEvents = {
       columns : {
          displayName : "deviceEvents.columns.displayName",
-         error : {
-            key : {
-               doesNotMatch : "deviceEvents.columns.error.key.doesNotMatch",
-               label : "deviceEvents.columns.error.key.label",
-            },
-            value : {
-               label : "deviceEvents.columns.error.value.label",
-            },
-         },
          schema : "deviceEvents.columns.schema",
          timestamp : "deviceEvents.columns.timestamp",
          unit : "deviceEvents.columns.unit",
+         validation : {
+            key : {
+               doesNotMatch : "deviceEvents.columns.validation.key.doesNotMatch",
+               isNotSpecified : "deviceEvents.columns.validation.key.isNotSpecified",
+            },
+            value : {
+               label : "deviceEvents.columns.validation.value.label",
+            },
+         },
          value : "deviceEvents.columns.value",
       },
       command : {
@@ -221,6 +221,11 @@ export class ResourceKeys {
          placeHolder : "deviceEvents.interfaceDropDown.placeHolder",
       },
       noEvent : "deviceEvents.noEvent",
+      toggle : {
+         label : "deviceEvents.toggle.label",
+         off : "deviceEvents.toggle.off",
+         on : "deviceEvents.toggle.on",
+      },
       tooltip : "deviceEvents.tooltip",
    };
    public static deviceIdentity = {


### PR DESCRIPTION
DeviceEventsPerInterface.ts has been updated to handle following cases:
1. Events has no system property
1. Events has system property
    1. Events has 'iothub-message-schema'in system property
    1. Events has no 'iothub-message-schema'in system property (which could be message explosion scenario), so beaking down event body key by key
        1. key has matching DTDL
        1. key has no matching DTDL

The following screenshot has illustrate the two cases for message explosion

* Enrich exploded message by break the message key by key and compare with DTDL
![image](https://user-images.githubusercontent.com/5489222/74485359-6b7e5800-4e6f-11ea-9374-8a927bb320b0.png)

* User have a way to toggle and see raw data:
![image](https://user-images.githubusercontent.com/5489222/74485373-7507c000-4e6f-11ea-9a0c-1db2085bb1f7.png)

Also moved close button to the right side in device detail pages for navigation per designer's suggestion
