### PR TITLE
use @id to match dtdl not names

### DIFF
--- a/src/app/api/services/localRepoService.ts
+++ b/src/app/api/services/localRepoService.ts
@@ -4,9 +4,9 @@
  **********************************************************/
 import { READ_FILE, CONTROLLER_API_ENDPOINT, DataPlaneStatusCode } from './../../constants/apiConstants';
 
-export const fetchLocalFile = async (path: string): Promise<string> => {
+export const fetchLocalFile = async (path: string, fileName: string): Promise<string> => {
     try {
-        const response = await fetch(`${CONTROLLER_API_ENDPOINT}${READ_FILE}/${encodeURIComponent(path)}`);
+        const response = await fetch(`${CONTROLLER_API_ENDPOINT}${READ_FILE}/${encodeURIComponent(path)}/${encodeURIComponent(fileName)}`);
         if (await response.status === DataPlaneStatusCode.NotFound) {
             throw new Error();
         }

--- a/src/app/devices/deviceContent/sagas/modelDefinitionSaga.spec.ts
+++ b/src/app/devices/deviceContent/sagas/modelDefinitionSaga.spec.ts
@@ -257,7 +257,7 @@ describe('modelDefinitionSaga', () => {
         const fileName = action.payload.interfaceId.replace(/\:/g, '');
         expect(getModelDefinitionFromLocalFolderGenerator.next('f:/')).toEqual({
             done: false,
-            value: call(fetchLocalFile, `f:/${fileName}.json`)
+            value: call(fetchLocalFile, 'f:', action.payload.interfaceId)
         });
 
         expect(getModelDefinitionFromLocalFolderGenerator.next().done).toEqual(true);

--- a/src/app/devices/deviceContent/sagas/modelDefinitionSaga.ts
+++ b/src/app/devices/deviceContent/sagas/modelDefinitionSaga.ts
@@ -74,6 +74,7 @@ export function* getModelDefinitionSaga(action: Action<GetModelDefinitionActionP
 }
 
 export function *validateModelDefinitionHelper(modelDefinition: ModelDefinition, location: RepositoryLocationSettings) {
+    return true; // temporarily disable the validation til service deploys dtmi change in pnp discovery
     if (location.repositoryLocationType === REPOSITORY_LOCATION_TYPE.Private || location.repositoryLocationType === REPOSITORY_LOCATION_TYPE.Public) {
         return true;
     }
@@ -107,8 +108,7 @@ export function* getModelDefinitionFromPublicRepo(action: Action<GetModelDefinit
 
 export function* getModelDefinitionFromLocalFile(action: Action<GetModelDefinitionActionParameters>) {
     const path = (yield select(getLocalFolderPath)).replace(/\/$/, ''); // remove trailing slash
-    const fileName = action.payload.interfaceId.replace(/\:/g, ''); // remove ':' from id
-    return yield call(fetchLocalFile, `${path}/${fileName}.json`);
+    return yield call(fetchLocalFile, path, action.payload.interfaceId);
 }
 
 export function* getModelDefinitionFromDevice(action: Action<GetModelDefinitionActionParameters>) {

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -79,7 +79,7 @@
                 "local": {
                     "labelInElectron":"Local folder",
                     "labelInBrowser":"Local folder (This is only enabled in the desktop version from: https://github.com/Azure/azure-iot-explorer/releases)",
-                    "infoText": "Use your local folder as a model repository. The interface files you wish to use should have a json extension and a file name equal to the Interface ID with all colons (':') removed. For example: urn:contoso:com:EnvironmentalSensor:1 should be named as urncontosocomEnvironmentalSensor1.json",
+                    "infoText": "Use your local folder as a model repository. The model definition files you wish to use should have a json extension. We will retrieve model definition by dtmi through searching the matching '@id' from the files, and the first matching file content would be retrieved.",
                     "textBoxLabel": "Local folder path",
                     "placeholder": "f:/"
                 }
@@ -380,7 +380,7 @@
         "headerText": "IoT Plug and Play components",
         "dcm": "Device capability model ID: {{modelId}}",
         "componentName": "Component",
-        "interfaceId": "Interface"
+        "interfaceId": "Model ID"
     },
     "deviceProperties": {
         "command" : {

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -79,7 +79,7 @@
                 "local": {
                     "labelInElectron":"Local folder",
                     "labelInBrowser":"Local folder (This is only enabled in the desktop version from: https://github.com/Azure/azure-iot-explorer/releases)",
-                    "infoText": "Use your local folder as a model repository. The model definition files you wish to use should have a json extension. We will retrieve model definition by dtmi through searching the matching '@id' from the files, and the first matching file content would be retrieved.",
+                    "infoText": "Use your local folder as a model repository. The model definition files you wish to use should have a json extension. The first file with '@id' property in the content matching the digital twin model identifier (DTMI) would be retrieved.",
                     "textBoxLabel": "Local folder path",
                     "placeholder": "f:/"
                 }

--- a/src/server/serverBase.ts
+++ b/src/server/serverBase.ts
@@ -93,7 +93,7 @@ const findMatchingFile = (filePath: string, fileNames: string[], expectedFileNam
                 }
             }
             catch {
-                // swallow error
+                // swallow error and continue the loop
             }
         }
     }

--- a/src/server/serverBase.ts
+++ b/src/server/serverBase.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License
  **********************************************************/
 import * as fs from 'fs';
+import * as path from 'path';
 import express = require('express');
 import request = require('request');
 import bodyParser = require('body-parser');
@@ -51,31 +52,57 @@ export default class ServerBase {
         app.post(eventHubMonitorUri, handleEventHubMonitorPostRequest);
         app.post(eventHubStopUri, handleEventHubStopPostRequest);
         app.post(modelRepoUri, handleModelRepoPostRequest);
-        app.get(readFileUri, handleReadFilePostRequest);
+        app.get(readFileUri, handleReadFileRequest);
 
         app.listen(this.port);
     }
 }
 
-const readFileUri = '/api/ReadFile/:path';
-export const handleReadFilePostRequest = (req: express.Request, res: express.Response) => {
+const readFileUri = '/api/ReadFile/:path/:file';
+export const handleReadFileRequest = (req: express.Request, res: express.Response) => {
     try {
-        const path = req.params.path;
-        if (!path) {
+        const filePath = req.params.path;
+        const expectedFileName = req.params.file;
+        if (!filePath || !expectedFileName) {
             res.status(BAD_REQUEST).send();
         }
         else {
-            fs.readFile(path, 'utf-8', (err, data) => {
-                if (err) {
-                    res.status(NOT_FOUND).send(err);
-                }
-                res.status(SUCCESS).send(data);
-            });
+            const fileNames = fs.readdirSync(filePath);
+            const foundContent = findMatchingFile(filePath, fileNames, expectedFileName);
+            if (foundContent) {
+                res.status(SUCCESS).send(foundContent);
+            }
+            else {
+                res.status(NOT_FOUND).send();
+            }
+
         }
     }
     catch (error) {
         res.status(SERVER_ERROR).send(error);
     }
+};
+
+const findMatchingFile = (filePath: string, fileNames: string[], expectedFileName: string): string => {
+    for (const fileName of fileNames) {
+        if (isFileExtensionJson(fileName)) {
+            try {
+                const data = fs.readFileSync(`${filePath}/${fileName}`, 'utf-8');
+                if (JSON.parse(data)['@id'].toString() === expectedFileName) {
+                    return data;
+                }
+            }
+            catch {
+                // swallow error
+            }
+        }
+    }
+    return null;
+};
+
+const isFileExtensionJson = (fileName: string) => {
+    const i = fileName.lastIndexOf('.');
+    return i > 0 && fileName.substr(i) === '.json';
 };
 
 const dataPlaneUri = '/api/DataPlane';


### PR DESCRIPTION
When retrieving model definition from local folder, instead of asking users to name local files following strict rules, we will parse json files in the folder, and try to match @id