### PR TITLE
Add the missing help link back for hub cs; allow breadcrum to nagivate back to login

### DIFF
--- a/src/app/css/_connectivityPane.scss
+++ b/src/app/css/_connectivityPane.scss
@@ -29,13 +29,6 @@
         padding-right: 50px;
         width: 650px;
 
-        .remember-connection-string {
-            .ms-Checkbox {
-                float: left;
-                padding-top: 7px;
-            }
-        }
-
         .notes {
             padding-top: 10px;
             padding-bottom: 10px;

--- a/src/app/css/_settingsPane.scss
+++ b/src/app/css/_settingsPane.scss
@@ -5,6 +5,10 @@
 @import 'themes';
 
 .settingsPane {
+    .ms-Panel-scrollableContent {
+        overflow-x: hidden;
+    }
+
     header.panel-header {
         h2 {
             height: 28px;
@@ -27,12 +31,7 @@
         line-height: 19px;
         text-decoration-line: underline;
     }
-    .remember-connection-string {
-        .ms-Checkbox {
-            float: left;
-            padding-top: 7px;
-        }
-    }
+
     .location-list {
         .item {
             display: grid;

--- a/src/app/login/components/__snapshots__/connectivityPane.spec.tsx.snap
+++ b/src/app/login/components/__snapshots__/connectivityPane.spec.tsx.snap
@@ -31,6 +31,18 @@ exports[`login/components/connectivityPane matches snapshot 1`] = `
         connectivityPane.notes
       </Text>
     </div>
+    <h3
+      aria-level={1}
+      role="heading"
+    >
+      settings.questions.headerText
+    </h3>
+    <StyledLinkBase
+      href="connectivityPane.connectionStringComboBox.link"
+      target="_blank"
+    >
+      connectivityPane.connectionStringComboBox.linkText
+    </StyledLinkBase>
     <div
       className="connection-button"
     >

--- a/src/app/login/components/connectivityPane.tsx
+++ b/src/app/login/components/connectivityPane.tsx
@@ -2,9 +2,10 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
+import * as React from 'react';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Text } from 'office-ui-fabric-react/lib/Text';
-import * as React from 'react';
+import { Link } from 'office-ui-fabric-react/lib/Link';
 import { RouteComponentProps } from 'react-router-dom';
 import { LocalizationContextConsumer, LocalizationContextInterface } from '../../shared/contexts/localizationContext';
 import { ResourceKeys } from '../../../localization/resourceKeys';
@@ -73,6 +74,15 @@ export default class ConnectivityPane extends React.Component<RouteComponentProp
                                     {context.t(ResourceKeys.connectivityPane.notes)}
                                 </Text>
                             </div>
+
+                            <h3 role="heading" aria-level={1}>{context.t(ResourceKeys.settings.questions.headerText)}</h3>
+                            <Link
+                                href={context.t(ResourceKeys.connectivityPane.connectionStringComboBox.link)}
+                                target="_blank"
+                            >
+                                {context.t(ResourceKeys.connectivityPane.connectionStringComboBox.linkText)}
+                            </Link>
+
                             <div className="connection-button">
                                 <PrimaryButton
                                     onClick={this.onSaveConnectionInfoClick}

--- a/src/app/shared/components/breadcrumb.tsx
+++ b/src/app/shared/components/breadcrumb.tsx
@@ -29,10 +29,10 @@ export const BreadcrumbItem: React.FC<BreadcrumbItemDataProps> = props => {
         const { t } = useLocalizationContext();
         if (route) {
             switch (route) {
-                case ROUTE_PARTS.RESOURCE:
-                    return <></>;
+                case ROUTE_PARTS.RESOURCE: // redirects to login page
+                    return <li className="breadcrumb-item"><NavLink to={'/'}>{'Hubs'}</NavLink></li>;
                 case props.hostName:
-                    return renderTextItem(t(ResourceKeys.breadcrumb.hub, {hubName: getShortHubName()}));
+                    return renderTextItem(getShortHubName());
                 case ROUTE_PARTS.DEVICE_DETAIL:
                     return renderTextItem(getDeviceIdFromQueryString(props));
                 case ROUTE_PARTS.DIGITAL_TWINS:

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -55,11 +55,7 @@
     "settings": {
         "headerText": "Settings",
         "configuration": {
-            "headerText": "App configurations",
-            "connectionString": {
-                "label": "IoT hub connection string",
-                "link": "https://aka.ms/iot-connection-strings"
-            }
+            "headerText": "App configurations"
         },
         "modelDefinitions": {
             "add": "Add module definition source",
@@ -103,7 +99,6 @@
         }
     },
     "breadcrumb": {
-        "hub": "Hub {{hubName}}",
         "devices": "Devices",
         "add": "Create a new identity",
         "identity": "Device identity",
@@ -145,6 +140,8 @@
         "connectionStringComboBox": {
             "ariaLabel": "Select or type an Iot hub connection string",
             "ariaLabelRemove": "Remove connection to host {{hostName}}",
+            "link": "https://aka.ms/iot-connection-strings",
+            "linkText": "Where do I get an IoT hub connection string",
             "item": {
                 "ariaLabel": "Connection to host {{hostName}} with shared access key for {{sharedAccessKeyName}}"
             },

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -14,7 +14,6 @@ export class ResourceKeys {
       commands : "breadcrumb.commands",
       devices : "breadcrumb.devices",
       events : "breadcrumb.events",
-      hub : "breadcrumb.hub",
       identity : "breadcrumb.identity",
       interfaces : "breadcrumb.interfaces",
       methods : "breadcrumb.methods",
@@ -119,6 +118,8 @@ export class ResourceKeys {
             ariaLabel : "connectivityPane.connectionStringComboBox.item.ariaLabel",
          },
          label : "connectivityPane.connectionStringComboBox.label",
+         link : "connectivityPane.connectionStringComboBox.link",
+         linkText : "connectivityPane.connectionStringComboBox.linkText",
          prompt : "connectivityPane.connectionStringComboBox.prompt",
       },
       dropDown : {
@@ -644,10 +645,6 @@ export class ResourceKeys {
    public static settings = {
       cancel : "settings.cancel",
       configuration : {
-         connectionString : {
-            label : "settings.configuration.connectionString.label",
-            link : "settings.configuration.connectionString.link",
-         },
          headerText : "settings.configuration.headerText",
       },
       confirmationMessage : "settings.confirmationMessage",


### PR DESCRIPTION
The link to hub cs text was lost when switched to combo box. Added it back by adding a help.
Enable breadcrum to nagivate users back to login page

![image](https://user-images.githubusercontent.com/5489222/74889829-0f1bac80-5337-11ea-8419-b818db5557da.png)
