### PR TITLE
Reusable schema

### DIFF
--- a/src/app/api/models/interfaceJsonParserOutput.ts
+++ b/src/app/api/models/interfaceJsonParserOutput.ts
@@ -3,19 +3,21 @@
  * Licensed under the MIT License
  **********************************************************/
 export interface ParsedJsonSchema {
-    type: string;
     required: string[];
 
     additionalProperties?: boolean; // use this props as a workaround to indicate whether parsed property is map type
     default?: {};
+    definitions?: any; // tslint:disable-line: no-any
     description?: string;
-    enum?: number[] ;
+    enum?: Array<number | string>;
     enumNames?: string[];
     format?: string;
     items?: any; // tslint:disable-line: no-any
     pattern?: string;
     properties?: {};
     title?: string;
+    type?: string;
+    $ref?: any; // tslint:disable-line: no-any
 }
 
 export interface ParsedCommandSchema {

--- a/src/app/api/models/modelDefinition.ts
+++ b/src/app/api/models/modelDefinition.ts
@@ -10,6 +10,7 @@ export interface ModelDefinition {
     contents: Array<PropertyContent | CommandContent | TelemetryContent | ComponentContent>;
     description?: string | object;
     displayName?: string | object;
+    schemas?: Array<ObjectSchema | MapSchema | EnumSchema>;
 }
 
 export interface PropertyContent extends ContentBase {
@@ -38,7 +39,6 @@ interface ContentBase {
     comment?: string | object;
     description?: string | object;
     displayName?: string | object;
-    displayUnit?: string;
     unit?: string;
 }
 
@@ -51,18 +51,22 @@ export interface Schema {
 
 export interface EnumSchema {
     '@type': string;
-    enumValues: Array<{ displayName: string | object, name: string, enumValue: number}>;
+    valueSchema: string;
+    enumValues: Array<{ displayName: string | object, name: string, enumValue: number | string}>;
+    '@id'?: string;
 }
 
 export interface ObjectSchema {
     '@type': string;
     fields: Schema[];
+    '@id'?: string;
 }
 
 export interface MapSchema {
     '@type': string;
     mapKey: Schema;
     mapValue: Schema;
+    '@id'?: string;
 }
 
 export enum ContentType{

--- a/src/app/devices/deviceContent/components/deviceCommands/selectors.spec.ts
+++ b/src/app/devices/deviceContent/components/deviceCommands/selectors.spec.ts
@@ -72,11 +72,13 @@ describe('getDeviceCommandPairs', () => {
                 parsedSchema: {
                     name: 'blink',
                     requestSchema: {
+                        definitions: {},
                         required: null,
                         title: 'blinkRequest',
                         type: 'number'
                     },
                     responseSchema: {
+                        definitions: {},
                         required: null,
                         title: 'blinkResponse',
                         type: 'string'

--- a/src/app/devices/deviceContent/components/deviceCommands/selectors.ts
+++ b/src/app/devices/deviceContent/components/deviceCommands/selectors.ts
@@ -2,30 +2,21 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
-import { ContentType, CommandContent } from '../../../../api/models/modelDefinition';
-import { parseInterfaceCommandToJsonSchema } from './../../../../shared/utils/jsonSchemaAdaptor';
+import { JsonSchemaAdaptor } from './../../../../shared/utils/jsonSchemaAdaptor';
 import { StateInterface } from '../../../../shared/redux/state';
 import { DeviceInterfaceWithSchema } from './deviceCommands';
 import { getModelDefinitionSelector } from '../../selectors';
 
 export const getDeviceCommandPairs = (state: StateInterface): DeviceInterfaceWithSchema => {
     const modelDefinition = getModelDefinitionSelector(state);
-    const commands = modelDefinition && modelDefinition.contents && modelDefinition.contents.filter((item: CommandContent) => filterCommand(item));
+    const jsonSchemaAdaptor = new JsonSchemaAdaptor(modelDefinition);
+    const commands = jsonSchemaAdaptor.getCommands();
     return {
-        commandSchemas: commands ? commands.map(command => ({
+        commandSchemas: commands.map(command => ({
             commandModelDefinition: command,
-            parsedSchema: parseInterfaceCommandToJsonSchema(command),
-        })) : []
+            parsedSchema: jsonSchemaAdaptor.parseInterfaceCommandToJsonSchema(command),
+        }))
     };
-};
-
-const filterCommand = (content: CommandContent) => {
-    if (typeof content['@type'] === 'string') {
-        return content['@type'].toLowerCase() === ContentType.Command;
-    }
-    else {
-        return content['@type'].some((entry: string) => entry.toLowerCase() === ContentType.Command);
-    }
 };
 
 export default getDeviceCommandPairs;

--- a/src/app/devices/deviceContent/components/deviceEvents/selectors.spec.ts
+++ b/src/app/devices/deviceContent/components/deviceEvents/selectors.spec.ts
@@ -53,6 +53,7 @@ describe('getDeviceCommandPairs', () => {
         const telemetrySchemas = [
             {
                 parsedSchema: {
+                    definitions: {},
                     required: null,
                     title: 'temp',
                     type: 'number'

--- a/src/app/devices/deviceContent/components/deviceEvents/selectors.ts
+++ b/src/app/devices/deviceContent/components/deviceEvents/selectors.ts
@@ -3,27 +3,18 @@
  * Licensed under the MIT License
  **********************************************************/
 import { StateInterface } from './../../../../shared/redux/state';
-import { ContentType, TelemetryContent } from '../../../../api/models/modelDefinition';
-import { parseInterfaceTelemetryToJsonSchema } from './../../../../shared/utils/jsonSchemaAdaptor';
+import { JsonSchemaAdaptor } from './../../../../shared/utils/jsonSchemaAdaptor';
 import { getModelDefinitionSelector } from '../../selectors';
 import { TelemetrySchema } from './deviceEventsPerInterface';
 
 export const getDeviceTelemetrySelector = (state: StateInterface): TelemetrySchema[] => {
     const modelDefinition = getModelDefinitionSelector(state);
-    const telemetryContents = modelDefinition && modelDefinition.contents && modelDefinition.contents.filter((item: TelemetryContent) => filterTelemetry(item)) as TelemetryContent[];
-    return telemetryContents ? telemetryContents.map(telemetry => ({
-        parsedSchema: parseInterfaceTelemetryToJsonSchema(telemetry),
+    const jsonSchemaAdaptor = new JsonSchemaAdaptor(modelDefinition);
+    const telemetryContents = jsonSchemaAdaptor.getTelemetry();
+    return telemetryContents.map(telemetry => ({
+        parsedSchema: jsonSchemaAdaptor.parseInterfaceTelemetryToJsonSchema(telemetry),
         telemetryModelDefinition: telemetry
-    })) : [];
-};
-
-const filterTelemetry = (content: TelemetryContent) => {
-    if (typeof content['@type'] === 'string') {
-        return content['@type'].toLowerCase() === ContentType.Telemetry;
-    }
-    else {
-        return content['@type'].some((entry: string) => entry.toLowerCase() === ContentType.Telemetry);
-    }
+    }));
 };
 
 export default getDeviceTelemetrySelector;

--- a/src/app/devices/deviceContent/components/deviceProperties/__snapshots__/devicePropertiesPerInterface.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceProperties/__snapshots__/devicePropertiesPerInterface.spec.tsx.snap
@@ -79,6 +79,7 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
     twinWithSchema={
       Array [
         Object {
+          "isComponentContainedInDigitalTwin": true,
           "metadata": Object {
             "lastUpdatedTime": "2020-03-31T23:17:42.4813073Z",
           },

--- a/src/app/devices/deviceContent/components/deviceProperties/selectors.ts
+++ b/src/app/devices/deviceContent/components/deviceProperties/selectors.ts
@@ -4,7 +4,7 @@
  **********************************************************/
 import { ModelDefinition, PropertyContent, ContentType } from '../../../../api/models/modelDefinition';
 import { StateInterface } from '../../../../shared/redux/state';
-import { parseInterfacePropertyToJsonSchema } from '../../../../shared/utils/jsonSchemaAdaptor';
+import { JsonSchemaAdaptor } from '../../../../shared/utils/jsonSchemaAdaptor';
 import { TwinWithSchema } from './devicePropertiesPerInterface';
 import { getModelDefinitionSelector, getComponentNameSelector, getDigitalTwinSelector } from '../../selectors';
 
@@ -14,13 +14,14 @@ export const getDevicePropertyTupleSelector = (state: StateInterface): TwinWithS
 };
 
 const getDevicePropertyProps = (state: StateInterface, model: ModelDefinition): TwinWithSchema[] => {
-    const nonWritableProperties = model && model.contents && model.contents.filter((content: PropertyContent) => filterProperties(content)) as PropertyContent[];
+    const jsonSchemaAdaptor = new JsonSchemaAdaptor(model);
+    const nonWritableProperties = jsonSchemaAdaptor.getNonWritableProperties();
 
-    return nonWritableProperties ? nonWritableProperties.map(property => ({
+    return nonWritableProperties.map(property => ({
         propertyModelDefinition: property,
-        propertySchema: parseInterfacePropertyToJsonSchema(property),
+        propertySchema: jsonSchemaAdaptor.parseInterfacePropertyToJsonSchema(property),
         reportedTwin: getReportedValueForSpecificProperty(state, property)
-    })) : [];
+    }));
 };
 
 export const filterProperties = (content: PropertyContent) => {

--- a/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettings.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettings.spec.tsx.snap
@@ -79,6 +79,7 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
     twinWithSchema={
       Array [
         Object {
+          "isComponentContainedInDigitalTwin": true,
           "metadata": Object {
             "lastUpdatedTime": "2020-03-31T23:17:42.4813073Z",
           },

--- a/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettingsPerInterface.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceSettings/__snapshots__/deviceSettingsPerInterface.spec.tsx.snap
@@ -79,6 +79,7 @@ exports[`components/devices/deviceSettings matches snapshot with one twinWithSch
     twinWithSchema={
       Array [
         Object {
+          "isComponentContainedInDigitalTwin": true,
           "metadata": Object {
             "lastUpdatedTime": "2020-03-31T23:17:42.4813073Z",
           },
@@ -161,6 +162,7 @@ exports[`components/devices/deviceSettingsPerInterface matches snapshot 1`] = `
       handleCollapseToggle={[Function]}
       handleOverlayToggle={[Function]}
       interfaceId="urn:contoso:com:EnvironmentalSensor:1"
+      isComponentContainedInDigitalTwin={true}
       key="0"
       metadata={
         Object {
@@ -190,6 +192,7 @@ exports[`components/devices/deviceSettingsPerInterface matches snapshot 1`] = `
       twinWithSchema={
         Array [
           Object {
+            "isComponentContainedInDigitalTwin": true,
             "metadata": Object {
               "lastUpdatedTime": "2020-03-31T23:17:42.4813073Z",
             },

--- a/src/app/devices/deviceContent/components/deviceSettings/deviceSettings.spec.tsx
+++ b/src/app/devices/deviceContent/components/deviceSettings/deviceSettings.spec.tsx
@@ -11,6 +11,7 @@ import { mountWithLocalization, testSnapshot } from '../../../../shared/utils/te
 import { TwinWithSchema } from './deviceSettingsPerInterfacePerSetting';
 
 export const twinWithSchema: TwinWithSchema = {
+    isComponentContainedInDigitalTwin: true,
     metadata: {
         lastUpdatedTime: '2020-03-31T23:17:42.4813073Z'
     },

--- a/src/app/devices/deviceContent/components/deviceSettings/selectors.spec.ts
+++ b/src/app/devices/deviceContent/components/deviceSettings/selectors.spec.ts
@@ -7,7 +7,7 @@ import 'jest';
 import { Record } from 'immutable';
 import { ModelDefinition } from '../../../../api/models/modelDefinition';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
-import { getDeviceSettingTupleSelector, filterProperties } from './selectors';
+import { getDeviceSettingTupleSelector } from './selectors';
 import { getInitialState } from '../../../../api/shared/testHelper';
 import { REPOSITORY_LOCATION_TYPE } from '../../../../constants/repositoryLocationTypes';
 
@@ -81,10 +81,6 @@ describe('getDigitalTwinSettingsSelector', () => {
         }
     })();
 
-    it('filters writable property with semantic types', () => {
-        expect(filterProperties(sampleSenmanticProperty)).toBeTruthy();
-    });
-
     it('returns interface settings tuple', () => {
         expect(getDeviceSettingTupleSelector(state).interfaceId).toEqual(interfaceId);
         expect(getDeviceSettingTupleSelector(state).componentName).toEqual(componentName);
@@ -98,6 +94,7 @@ describe('getDigitalTwinSettingsSelector', () => {
             reportedTwin: 123,
             settingModelDefinition: modelDefinition.contents[0],
             settingSchema: {
+                definitions: {},
                 required: null,
                 title: modelDefinition.contents[0].name,
                 type: 'number'

--- a/src/app/devices/deviceContent/components/deviceSettings/selectors.ts
+++ b/src/app/devices/deviceContent/components/deviceSettings/selectors.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License
  **********************************************************/
 import { ModelDefinition } from './../../../../api/models/modelDefinition';
-import { PropertyContent, ContentType } from '../../../../api/models/modelDefinition';
+import { PropertyContent } from '../../../../api/models/modelDefinition';
 import { StateInterface } from '../../../../shared/redux/state';
-import { parseInterfacePropertyToJsonSchema } from '../../../../shared/utils/jsonSchemaAdaptor';
 import { getModelDefinitionSelector, getComponentNameSelector } from '../../selectors';
 import { DeviceInterfaceWithSchema } from './deviceSettings';
 import { getReportedValueForSpecificProperty, getDigitalTwinForSpecificComponent } from '../deviceProperties/selectors';
+import { JsonSchemaAdaptor } from './../../../../shared/utils/jsonSchemaAdaptor';
 
 export const getDeviceSettingTupleSelector = (state: StateInterface) => {
     const modelDefinition = getModelDefinitionSelector(state);
@@ -16,33 +16,25 @@ export const getDeviceSettingTupleSelector = (state: StateInterface) => {
 };
 
 const generateTwinSchemaAndInterfaceTuple = (state: StateInterface, model: ModelDefinition): DeviceInterfaceWithSchema => {
-    const writableProperties = model && model.contents && model.contents.filter((item: PropertyContent) => filterProperties(item)) as PropertyContent[];
+    const jsonSchemaAdaptor = new JsonSchemaAdaptor(model);
+    const writableProperties = jsonSchemaAdaptor.getWritableProperties();
 
-    const settings = writableProperties ? writableProperties
+    const settings = writableProperties
         .map(setting => {
             return {
                 isComponentContainedInDigitalTwin: !!getDigitalTwinForSpecificComponent(state),
                 metadata: getMetadataSectionForSpecificProperty(state, setting),
                 reportedTwin: getReportedValueForSpecificProperty(state, setting),
                 settingModelDefinition: setting,
-                settingSchema: parseInterfacePropertyToJsonSchema(setting)
+                settingSchema: jsonSchemaAdaptor.parseInterfacePropertyToJsonSchema(setting)
             };
-        }) : [];
+        });
 
     return {
         componentName: getComponentNameSelector(state),
         interfaceId: model['@id'],
         twinWithSchema: settings,
     };
-};
-
-export const filterProperties = (content: PropertyContent) => {
-    if (typeof content['@type'] === 'string') {
-        return content['@type'].toLowerCase() === ContentType.Property && content.writable;
-    }
-    else {
-        return content['@type'].some((entry: string) => entry.toLowerCase() === ContentType.Property) && content.writable;
-    }
 };
 
 export interface MetadataSection {

--- a/src/app/devices/deviceContent/components/shared/__snapshots__/complexReportedFormPanel.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/shared/__snapshots__/complexReportedFormPanel.spec.tsx.snap
@@ -45,6 +45,7 @@ exports[`complexReportedFormPanel matches snapshot without twinWithSchema 1`] = 
       schema={
         Object {
           "description": "Brightness Level / The brightness level for the light on the device. Can be specified as 1 (high), 2 (medium), 3 (low)",
+          "required": null,
           "title": "brightness",
           "type": "number",
         }

--- a/src/app/devices/deviceContent/components/shared/complexReportedFormPanel.spec.tsx
+++ b/src/app/devices/deviceContent/components/shared/complexReportedFormPanel.spec.tsx
@@ -11,6 +11,7 @@ describe('complexReportedFormPanel', () => {
     const formData = 123;
     const schema = {
         description: 'Brightness Level / The brightness level for the light on the device. Can be specified as 1 (high), 2 (medium), 3 (low)',
+        required: null,
         title: 'brightness',
         type: 'number'
     };

--- a/src/app/jsonSchemaFormFabricPlugin/fields/objectTemplate.tsx
+++ b/src/app/jsonSchemaFormFabricPlugin/fields/objectTemplate.tsx
@@ -4,30 +4,13 @@
  **********************************************************/
 import * as React from 'react';
 import { ObjectFieldTemplateProps } from 'react-jsonschema-form';
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
-import { DirectionalHint } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { getId } from 'office-ui-fabric-react/lib/Utilities';
-import { INFO } from '../../constants/iconNames';
+import { Label } from 'office-ui-fabric-react/lib/Label';
 import '../css/_objectTemplate.scss';
 
 export const ObjectTemplate = (props: ObjectFieldTemplateProps) => {
-    const hostId = getId('hostId');
     return (
         <section key={props.title} className="objectField">
-            {props.description && (
-                <TooltipHost
-                    content={props.description}
-                    id={hostId}
-                    calloutProps={{ gapSpace: 0 }}
-                    directionalHint={DirectionalHint.rightCenter}
-                >
-                    <IconButton
-                        iconProps={{ iconName: INFO }}
-                        aria-labelledby={hostId}
-                    />
-                </TooltipHost>
-            )}
+            <Label>{props.title}</Label>
             {props.properties.map((element, index) =>
                 <div key={index} className="element">{element.content}</div>
             )}

--- a/src/app/shared/utils/jsonSchemaAdaptor.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.ts
@@ -2,183 +2,277 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
-import { PropertyContent, CommandContent, EnumSchema, ObjectSchema, MapSchema, ContentType, TelemetryContent, Schema } from '../../api/models/modelDefinition';
+import { PropertyContent, CommandContent, EnumSchema, MapSchema, ObjectSchema, ContentType, TelemetryContent, ModelDefinition } from '../../api/models/modelDefinition';
 import { ParsedCommandSchema, ParsedJsonSchema } from '../../api/models/interfaceJsonParserOutput';
 import { InterfaceSchemaNotSupportedException } from './exceptions/interfaceSchemaNotSupportedException';
 
-export const parseInterfacePropertyToJsonSchema = (property: PropertyContent): ParsedJsonSchema => {
-    try {
-        return parseInterfacePropertyHelper(property);
-    } catch {
-        return; // swallow the error and let UI render JSON editor for types which are not supported yet
-    }
-};
+export interface JsonSchemaAdaptorInterface {
+    getWritableProperties: () => PropertyContent[];
+    getNonWritableProperties: () => PropertyContent[];
+    getCommands: () => CommandContent[];
+    getTelemetry: () => TelemetryContent[];
+    parseInterfacePropertyToJsonSchema: (property: PropertyContent) => ParsedJsonSchema;
+    parseInterfaceCommandToJsonSchema: (command: CommandContent) => ParsedCommandSchema;
+    parseInterfaceTelemetryToJsonSchema: (telemetry: TelemetryContent) => ParsedJsonSchema;
+}
 
-export const parseInterfaceCommandToJsonSchema = (command: CommandContent): ParsedCommandSchema => {
-    try {
-        return {
-            name: command.name,
-            requestSchema: parseInterfaceCommandsHelper(command, true),
-            responseSchema: parseInterfaceCommandsHelper(command, false)
-        };
-    } catch {
-        return; // swallow the error and let UI render JSON editor for types which are not supported yet
-    }
-};
+export class JsonSchemaAdaptor implements JsonSchemaAdaptorInterface{
+    private readonly model: ModelDefinition;
+    private readonly definitions: any; // tslint:disable-line: no-any
 
-export const parseInterfaceTelemetryToJsonSchema = (telemetry: TelemetryContent): ParsedJsonSchema => {
-    try {
-        return parseInterfacePropertyHelper(telemetry);
-    } catch {
-        return; // swallow the error and let UI render JSON editor for types which are not supported yet
-    }
-};
-
-// tslint:disable-next-line:cyclomatic-complexity
-const parseInterfacePropertyHelper = (property:  PropertyContent): ParsedJsonSchema  => {
-    if (!property || !property.schema) { return; }
-
-    if (typeof(property.schema) === 'string') {
-        switch (property.schema.toLowerCase()) {
-            case 'boolean':
-                return {
-                    default: false,
-                    required: null,
-                    title: property.name,
-                    type: 'boolean'
-                };
-            case 'date':
-                return {
-                    format: 'date',
-                    required: null,
-                    title: property.name,
-                    type: 'string',
-                };
-            case 'datetime':
-                return {
-                    pattern: '^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$', // regex for ISO 8601
-                    required: null,
-                    title: property.name,
-                    type: 'string',
-                };
-            case 'double':
-            case 'float':
-            case 'long':
-                return {
-                    required: null,
-                    title: property.name,
-                    type: 'number',
-                };
-            case 'integer':
-                return {
-                    default: 0,
-                    required: null,
-                    title: property.name,
-                    type: 'integer',
-                };
-            case 'time': // todo: no widget for 'time' type
-            case 'duration': // todo: no widget for 'duration' type
-            case 'string':
-                return {
-                    required: null,
-                    title: property.name,
-                    type: 'string'
-                };
-            default:
-                throw new InterfaceSchemaNotSupportedException();
-        }
-    }
-
-    if (property.schema['@type'] === 'Enum') {
-        return property.schema && (property.schema as EnumSchema).enumValues ? {
-            enum: (property.schema as EnumSchema).enumValues.map(item => item.enumValue),
-            enumNames : (property.schema as EnumSchema).enumValues.map(item => item.name),
-            required: null,
-            title: property.name,
-            type: (property.schema as EnumSchema).enumValues.some(item => typeof item.enumValue === 'string') ? 'string' : 'number',
-        } : undefined;
-    }
-
-    if (property.schema['@type'] === 'Object') {
-        if (!(property.schema as ObjectSchema).fields) {
-            return;
-        }
-        const children: any = {}; // tslint:disable-line: no-any
-        (property.schema as ObjectSchema).fields.forEach(element => {
-            const child = parseInterfacePropertyHelper({...element, '@type': null});
-            if (child) {
-                const propertyName = child.title;
-                children[propertyName] = child;
+    constructor(model: ModelDefinition) {
+        this.model = model;
+        const reusableSchema = model && model.schemas || [];
+        this.definitions = {} as any; // tslint:disable-line: no-any
+        reusableSchema.forEach(schema => {
+            try {
+                const parsedReusableSchema = this.parseInterfaceContentSchemaHelper(schema);
+                this.definitions[schema['@id']] = parsedReusableSchema;
+            }
+            catch {
+                this.definitions[schema['@id']] = {};
             }
         });
+    }
 
-        return  {
-            properties: children,
+    public getWritableProperties = () => {
+        return this.model && this.model.contents && this.model.contents.filter((item: PropertyContent) => this.filterProperty(item, true)) as PropertyContent[] || [];
+    }
+
+    public getNonWritableProperties = () => {
+        return this.model && this.model.contents && this.model.contents.filter((item: PropertyContent) => this.filterProperty(item, false || undefined)) as PropertyContent[] || [];
+    }
+
+    public getCommands = () => {
+        return this.model && this.model.contents && this.model.contents.filter((item: CommandContent) => this.filterCommand(item)) as CommandContent[] || [];
+    }
+
+    public getTelemetry = () => {
+        return this.model && this.model.contents && this.model.contents.filter((item: TelemetryContent) => this.filterTelemetry(item)) as TelemetryContent[] || [];
+    }
+
+    public parseInterfacePropertyToJsonSchema = (property: PropertyContent): ParsedJsonSchema => {
+        try {
+            return {
+                ...this.parseInterfaceContentHelper(property),
+                definitions: this.definitions
+            };
+        } catch {
+            return; // swallow the error and let UI render JSON editor for types which are not supported yet
+        }
+    }
+
+    public parseInterfaceCommandToJsonSchema = (command: CommandContent): ParsedCommandSchema => {
+        try {
+            return {
+                name: command.name,
+                requestSchema: this.parseInterfaceCommandsHelper(command, true),
+                responseSchema: this.parseInterfaceCommandsHelper(command, false)
+            };
+        } catch {
+            return; // swallow the error and let UI render JSON editor for types which are not supported yet
+        }
+    }
+
+    public parseInterfaceTelemetryToJsonSchema = (telemetry: TelemetryContent): ParsedJsonSchema => {
+        try {
+            return {
+                ...this.parseInterfaceContentHelper(telemetry),
+                definitions: this.definitions
+            };
+        } catch {
+            return; // swallow the error and let UI render JSON editor for types which are not supported yet
+        }
+    }
+
+    private readonly filterProperty = (content: PropertyContent, writable: boolean) => {
+        if (typeof content['@type'] === 'string') {
+            return content['@type'].toLowerCase() === ContentType.Property && content.writable === writable;
+        }
+        else {
+            return content['@type'].some((entry: string) => entry.toLowerCase() === ContentType.Property) && content.writable === writable;
+        }
+    }
+
+    private readonly filterCommand = (content: CommandContent) => {
+        if (typeof content['@type'] === 'string') {
+            return content['@type'].toLowerCase() === ContentType.Command;
+        }
+        else {
+            return content['@type'].some((entry: string) => entry.toLowerCase() === ContentType.Command);
+        }
+    }
+
+    private readonly filterTelemetry = (content: TelemetryContent) => {
+        if (typeof content['@type'] === 'string') {
+            return content['@type'].toLowerCase() === ContentType.Telemetry;
+        }
+        else {
+            return content['@type'].some((entry: string) => entry.toLowerCase() === ContentType.Telemetry);
+        }
+    }
+
+    private readonly parseInterfaceContentHelper = (property:  PropertyContent): ParsedJsonSchema  => {
+        if (!property || !property.schema) { return; }
+
+        const parsedSchema = this.parseInterfaceContentSchemaHelper(property.schema);
+        return {
+            ...parsedSchema,
+            title: property.name
+        };
+    }
+
+    // tslint:disable-next-line: cyclomatic-complexity
+    private readonly parseInterfaceContentSchemaHelper = (propertySchema: string | EnumSchema | ObjectSchema | MapSchema): ParsedJsonSchema  => {
+        if (typeof(propertySchema) === 'string') {
+            if (propertySchema.startsWith('dtmi')) {
+                if (Object.keys(this.definitions).includes(propertySchema)) {
+                    return {
+                        $ref: `#/definitions/${propertySchema}`,
+                        required: null
+                    };
+                }
+                else {
+                    return {
+                        required: null,
+                        type: 'string'
+                    };
+                }
+            }
+            else {
+                switch (propertySchema.toLowerCase()) {
+                    case 'boolean':
+                        return {
+                            default: false,
+                            required: null,
+                            type: 'boolean'
+                        };
+                    case 'date':
+                        return {
+                            format: 'date',
+                            required: null,
+                            type: 'string',
+                        };
+                    case 'datetime':
+                        return {
+                            pattern: '^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$', // regex for ISO 8601
+                            required: null,
+                            type: 'string',
+                        };
+                    case 'double':
+                    case 'float':
+                    case 'long':
+                        return {
+                            required: null,
+                            type: 'number',
+                        };
+                    case 'integer':
+                        return {
+                            required: null,
+                            type: 'integer',
+                        };
+                    case 'time': // todo: no widget for 'time' type
+                    case 'duration': // todo: no widget for 'duration' type
+                    case 'string':
+                        return {
+                            required: null,
+                            type: 'string'
+                        };
+                    default:
+                        throw new InterfaceSchemaNotSupportedException();
+                }
+            }
+        }
+
+        if (propertySchema['@type'] === 'Enum') {
+            return propertySchema && (propertySchema as EnumSchema).enumValues ? {
+                enum: (propertySchema as EnumSchema).enumValues.map(item => item.enumValue),
+                enumNames : (propertySchema as EnumSchema).enumValues.map(item => item.name),
+                required: null,
+                type: (propertySchema as EnumSchema).enumValues.some(item => typeof item.enumValue === 'string') ? 'string' : 'number',
+            } : undefined;
+        }
+
+        if (propertySchema['@type'] === 'Object') {
+            if (!(propertySchema as ObjectSchema).fields) {
+                return;
+            }
+            const children: any = {}; // tslint:disable-line: no-any
+            (propertySchema as ObjectSchema).fields.forEach(element => {
+                const child = this.parseInterfaceContentHelper({...element, '@type': null});
+                if (child) {
+                    const propertyName = child.title;
+                    children[propertyName] = child;
+                }
+            });
+
+            return  {
+                properties: children,
+                required: null,
+                type: 'object'
+            };
+        }
+
+        if (propertySchema['@type'] === 'Map') {
+            if (!(propertySchema as MapSchema).mapKey || !(propertySchema as MapSchema).mapValue) {
+                return;
+            }
+            return {
+                additionalProperties: true,
+                items: this.parseInterfaceMapTypePropertyItems(propertySchema),
+                required: null,
+                type: 'array' // there is no map type in json schema, instead we use an array of object type to present it
+            };
+        }
+
+        return {
             required: null,
-            title: property.name,
+            type: 'string'
+        };
+    }
+
+    // tslint:disable-next-line:cyclomatic-complexity
+    private readonly parseInterfaceCommandsHelper = (command: CommandContent, parseRequestSchema: boolean): ParsedJsonSchema => {
+        const commandSchema = parseRequestSchema ? command.request : command.response;
+
+        if (!commandSchema) { return; }
+
+        // add a dummy head for command request/response schema to make the recursion logic simpler
+        const dummyCommand: PropertyContent = {
+            '@type': ContentType.Command,
+            'name': commandSchema.name,
+            'schema': commandSchema.schema,
+        };
+
+        if (!dummyCommand || !dummyCommand.schema) { return; }
+        try {
+            return {
+                ...this.parseInterfaceContentHelper(dummyCommand),
+                definitions: this.definitions
+            };
+        }
+        catch {
+            return;  // swallow the error and let UI render JSON editor for types which are not supported yet
+        }
+    }
+
+    private readonly parseInterfaceMapTypePropertyItems = (propertySchema: string | EnumSchema | ObjectSchema | MapSchema): ParsedJsonSchema => {
+        const parsedMapValue = this.parseInterfaceContentHelper({...(propertySchema as MapSchema).mapValue, '@type': null});
+        // there is no map type in json schema, instead we use an object type to present every single key value pair
+        const items = {
+            description: '',
+            properties: {} as any, // tslint:disable-line: no-any
+            required: [] as string[],
             type: 'object'
         };
-    }
-
-    if (property.schema['@type'] === 'Map') {
-        if (!(property.schema as MapSchema).mapKey || !(property.schema as MapSchema).mapValue) {
-            return;
-        }
-        return {
-            additionalProperties: true,
-            items: parseInterfaceMapTypePropertyItems(property),
-            required: null,
-            title: property.name,
-            type: 'array' // there is no map type in json schema, instead we use an array of object type to present it
+        // make mapKey as the first property of the object type, which is always a string
+        items.properties[(propertySchema as MapSchema).mapKey.name] = {
+            type: 'string'
         };
+        // make mapValue as the second property of the object type
+        items.properties[(propertySchema as MapSchema).mapValue.name] = parsedMapValue;
+        items.required.push(...[(propertySchema as MapSchema).mapKey.name, (propertySchema as MapSchema).mapValue.name]);
+        items.description = `Key of the map is: ${(propertySchema as MapSchema).mapKey.name}`;
+        return items;
     }
-
-    return {
-        required: null,
-        title: property.name,
-        type: 'string'
-    };
-};
-
-const parseInterfaceMapTypePropertyItems = (property: PropertyContent): ParsedJsonSchema => {
-    const parsedMapValue = parseInterfacePropertyHelper({...(property.schema as MapSchema).mapValue, '@type': null});
-
-    // there is no map type in json schema, instead we use an object type to present every single key value pair
-    const items = {
-        description: '',
-        properties: {} as any, // tslint:disable-line: no-any
-        required: [] as string[],
-        type: 'object'
-    };
-    // make mapKey as the first property of the object type, which is always a string
-    items.properties[(property.schema as MapSchema).mapKey.name] = {
-        type: 'string'
-    };
-    // make mapValue as the second property of the object type
-    items.properties[(property.schema as MapSchema).mapValue.name] = parsedMapValue;
-    items.required.push(...[(property.schema as MapSchema).mapKey.name, (property.schema as MapSchema).mapValue.name]);
-    items.description = `${property.name}'s key: ${(property.schema as MapSchema).mapKey.name}`;
-    return items;
-};
-
-// tslint:disable-next-line:cyclomatic-complexity
-const parseInterfaceCommandsHelper = (command: CommandContent, parseRequestSchema: boolean): ParsedJsonSchema => {
-    const commandSchema = parseRequestSchema ? command.request : command.response;
-
-    if (!commandSchema) { return; }
-
-    // add a dummy head for command request/response schema to make the recursion logic simpler
-    const dummyCommand: PropertyContent = {
-        '@type': ContentType.Command,
-        'name': commandSchema.name,
-        'schema': commandSchema.schema,
-    };
-
-    if (!dummyCommand || !dummyCommand.schema) { return; }
-    try {
-        return parseInterfacePropertyHelper(dummyCommand);
-    }
-    catch {
-        return;  // swallow the error and let UI render JSON editor for types which are not supported yet
-    }
-};
+}

--- a/src/app/shared/utils/mockModelDefinition.ts
+++ b/src/app/shared/utils/mockModelDefinition.ts
@@ -1,0 +1,140 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+// tslint:disable
+export const stringTypeWritableProperty = {
+    "@type": "Property",
+    "name": "property0",
+    "writable": true,
+    "schema": "string"
+};
+
+
+export const longTypeNonWritableProperty = {
+    "@type": "Property",
+    "name": "property1",
+    "schema": "long"
+};
+
+export const enumbTypeProperty = {
+    "@type": [
+        "Property",
+        "SemanticType/Humidity"
+    ],
+    "name": "state",
+    "displayName": "State",
+    "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+            {
+                "displayName": "Offline",
+                "name": "offline",
+                "enumValue": "1"
+            },
+            {
+                "displayName": "Online",
+                "name": "online",
+                "enumValue": "2"
+            }
+        ]
+    },
+    "writable": true
+};
+
+export const timeTypeCommand = {
+    "@type": "Command",
+    "name": "command",
+    "request": {
+        "name": "name0",
+        "schema": "datetime"
+    },
+    "response": {
+        "name": "name1",
+        "schema": "duration"
+    }
+};
+
+export const commandWithReusableSchema = {
+    "@type": [
+        "Command",
+        "SemanticType/Humidity"
+    ],
+    "name": "reboot2",
+    "commandType": "asynchronous",
+    "request": {
+        "name": "commandWithReusableSchema",
+        "schema": {
+            "@type": "Object",
+            "fields": [
+                {
+                    "name": "sensor0",
+                    "schema": "dtmi:example:schema;1"
+                },
+                {
+                    "name": "sensor1",
+                    "schema": "dtmi:example:schema;2"
+                }
+            ]
+        }
+    }
+};
+
+export const mapTypeTelemetry = {
+    "@type": "Telemetry",
+    "name": "telemetry",
+    "schema": {
+        "@type": "Map",
+        "mapKey": {
+            "name": "telemetryName",
+            "schema": "string"
+        },
+        "mapValue": {
+            "name": "telemetryConfig",
+            "schema": "date"
+        }
+    }
+};
+
+export const schema = [
+    {
+        "@id": "dtmi:example:schema;1",
+        "@type": "Object",
+        "fields": [
+            {
+                "name": "sensor0",
+                "schema": "time"
+            },
+            {
+                "name": "sensor1",
+                "schema": "integer"
+            },
+            {
+                "name": "sensor2",
+                "schema": "boolean"
+            }
+        ]
+    }
+];
+
+export const mockModelDefinition = {
+    "@id": "dtmi:contoso:com:EnvironmentalSensor;1",
+    "@type": "Interface",
+    "contents": [
+        {
+            ...stringTypeWritableProperty
+        },
+        {
+            ...longTypeNonWritableProperty
+        },
+        {
+            ...timeTypeCommand
+        },
+        {
+            ...mapTypeTelemetry
+        }
+    ],
+    "@context": "dtmi:dtdl:context;2"
+};
+// tslint:enable

--- a/src/app/shared/utils/twinAndJsonSchemaDataConverter.ts
+++ b/src/app/shared/utils/twinAndJsonSchemaDataConverter.ts
@@ -107,7 +107,7 @@ export const findPathsTowardsMapType = (
 };
 
 export const getNumberOfMapsInSchema = (settingSchema: ParsedJsonSchema): number => {
-    const hasMatch = JSON.stringify(settingSchema).match(/additionalProperties/g);
+    const hasMatch = settingSchema && JSON.stringify(settingSchema).match(/additionalProperties/g);
     return hasMatch ? hasMatch.length : 0;
 };
 


### PR DESCRIPTION
Implement dtdl reusable schema.
The **jsonSchemaAdaptor.ts** has switched from a set of utility funciton to an instantiable class. The reason being, during class instantiation, the class can store and parse the 'schemas' section of dtdl for future uses (example in **mockModelDefinition.ts**).
Most of the implemetation stays the same, while **parseInterfaceContentSchemaHelper** is extracted out from the old parseInterfacePropertyHelper, because of reusable schema definition in dtdl. The main change is in line 129, which utilize the 'reuse' capablity of json schema https://json-schema.org/understanding-json-schema/structuring.html#id1