### PR TITLE
MacOS codesign fix

### DIFF
--- a/pipelines/release-pipeline.yml
+++ b/pipelines/release-pipeline.yml
@@ -154,7 +154,7 @@ stages:
         artifact: Mac
 
       - task: EsrpCodeSigning@1
-        displayName: 'Sign MacOS DMG - Hardened'
+        displayName: 'Sign MacOS DMG'
         inputs:
           ConnectedServiceName: 'Azure IoT Explorer CodeSign'
           FolderPath: '$(Pipeline.Workspace)'
@@ -165,7 +165,7 @@ stages:
                 {
                   "KeyCode" : "CP-401337-Apple",
                   "OperationCode" : "MacAppDeveloperSign",
-                  "Parameters" : {"Hardening":"--options=runtime"},
+                  "Parameters" : {},
                   "ToolName" : "sign",
                   "ToolVersion" : "1.0"
                 }
@@ -175,27 +175,27 @@ stages:
           MaxRetryAttempts: '5'
           VerboseLogin: false
 
-      - task: EsrpCodeSigning@1
-        displayName: 'Sign MacOS DMG - Notarized'
-        inputs:
-          ConnectedServiceName: 'Azure IoT Explorer CodeSign'
-          FolderPath: '$(Pipeline.Workspace)'
-          Pattern: '*.dmg'
-          signConfigType: 'inlineSignParams'
-          inlineOperation: |
-            [
-              {
-                "KeyCode" : "CP-401337-Apple",
-                "OperationCode" : "MacAppNotarize",
-                "Parameters" : {"BundleId":"com.microsoft.Azure.IoTExplorer"},
-                "ToolName" : "sign",
-                "ToolVersion" : "1.0"
-              }
-            ]
-          SessionTimeout: '60'
-          MaxConcurrency: '50'
-          MaxRetryAttempts: '5'
-          VerboseLogin: false
+      # - task: EsrpCodeSigning@1
+      #   displayName: 'Sign MacOS DMG - Notarized'
+      #   inputs:
+      #     ConnectedServiceName: 'Azure IoT Explorer CodeSign'
+      #     FolderPath: '$(Pipeline.Workspace)'
+      #     Pattern: '*.dmg'
+      #     signConfigType: 'inlineSignParams'
+      #     inlineOperation: |
+      #       [
+      #         {
+      #           "KeyCode" : "CP-401337-Apple",
+      #           "OperationCode" : "MacAppNotarize",
+      #           "Parameters" : {"BundleId":"com.microsoft.Azure.IoTExplorer"},
+      #           "ToolName" : "sign",
+      #           "ToolVersion" : "1.0"
+      #         }
+      #       ]
+      #     SessionTimeout: '60'
+      #     MaxConcurrency: '50'
+      #     MaxRetryAttempts: '5'
+      #     VerboseLogin: false
     
       - task: CopyFiles@2
         displayName: 'ArtifactIgnore'


### PR DESCRIPTION
Seems like our new codesigning parameters caused some badness (#234) in our latest package.

Until we have a solution for a hardened / notarized package that doesn't crash, we'll revert to the basic dev signing for now.