### PR TITLE
Update json schema adaptor; integrate service update for json patch

### DIFF
--- a/src/app/api/models/interfaceJsonParserOutput.ts
+++ b/src/app/api/models/interfaceJsonParserOutput.ts
@@ -19,8 +19,9 @@ export interface ParsedJsonSchema {
 }
 
 export interface ParsedCommandSchema {
-    description: string;
     name: string;
+
+    description?: string;
     requestSchema?: ParsedJsonSchema;
     responseSchema?: ParsedJsonSchema;
 }

--- a/src/app/api/parameters/deviceParameters.ts
+++ b/src/app/api/parameters/deviceParameters.ts
@@ -66,7 +66,11 @@ export enum JsonPatchOperation {
 
 export interface PatchDigitalTwinParameters extends DataPlaneParameters {
     digitalTwinId: string; // Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.
-    operation: JsonPatchOperation;
+    payload: PatchPayload[];
+}
+
+export interface PatchPayload {
+    op: JsonPatchOperation;
     path: string;
     value?: boolean | number | string | object;
 }

--- a/src/app/api/services/dataplaneServiceHelper.ts
+++ b/src/app/api/services/dataplaneServiceHelper.ts
@@ -102,8 +102,3 @@ export const dataPlaneResponseHelper = async (response: Response) => {
 
     throw new Error(dataPlaneResponse.status && dataPlaneResponse.status.toString());
 };
-
-export const dataPlaneResponseCodeHelper = async (response: Response) => {
-    const dataPlaneResponse = await response;
-    return dataPlaneResponse.status;
-};

--- a/src/app/api/services/digitalTwinService.spec.ts
+++ b/src/app/api/services/digitalTwinService.spec.ts
@@ -125,9 +125,12 @@ describe('digitalTwinService', () => {
         const parameters = {
             connectionString,
             digitalTwinId: undefined,
-            operation: JsonPatchOperation.REPLACE,
-            path: '/environmentalSensor/state',
-            value: false
+            payload: [
+                {
+                    op: JsonPatchOperation.REPLACE,
+                    path: '/environmentalSensor/state',
+                    value: false
+                }]
         };
         it ('returns if digitalTwinId is not specified', () => {
             expect(DigitalTwinService.patchDigitalTwinAndGetResponseCode(parameters)).toEqual(emptyPromise);
@@ -137,10 +140,17 @@ describe('digitalTwinService', () => {
             jest.spyOn(DataplaneService, 'dataPlaneConnectionHelper').mockReturnValue({
                 connectionInfo: getConnectionInfoFromConnectionString(parameters.connectionString), sasToken});
 
+            // tslint:disable
             const response = {
+                json: () => {
+                    return {
+                        body: {},
+                        headers:{}
+                        }
+                    },
                 status: 200
-            // tslint:disable-next-line: no-any
             } as any;
+            // tslint:enable
             jest.spyOn(window, 'fetch').mockResolvedValue(response);
 
             const result = await DigitalTwinService.patchDigitalTwinAndGetResponseCode({
@@ -151,11 +161,7 @@ describe('digitalTwinService', () => {
             const connectionInformation = mockDataPlaneConnectionHelper({connectionString});
             const dataPlaneRequest: DataplaneService.DataPlaneRequest = {
                 apiVersion: DIGITAL_TWIN_API_VERSION_PREVIEW,
-                body: JSON.stringify([{
-                    op: parameters.operation,
-                    path: parameters.path,
-                    value: parameters.value
-                }]),
+                body: JSON.stringify(parameters.payload),
                 hostName: connectionInformation.connectionInfo.hostName,
                 httpMethod: HTTP_OPERATION_TYPES.Patch,
                 path: `/digitalTwins/${deviceId}`,

--- a/src/app/devices/deviceContent/actions.ts
+++ b/src/app/devices/deviceContent/actions.ts
@@ -8,7 +8,7 @@ import * as actionTypes from '../../constants/actionTypes';
 import { Twin } from '../../api/models/device';
 import { DeviceIdentity } from '../../api/models/deviceIdentity';
 import { ModelDefinitionWithSource } from '../../api/models/modelDefinitionWithSource';
-import { JsonPatchOperation } from '../../api/parameters/deviceParameters';
+import { PatchPayload } from '../../api/parameters/deviceParameters';
 
 const deviceContentCreator = actionCreatorFactory(actionPrefixes.DEVICECONTENT);
 const clearModelDefinitionsAction = deviceContentCreator(actionTypes.CLEAR_MODEL_DEFINITIONS);
@@ -47,9 +47,7 @@ export interface CloudToDeviceMessageActionParameters {
 
 export interface PatchDigitalTwinActionParameters {
     digitalTwinId: string;
-    operation: JsonPatchOperation;
-    path: string;
-    value?: boolean | number | string | object;
+    payload: PatchPayload[];
 }
 
 export interface InvokeDigitalTwinInterfaceCommandActionParameters {

--- a/src/app/devices/deviceContent/components/deviceCommands/selectors.spec.ts
+++ b/src/app/devices/deviceContent/components/deviceCommands/selectors.spec.ts
@@ -70,16 +70,13 @@ describe('getDeviceCommandPairs', () => {
                     }
                 },
                 parsedSchema: {
-                    description: 'This command will begin blinking the LED for given time interval.',
                     name: 'blink',
                     requestSchema: {
-                        description: '',
                         required: null,
                         title: 'blinkRequest',
                         type: 'number'
                     },
                     responseSchema: {
-                        description: '',
                         required: null,
                         title: 'blinkResponse',
                         type: 'string'

--- a/src/app/devices/deviceContent/components/deviceEvents/selectors.spec.ts
+++ b/src/app/devices/deviceContent/components/deviceEvents/selectors.spec.ts
@@ -53,7 +53,6 @@ describe('getDeviceCommandPairs', () => {
         const telemetrySchemas = [
             {
                 parsedSchema: {
-                    description: 'Temperature / Current temperature on the device',
                     required: null,
                     title: 'temp',
                     type: 'number'

--- a/src/app/devices/deviceContent/components/deviceProperties/selectors.spec.ts
+++ b/src/app/devices/deviceContent/components/deviceProperties/selectors.spec.ts
@@ -95,7 +95,6 @@ describe('getDigitalTwinPropertiesSelector', () => {
             payload:  digitalTwin,
             synchronizationStatus: SynchronizationStatus.fetched,
         },
-        digitalTwinInterfaceProperties: null,
         modelDefinitionWithSource: {
             payload: {
                 isModelValid: true,
@@ -114,7 +113,6 @@ describe('getDigitalTwinPropertiesSelector', () => {
         const result = getDevicePropertyTupleSelector(state);
         expect(result[0].propertyModelDefinition).toEqual(modelDefinition.contents[0]);
         expect(result[0].reportedTwin).toEqual(modelInformationReportedValue);
-        expect(result[0].propertySchema.description).toEqual(`${modelDefinition.contents[0].displayName} / ${modelDefinition.contents[0].description}`);
         expect(result[0].propertySchema.title).toEqual(modelDefinition.contents[0].name);
     });
 });

--- a/src/app/devices/deviceContent/components/deviceProperties/selectors.ts
+++ b/src/app/devices/deviceContent/components/deviceProperties/selectors.ts
@@ -32,10 +32,13 @@ export const filterProperties = (content: PropertyContent) => {
     }
 };
 
-export const getReportedValueForSpecificProperty = (state: StateInterface, property: PropertyContent): boolean | string | number | object => {
+export const getDigitalTwinForSpecificComponent = (state: StateInterface) => {
     const digitalTwin = getDigitalTwinSelector(state);
     const componentNameSelected = getComponentNameSelector(state);
-    return digitalTwin &&
-        digitalTwin[componentNameSelected] &&
-        digitalTwin[componentNameSelected][property.name];
+    return digitalTwin && digitalTwin[componentNameSelected];
+};
+
+export const getReportedValueForSpecificProperty = (state: StateInterface, property: PropertyContent): boolean | string | number | object => {
+    const digitalTwinForSpecificComponent = getDigitalTwinForSpecificComponent (state);
+    return digitalTwinForSpecificComponent && digitalTwinForSpecificComponent[property.name];
 };

--- a/src/app/devices/deviceContent/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
+++ b/src/app/devices/deviceContent/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
@@ -215,16 +215,10 @@ export default class DeviceSettingsPerInterfacePerSetting
     }
 
     private readonly createForm = () => {
-        let formData = null;
-        if (this.props.metadata) {
-            if (this.props.metadata.desiredValue || typeof this.props.metadata.desiredValue === 'boolean') {
-                formData = this.props.metadata.desiredValue;
-            }
-        }
         return (
             <DataForm
                 buttonText={ResourceKeys.deviceSettings.command.submit}
-                formData={formData}
+                formData={this.props.metadata && this.props.metadata.desiredValue}
                 settingSchema={this.props.settingSchema}
                 handleSave={this.onSubmit}
                 craftPayload={this.createSettingsPayload}

--- a/src/app/devices/deviceContent/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
+++ b/src/app/devices/deviceContent/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
@@ -18,7 +18,7 @@ import { PatchDigitalTwinActionParameters } from '../../actions';
 import ErrorBoundary from '../../../errorBoundary';
 import { getLocalizedData } from '../../../../api/dataTransforms/modelDefinitionTransform';
 import { SemanticUnit } from '../../../../shared/units/components/semanticUnit';
-import { JsonPatchOperation } from '../../../../api/parameters/deviceParameters';
+import { JsonPatchOperation, PatchPayload } from '../../../../api/parameters/deviceParameters';
 import { MetadataSection } from './selectors';
 import '../../../../css/_deviceSettings.scss';
 
@@ -229,22 +229,37 @@ export default class DeviceSettingsPerInterfacePerSetting
     }
 
     // tslint:disable-next-line: cyclomatic-complexity
-    private readonly createSettingsPayload = (twin: boolean | number | string | object): {operation: JsonPatchOperation; path: string; value?: boolean | number | string | object} => {
-        // todo: refactor this whenever service has updated json patch
-        return twin || typeof twin === 'boolean' ? {
-            operation: this.props.metadata && this.props.metadata.desiredValue && this.props.metadata.desiredValue !== {} ? JsonPatchOperation.REPLACE : JsonPatchOperation.ADD,
-            path: `/${this.props.componentName}/${this.props.settingModelDefinition.name}`,
-            value: twin,
-        } : {
-            operation: JsonPatchOperation.REMOVE,
-            path: `/${this.props.componentName}/${this.props.settingModelDefinition.name}`,
-        };
+    private readonly createSettingsPayload = (twin: boolean | number | string | object): PatchPayload[] => {
+        const { componentName, metadata, isComponentContainedInDigitalTwin, settingModelDefinition } = this.props;
+        if (!isComponentContainedInDigitalTwin) {
+            const value: any = { // tslint:disable-line: no-any
+                $metadata: {}
+            };
+            value[settingModelDefinition.name] = twin;
+            return[{
+                op: JsonPatchOperation.ADD,
+                path: `/${componentName}`,
+                value
+            }];
+        }
+        else {
+            const patchPayloadWithTwin = twin || typeof twin === 'boolean' ? {
+                op: metadata && metadata.desiredValue ?
+                    JsonPatchOperation.REPLACE : JsonPatchOperation.ADD,
+                path: `/${componentName}/${settingModelDefinition.name}`,
+                value: twin,
+            } : {
+                op: JsonPatchOperation.REMOVE,
+                path: `/${componentName}/${settingModelDefinition.name}`,
+            };
+            return[patchPayloadWithTwin];
+        }
     }
 
     private readonly onSubmit = (twin: boolean | number | string | object) => () => {
         this.props.patchDigitalTwin({
-            ...this.createSettingsPayload(twin),
-            digitalTwinId: this.props.deviceId
+            digitalTwinId: this.props.deviceId,
+            payload: this.createSettingsPayload(twin)
         });
     }
 }

--- a/src/app/devices/deviceContent/components/deviceSettings/selectors.spec.ts
+++ b/src/app/devices/deviceContent/components/deviceSettings/selectors.spec.ts
@@ -71,7 +71,6 @@ describe('getDigitalTwinSettingsSelector', () => {
             payload:  digitalTwin,
             synchronizationStatus: SynchronizationStatus.fetched,
         },
-        digitalTwinInterfaceProperties: null,
         modelDefinitionWithSource: {
             payload: {
                 isModelValid: true,
@@ -90,6 +89,7 @@ describe('getDigitalTwinSettingsSelector', () => {
         expect(getDeviceSettingTupleSelector(state).interfaceId).toEqual(interfaceId);
         expect(getDeviceSettingTupleSelector(state).componentName).toEqual(componentName);
         expect(getDeviceSettingTupleSelector(state).twinWithSchema[0]).toEqual({
+            isComponentContainedInDigitalTwin: true,
             metadata: {
                 desiredValue: 456,
                 desiredVersion: 2,
@@ -98,7 +98,6 @@ describe('getDigitalTwinSettingsSelector', () => {
             reportedTwin: 123,
             settingModelDefinition: modelDefinition.contents[0],
             settingSchema: {
-                description: `${modelDefinition.contents[0].displayName} / ${modelDefinition.contents[0].description}`,
                 required: null,
                 title: modelDefinition.contents[0].name,
                 type: 'number'

--- a/src/app/devices/deviceContent/components/deviceSettings/selectors.ts
+++ b/src/app/devices/deviceContent/components/deviceSettings/selectors.ts
@@ -6,9 +6,9 @@ import { ModelDefinition } from './../../../../api/models/modelDefinition';
 import { PropertyContent, ContentType } from '../../../../api/models/modelDefinition';
 import { StateInterface } from '../../../../shared/redux/state';
 import { parseInterfacePropertyToJsonSchema } from '../../../../shared/utils/jsonSchemaAdaptor';
-import { getModelDefinitionSelector, getComponentNameSelector, getDigitalTwinSelector } from '../../selectors';
+import { getModelDefinitionSelector, getComponentNameSelector } from '../../selectors';
 import { DeviceInterfaceWithSchema } from './deviceSettings';
-import { getReportedValueForSpecificProperty } from '../deviceProperties/selectors';
+import { getReportedValueForSpecificProperty, getDigitalTwinForSpecificComponent } from '../deviceProperties/selectors';
 
 export const getDeviceSettingTupleSelector = (state: StateInterface) => {
     const modelDefinition = getModelDefinitionSelector(state);
@@ -21,6 +21,7 @@ const generateTwinSchemaAndInterfaceTuple = (state: StateInterface, model: Model
     const settings = writableProperties ? writableProperties
         .map(setting => {
             return {
+                isComponentContainedInDigitalTwin: !!getDigitalTwinForSpecificComponent(state),
                 metadata: getMetadataSectionForSpecificProperty(state, setting),
                 reportedTwin: getReportedValueForSpecificProperty(state, setting),
                 settingModelDefinition: setting,
@@ -54,10 +55,8 @@ export interface MetadataSection {
 }
 
 const getMetadataSectionForSpecificProperty = (state: StateInterface, property: PropertyContent): MetadataSection => {
-    const digitalTwin = getDigitalTwinSelector(state);
-    const componentNameSelected = getComponentNameSelector(state);
-    return digitalTwin &&
-        digitalTwin[componentNameSelected] &&
-        digitalTwin[componentNameSelected].$metadata &&
-        digitalTwin[componentNameSelected].$metadata[property.name];
+    const digitalTwinForSpecificComponent = getDigitalTwinForSpecificComponent(state);
+    return digitalTwinForSpecificComponent &&
+        digitalTwinForSpecificComponent.$metadata &&
+        digitalTwinForSpecificComponent.$metadata[property.name];
 };

--- a/src/app/devices/deviceContent/components/shared/dataForm.tsx
+++ b/src/app/devices/deviceContent/components/shared/dataForm.tsx
@@ -179,12 +179,15 @@ export default class DataForm extends React.Component<DataFormDataProps & DataFo
         this.setState({stringifiedFormData: data});
     }
 
+    private readonly generatePayload = () => {
+        return (this.state.parseMapTypeError || !this.props.settingSchema) ?
+            this.state.stringifiedFormData && JSON.parse(this.state.stringifiedFormData) :
+            dataToTwinConverter(this.state.formData, this.props.settingSchema, this.state.originalFormData).twin;
+    }
+
     private readonly createPayloadPreview = () => {
-        const payload = (this.state.parseMapTypeError || !this.props.settingSchema) ?
-        this.state.stringifiedFormData && JSON.parse(this.state.stringifiedFormData) :
-        dataToTwinConverter(this.state.formData, this.props.settingSchema, this.state.originalFormData).twin;
         this.setState({
-            payloadPreviewData: this.props.craftPayload(payload || null),
+            payloadPreviewData: this.props.craftPayload(this.generatePayload()),
             showPayloadDialog: true
         });
     }
@@ -205,9 +208,7 @@ export default class DataForm extends React.Component<DataFormDataProps & DataFo
         let buttonDisabled = false;
 
         try {
-            payload = (this.state.parseMapTypeError || !this.props.settingSchema) ?
-            (this.state.stringifiedFormData && JSON.parse(this.state.stringifiedFormData)) :
-            dataToTwinConverter(this.state.formData, this.props.settingSchema, this.state.originalFormData).twin;
+            payload = this.generatePayload();
         } catch (e) {
             payload = null;
             buttonDisabled = true;

--- a/src/app/devices/deviceContent/sagas/digitalTwinSaga.ts
+++ b/src/app/devices/deviceContent/sagas/digitalTwinSaga.ts
@@ -36,13 +36,13 @@ export function* patchDigitalTwinSaga(action: Action<PatchDigitalTwinActionParam
             connectionString
         };
 
-        const responseCode = yield call(patchDigitalTwinAndGetResponseCode, parameters);
+        const response = yield call(patchDigitalTwinAndGetResponseCode, parameters);
         const digitalTwin = yield call(fetchDigitalTwin, {connectionString, digitalTwinId: parameters.digitalTwinId});
 
-        if (responseCode === DataPlaneStatusCode.Accepted || responseCode === DataPlaneStatusCode.SuccessLowerBound) {
+        if (response === DataPlaneStatusCode.Accepted || response === DataPlaneStatusCode.SuccessLowerBound) {
             yield put(addNotificationAction.started({
                 text: {
-                    translationKey: responseCode === DataPlaneStatusCode.Accepted ?
+                    translationKey: response === DataPlaneStatusCode.Accepted ?
                         ResourceKeys.notifications.patchDigitalTwinOnAccept : ResourceKeys.notifications.patchDigitalTwinOnSuccess,
                     translationOptions: {
                         deviceId: action.payload.digitalTwinId
@@ -53,7 +53,7 @@ export function* patchDigitalTwinSaga(action: Action<PatchDigitalTwinActionParam
             yield put(patchDigitalTwinAction.done({params: action.payload, result: digitalTwin}));
         }
         else {
-            throw new Error(responseCode);
+            throw new Error(response);
         }
     } catch (error) {
         yield put(addNotificationAction.started({

--- a/src/app/jsonSchemaFormFabricPlugin/widgets/checkBox.tsx
+++ b/src/app/jsonSchemaFormFabricPlugin/widgets/checkBox.tsx
@@ -4,22 +4,20 @@
  **********************************************************/
 import * as React from 'react';
 import { WidgetProps } from 'react-jsonschema-form';
-import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 
 // tslint:disable-next-line:no-any
 const onChangePassthrough = (props: WidgetProps) => (event: any, value: any) => {
-    props.onChange(!props.value);
+    props.onChange(value.key === 'true' ? true : false);
 };
 
-export const FabricCheckbox = (props: WidgetProps & { label: string }) => (
-    <div className="ms-font-m" style={{ display: 'flex' }}>
-        <Checkbox
-            checked={!!props.value}
-            value={props.value}
-            disabled={props.disabled}
-            label={props.label}
-            placeholder={props.placeholder}
-            onChange={onChangePassthrough(props)}
-        />
-    </div>
-);
+export const FabricCheckbox = (props: WidgetProps & { label: string }) => {
+    const options: IChoiceGroupOption[] = [
+        { key: 'true', text: 'true' },
+        { key: 'false', text: 'false' }
+      ];
+
+    return(
+        <ChoiceGroup selectedKey={props.value.toString()} options={options} onChange={onChangePassthrough(props)} label={props.label} disabled={props.disabled}/>
+    );
+};

--- a/src/app/shared/utils/jsonSchemaAdaptor.spec.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.spec.ts
@@ -20,7 +20,6 @@ describe('parse interface model definition to Json schema', () => {
 
         const interfacePropertyInJsonSchema =
             {
-                description: 'Firmware version',
                 required: null,
                 title: 'fwVersion',
                 type: 'string'
@@ -41,7 +40,6 @@ describe('parse interface model definition to Json schema', () => {
         /* tslint:enable */
         const interfacePropertyInJsonSchema =
             {
-                description: 'Total storage',
                 required: null,
                 title: 'totalStorage',
                 type: 'number',
@@ -63,7 +61,6 @@ describe('parse interface model definition to Json schema', () => {
         const interfacePropertyInJsonSchema =
             {
                 default: false,
-                description: 'Total storage',
                 required: null,
                 title: 'totalStorage',
                 type: 'boolean'
@@ -114,7 +111,6 @@ describe('parse interface model definition to Json schema', () => {
         }
         /* tslint:enable */
         expect(parseInterfacePropertyToJsonSchema(interfacePropertyDefinition)).toEqual({
-            description: '',
             // tslint:disable-next-line:no-magic-numbers
             enum: [1, 2],
             enumNames : ['offline', 'online'],
@@ -157,11 +153,9 @@ describe('parse interface model definition to Json schema', () => {
 		};
         /* tslint:enable */
         const interfacePropertyInJsonSchema = {
-            description: 'Model Information / Providing model and optional interfaces information on a digital twin.',
             properties:  {
                 interfaces:  {
                     additionalProperties: true,
-                    description: '',
                     items:  {
                         description: `interfaces's key: name`,
                         properties:  {
@@ -169,7 +163,6 @@ describe('parse interface model definition to Json schema', () => {
                                 type: 'string',
                             },
                             schema:  {
-                                description: '',
                                 required: null,
                                 title: 'schema',
                                 type: 'string',
@@ -186,7 +179,6 @@ describe('parse interface model definition to Json schema', () => {
                     type: 'array',
                 },
                 modelId: {
-                    description: '',
                     required: null,
                     title: 'modelId',
                     type: 'string',
@@ -233,16 +225,13 @@ describe('parse interface model definition to Json schema', () => {
         /* tslint:enable */
         const interfaceCommandInJsonSchema =
             {
-                description: 'This command will begin blinking the LED for given time interval.',
                 name: 'blink',
                 requestSchema: {
-                    description: 'blink interval / blinking the LED for given time interval',
                     required: null,
                     title: 'blinkRequest',
                     type: 'number'
                 },
                 responseSchema: {
-                    description: '',
                     required: null,
                     title: 'blinkResponse',
                     type: 'string'
@@ -258,8 +247,8 @@ describe('parse interface model definition to Json schema', () => {
 			'@type': [
 				'Telemetry',
 				'SemanticType/Temperature'
-			],
-			'description': 'Current temperature on the device',
+            ],
+            'description': 'Current temperature on the device',
 			'displayName': 'Temperature',
 			'name': 'temp',
 			'schema': 'double',
@@ -269,7 +258,6 @@ describe('parse interface model definition to Json schema', () => {
 
         const interfaceTelemetryInJsonSchema =
             {
-                description: 'Temperature / Current temperature on the device',
                 required: null,
                 title: 'temp',
                 type: 'number'

--- a/src/app/shared/utils/jsonSchemaAdaptor.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.ts
@@ -5,7 +5,6 @@
 import { PropertyContent, CommandContent, EnumSchema, ObjectSchema, MapSchema, ContentType, TelemetryContent, Schema } from '../../api/models/modelDefinition';
 import { ParsedCommandSchema, ParsedJsonSchema } from '../../api/models/interfaceJsonParserOutput';
 import { InterfaceSchemaNotSupportedException } from './exceptions/interfaceSchemaNotSupportedException';
-import { getLocalizedData } from '../../api/dataTransforms/modelDefinitionTransform';
 
 export const parseInterfacePropertyToJsonSchema = (property: PropertyContent): ParsedJsonSchema => {
     try {
@@ -18,7 +17,6 @@ export const parseInterfacePropertyToJsonSchema = (property: PropertyContent): P
 export const parseInterfaceCommandToJsonSchema = (command: CommandContent): ParsedCommandSchema => {
     try {
         return {
-            description: getDescription(command),
             name: command.name,
             requestSchema: parseInterfaceCommandsHelper(command, true),
             responseSchema: parseInterfaceCommandsHelper(command, false)
@@ -45,14 +43,12 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
             case 'boolean':
                 return {
                     default: false,
-                    description: getDescription(property),
                     required: null,
                     title: property.name,
                     type: 'boolean'
                 };
             case 'date':
                 return {
-                    description: getDescription(property),
                     format: 'date',
                     required: null,
                     title: property.name,
@@ -60,7 +56,6 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
                 };
             case 'datetime':
                 return {
-                    description: getDescription(property),
                     pattern: '^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$', // regex for ISO 8601
                     required: null,
                     title: property.name,
@@ -70,7 +65,6 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
             case 'float':
             case 'long':
                 return {
-                    description: getDescription(property),
                     required: null,
                     title: property.name,
                     type: 'number',
@@ -78,7 +72,6 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
             case 'integer':
                 return {
                     default: 0,
-                    description: getDescription(property),
                     required: null,
                     title: property.name,
                     type: 'integer',
@@ -87,7 +80,6 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
             case 'duration': // todo: no widget for 'duration' type
             case 'string':
                 return {
-                    description: getDescription(property),
                     required: null,
                     title: property.name,
                     type: 'string'
@@ -99,7 +91,6 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
 
     if (property.schema['@type'] === 'Enum') {
         return property.schema && (property.schema as EnumSchema).enumValues ? {
-            description: getDescription(property),
             enum: (property.schema as EnumSchema).enumValues.map(item => item.enumValue),
             enumNames : (property.schema as EnumSchema).enumValues.map(item => item.name),
             required: null,
@@ -122,7 +113,6 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
         });
 
         return  {
-            description: getDescription(property),
             properties: children,
             required: null,
             title: property.name,
@@ -136,7 +126,6 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
         }
         return {
             additionalProperties: true,
-            description: getDescription(property),
             items: parseInterfaceMapTypePropertyItems(property),
             required: null,
             title: property.name,
@@ -145,7 +134,6 @@ const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSch
     }
 
     return {
-        description: getDescription(property),
         required: null,
         title: property.name,
         type: 'string'
@@ -182,7 +170,6 @@ const parseInterfaceCommandsHelper = (command: CommandContent, parseRequestSchem
     // add a dummy head for command request/response schema to make the recursion logic simpler
     const dummyCommand: PropertyContent = {
         '@type': ContentType.Command,
-        'displayName': getDescription(commandSchema),
         'name': commandSchema.name,
         'schema': commandSchema.schema,
     };
@@ -194,12 +181,4 @@ const parseInterfaceCommandsHelper = (command: CommandContent, parseRequestSchem
     catch {
         return;  // swallow the error and let UI render JSON editor for types which are not supported yet
     }
-};
-
-const getDescription = (schema: PropertyContent | CommandContent | Schema): string => {
-    const displayName = getLocalizedData(schema.displayName);
-    const description = getLocalizedData(schema.description);
-    return displayName && description ?
-    `${displayName} / ${description}` :
-     (description || displayName || '') as string;
 };

--- a/src/app/shared/utils/twinAndJsonSchemaDataConverter.spec.ts
+++ b/src/app/shared/utils/twinAndJsonSchemaDataConverter.spec.ts
@@ -32,6 +32,7 @@ describe('top level map converter', () => {
             required: ['telemetryName', 'telemetryConfig'],
             type: 'object'
         },
+        required: null,
         title: 'MapValStringValue',
         type: 'array'
     };
@@ -69,8 +70,8 @@ describe('top level map converter', () => {
         ]
     };
 
-    it('transforms json form data to twin and would return undefined form data if form data has no corresponding path',  () => {
-        expect(dataToTwinConverter(formDataWithNoMatchingPath, settingWithTopLevelMap).twin).toEqual(undefined);
+    it('transforms json form data to twin and would return empty form data if form data has no corresponding path',  () => {
+        expect(dataToTwinConverter(formDataWithNoMatchingPath, settingWithTopLevelMap).twin).toEqual({});
     });
 });
 
@@ -93,6 +94,7 @@ describe('nested map type converter', () => {
                     },
                     required: ['commandName', 'commandConfig']
                 },
+                required: null,
                 title: 'commands',
                 type: 'array'
             },
@@ -112,10 +114,12 @@ describe('nested map type converter', () => {
                     },
                     required: ['telemetryName', 'telemetryConfig']
                 },
+                required: null,
                 title: 'telemetry',
                 type: 'array'
             },
         },
+        required: null,
         title: 'interfaceConfig',
         type: 'object'
     };
@@ -232,6 +236,7 @@ describe('map in map converter', () => {
             required: ['level_1_Key', 'level_1_Name'],
             type: 'object'
         },
+        required: null,
         title: 'Map With Map',
         type: 'array',
     };

--- a/src/app/shared/utils/twinAndJsonSchemaDataConverter.ts
+++ b/src/app/shared/utils/twinAndJsonSchemaDataConverter.ts
@@ -26,17 +26,19 @@ export const dataToTwinConverter = (formData: any, settingSchema: ParsedJsonSche
 };
 
 export const twinToFormDataConverter = (twin: any, settingSchema: ParsedJsonSchema): {formData: any, error?: Exception} => { // tslint:disable-line:no-any
-    if (!twin) {
-        return {formData: {twin: null}};
-    }
-
     try {
         const numberOfMaps = getNumberOfMapsInSchema(settingSchema);
         if (numberOfMaps > 0) {
+            if (!twin) {
+                return {formData: {twin: null}};
+            }
             const twinClone = JSON.parse(JSON.stringify(twin)); // important: needs this deep copy to prevent inital twin got changed in store
             const pathsWithKeyValuePair = findPathsTowardsMapType(settingSchema, [], numberOfMaps);
             const formData = convertTwinToJsonFormData(twinClone, pathsWithKeyValuePair, settingSchema.title);
             return {formData};
+        }
+        if (!twin) {
+            return {formData: twin};
         }
     }catch (ex) {
         return {formData: twin, error: ex};

--- a/src/app/shared/utils/twinAndJsonSchemaDataConverter.ts
+++ b/src/app/shared/utils/twinAndJsonSchemaDataConverter.ts
@@ -27,7 +27,7 @@ export const dataToTwinConverter = (formData: any, settingSchema: ParsedJsonSche
 
 export const twinToFormDataConverter = (twin: any, settingSchema: ParsedJsonSchema): {formData: any, error?: Exception} => { // tslint:disable-line:no-any
     if (!twin) {
-        return {formData: twin};
+        return {formData: {twin: null}};
     }
 
     try {
@@ -208,22 +208,30 @@ const convertJsonFormDataToTwin = (
                     }
 
                     let deletedKeys: string[] = [];
-                    if (originalFormData && dummyOriginalFormData[key] &&  dummyOriginalFormData[key].length !== parentFormData[key].length) {
+                    if (originalFormData &&
+                        dummyOriginalFormData[key] &&
+                        dummyOriginalFormData[key].length > 0 &&
+                        parentFormData[key] &&
+                        parentFormData[key].length > 0 &&
+                        dummyOriginalFormData[key].length !== parentFormData[key].length) {
                         // find keys that have been deleted from the orignal form and specifically set its value to null
                         const oldKeys: string[] = dummyOriginalFormData[key].map((item: any) => item[mapKeyName]); // tslint:disable-line:no-any
                         const newKeys: string[] = parentFormData[key].map((item: any) => item[mapKeyName]); // tslint:disable-line:no-any
                         deletedKeys = oldKeys.filter((oldKey: string) => newKeys.indexOf(oldKey) === -1);
                     }
 
-                    parentFormData[key].forEach((keyValue: any) => { // tslint:disable-line: no-any
-                        try {
-                            newFormNode[keyValue[mapKeyName]] = keyValue[mapValueName];
-                        }
-                        catch {
-                            return;
-                        }
-                    });
-                    if (deletedKeys) {
+                    if (parentFormData[key] && parentFormData[key].length > 0) {
+                        parentFormData[key].forEach((keyValue: any) => { // tslint:disable-line: no-any
+                            try {
+                                newFormNode[keyValue[mapKeyName]] = keyValue[mapValueName];
+                            }
+                            catch {
+                                return;
+                            }
+                        });
+                    }
+
+                    if (deletedKeys && deletedKeys.length > 0) {
                         deletedKeys.forEach(deletedKey => {
                             newFormNode[deletedKey] = null;
                         });


### PR DESCRIPTION
- remove tooltip from json schema form. This has now become duplicate information and hence not necessary to show anymore
- fix map in object data converter. When there was no value in digital twin, couple edge case was not properly checked
- update dt service and selectors to deal with new patch update 