### PR TITLE
add server test; bug fix; date-time check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "This project welcomes contributions and suggestions. Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "public/electron.js",
   "build": {

--- a/src/app/api/models/interfaceJsonParserOutput.ts
+++ b/src/app/api/models/interfaceJsonParserOutput.ts
@@ -12,6 +12,7 @@ export interface ParsedJsonSchema {
     enumNames?: string[];
     format?: string;
     items?: any; // tslint:disable-line: no-any
+    pattern?: string;
     properties?: {};
     required?: string[];
     title?: string;

--- a/src/app/azureResource/selectors.spec.ts
+++ b/src/app/azureResource/selectors.spec.ts
@@ -11,7 +11,7 @@ import {
 } from './selectors';
 import { getInitialState } from '../api/shared/testHelper';
 
-describe('getDigitalTwinInterfacePropertiesSelector', () => {
+describe('getAzureResourceSelector', () => {
     const state = getInitialState();
     const hostName = 'testhub.azure-devices.net';
     state.azureResourceState = Record({

--- a/src/app/shared/utils/jsonSchemaAdaptor.spec.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.spec.ts
@@ -82,7 +82,7 @@ describe('parse interface model definition to Json schema', () => {
 
         interfacePropertyDefinition.schema = 'datetime';
         expect(parseInterfacePropertyToJsonSchema(interfacePropertyDefinition).type).toEqual('string');
-        expect(parseInterfacePropertyToJsonSchema(interfacePropertyDefinition).format).toEqual('date-time');
+        expect(parseInterfacePropertyToJsonSchema(interfacePropertyDefinition).pattern).toEqual('^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$');
 
         interfacePropertyDefinition.schema = 'integer';
         expect(parseInterfacePropertyToJsonSchema(interfacePropertyDefinition).type).toEqual('integer');

--- a/src/app/shared/utils/jsonSchemaAdaptor.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.ts
@@ -59,7 +59,7 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
             case 'datetime':
                 return {
                     description: getDescription(property),
-                    format: 'date-time',
+                    pattern: '^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$', // regex for ISO 8601
                     title: property.name,
                     type: 'string',
                 };

--- a/src/server/serverBase.spec.ts
+++ b/src/server/serverBase.spec.ts
@@ -1,0 +1,147 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import 'jest';
+import * as ServerBase from './serverBase';
+
+describe('serverBase', () => {
+    const mockRequest = (bodyData?: any) => { // tslint:disable-line:no-any
+        return { body: bodyData } as any; // tslint:disable-line:no-any
+    };
+
+    const mockResponse = () => {
+        const res = {status: undefined, json: undefined, send: undefined};
+        res.status = jest.fn().mockReturnValue(res);
+        res.send = jest.fn().mockReturnValue(res);
+        res.json = jest.fn().mockReturnValue(res);
+        return res as any;  // tslint:disable-line:no-any
+    };
+
+    context('handleDataPlanePostRequest', () => {
+        it('returns 400 if body is not provided', async () => {
+            const req = mockRequest();
+            const res = mockResponse();
+
+            await ServerBase.handleDataPlanePostRequest(req, res);
+            expect(res.status).toHaveBeenCalledWith(400); // tslint:disable-line:no-magic-numbers
+        });
+    });
+
+    context('handlhandleCloudToDevicePostRequesteDataPlanePostRequest', () => {
+        it('returns 400 if body is not provided', async () => {
+            const req = mockRequest();
+            const res = mockResponse();
+
+            await ServerBase.handleCloudToDevicePostRequest(req, res);
+            expect(res.status).toHaveBeenCalledWith(400); // tslint:disable-line:no-magic-numbers
+        });
+    });
+
+    context('handleEventHubMonitorPostRequest', () => {
+        it('returns 400 if body is not provided', async () => {
+            const req = mockRequest();
+            const res = mockResponse();
+
+            await ServerBase.handleEventHubMonitorPostRequest(req, res);
+            expect(res.status).toHaveBeenCalledWith(400); // tslint:disable-line:no-magic-numbers
+        });
+
+        it('calls eventHubProvider when body is provided', async () => {
+            const req = mockRequest('testBody');
+            const res = mockResponse();
+            const promise = {then: jest.fn()} as any;  // tslint:disable-line:no-any
+            jest.spyOn(ServerBase, 'eventHubProvider').mockReturnValue(promise);
+
+            await ServerBase.handleEventHubMonitorPostRequest(req, res);
+            expect(ServerBase.eventHubProvider).toBeCalled();
+        });
+    });
+
+    context('handleEventHubStopPostRequest ', () => {
+        it('returns 400 if body is not provided', async () => {
+            const req = mockRequest();
+            const res = mockResponse();
+
+            await ServerBase.handleEventHubStopPostRequest (req, res);
+            expect(res.status).toHaveBeenCalledWith(400); // tslint:disable-line:no-magic-numbers
+        });
+
+        it('calls stopClient when body is provided', async () => {
+            const req = mockRequest('testBody');
+            const res = mockResponse();
+            const promise = {then: jest.fn()} as any;  // tslint:disable-line:no-any
+            jest.spyOn(ServerBase, 'stopClient').mockReturnValue(promise);
+
+            await ServerBase.handleEventHubStopPostRequest(req, res);
+            expect(ServerBase.stopClient).toBeCalled();
+        });
+    });
+
+    context('handleModelRepoPostRequest', () => {
+        it('returns 400 if body is not provided', async () => {
+            const req = mockRequest();
+            const res = mockResponse();
+            await ServerBase.handleModelRepoPostRequest(req, res);
+            expect(res.status).toHaveBeenCalledWith(400); // tslint:disable-line:no-magic-numbers
+        });
+
+        it('returns 500 if response is error', async () => {
+            const req = mockRequest('test');
+            const res = mockResponse();
+            await ServerBase.handleModelRepoPostRequest(req, res);
+            expect(res.status).toHaveBeenCalledWith(500); // tslint:disable-line:no-magic-numbers
+        });
+    });
+
+    context('addPropertiesToCloudToDeviceMessage', () => {
+        it('add system properties to message', async () => {
+            const message: any = {properties: new Map()};  // tslint:disable-line:no-any
+            const properties = [
+                {
+                    isSystemProperty: true,
+                    key: 'ack',
+                    value: '1',
+                },
+                {
+                    isSystemProperty: true,
+                    key: 'contentType',
+                    value: 'json',
+                },
+                {
+                    isSystemProperty: true,
+                    key: 'correlationId',
+                    value: '2',
+                },
+                {
+                    isSystemProperty: true,
+                    key: 'contentEncoding',
+                    value: '3',
+                },
+                {
+                    isSystemProperty: true,
+                    key: 'expiryTimeUtc',
+                    value: '4',
+                },
+                {
+                    isSystemProperty: true,
+                    key: 'messageId',
+                    value: '5',
+                },
+                {
+                    isSystemProperty: true,
+                    key: 'lockToken',
+                    value: '6',
+                }
+            ];
+            ServerBase.addPropertiesToCloudToDeviceMessage(message, properties);
+            expect(message.ack).toEqual('1');
+            expect(message.contentType).toEqual('json');
+            expect(message.correlationId).toEqual('2');
+            expect(message.contentEncoding).toEqual('3');
+            expect(message.expiryTimeUtc).toEqual(4); // tslint:disable-line:no-magic-numbers
+            expect(message.messageId).toEqual('5');
+            expect(message.lockToken).toEqual('6');
+        });
+    });
+});


### PR DESCRIPTION
Added server test and fixed a small bug found by the test
Loosen up the date-time check for DTDL. DTDL date time requires ISO 8601 format, where second can be omitted. The default json schema 'data-time' formatter in place requires seconds. Switched to use regex instead.