### PR TITLE
fix custom event hub

### DIFF
--- a/src/app/api/parameters/deviceParameters.ts
+++ b/src/app/api/parameters/deviceParameters.ts
@@ -36,6 +36,7 @@ export interface MonitorEventsParameters {
     deviceId: string;
     consumerGroup: string;
 
+    customEventHubName?: string;
     customEventHubConnectionString?: string;
     hubConnectionString?: string;
 

--- a/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEvents.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEvents.spec.tsx.snap
@@ -56,16 +56,15 @@ exports[`components/devices/deviceEvents matches snapshot in electron 1`] = `
     underlined={true}
     value="$Default"
   />
-  <StyledTextFieldBase
-    ariaLabel="deviceEvents.customEventHub.label"
-    className="custom-event-hub-text-field"
+  <StyledToggleBase
+    ariaLabel="deviceEvents.toggleUseDefaultEventHub.label"
+    checked={true}
+    className="toggle-button"
     disabled={false}
-    errorMessage={false}
-    label="deviceEvents.customEventHub.label"
+    label="deviceEvents.toggleUseDefaultEventHub.label"
+    offText="deviceEvents.toggleUseDefaultEventHub.off"
     onChange={[Function]}
-    onRenderLabel={[Function]}
-    placeholder="deviceEvents.customEventHub.placeHolder"
-    underlined={true}
+    onText="deviceEvents.toggleUseDefaultEventHub.on"
   />
   <InfiniteScroll
     className="device-events-container"
@@ -156,16 +155,15 @@ exports[`components/devices/deviceEvents matches snapshot in hosted environment 
     underlined={true}
     value="$Default"
   />
-  <StyledTextFieldBase
-    ariaLabel="deviceEvents.customEventHub.label"
-    className="custom-event-hub-text-field"
+  <StyledToggleBase
+    ariaLabel="deviceEvents.toggleUseDefaultEventHub.label"
+    checked={true}
+    className="toggle-button"
     disabled={false}
-    errorMessage={false}
-    label="deviceEvents.customEventHub.label"
+    label="deviceEvents.toggleUseDefaultEventHub.label"
+    offText="deviceEvents.toggleUseDefaultEventHub.off"
     onChange={[Function]}
-    onRenderLabel={[Function]}
-    placeholder="deviceEvents.customEventHub.placeHolder"
-    underlined={true}
+    onText="deviceEvents.toggleUseDefaultEventHub.on"
   />
   <InfiniteScroll
     className="device-events-container"

--- a/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEventsPerInterface.spec.tsx.snap
+++ b/src/app/devices/deviceContent/components/deviceEvents/__snapshots__/deviceEventsPerInterface.spec.tsx.snap
@@ -131,13 +131,13 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
     value="$Default"
   />
   <StyledToggleBase
-    ariaLabel="deviceEvents.toggle.label"
+    ariaLabel="deviceEvents.toggleShowRawData.label"
     checked={false}
     className="toggle-button"
-    label="deviceEvents.toggle.label"
-    offText="deviceEvents.toggle.off"
+    label="deviceEvents.toggleShowRawData.label"
+    offText="deviceEvents.toggleShowRawData.off"
     onChange={[Function]}
-    onText="deviceEvents.toggle.on"
+    onText="deviceEvents.toggleShowRawData.on"
   />
   <InfiniteScroll
     className="device-events-container"
@@ -246,13 +246,13 @@ exports[`components/devices/deviceEventsPerInterface matches snapshot while inte
     value="$Default"
   />
   <StyledToggleBase
-    ariaLabel="deviceEvents.toggle.label"
+    ariaLabel="deviceEvents.toggleShowRawData.label"
     checked={false}
     className="toggle-button"
-    label="deviceEvents.toggle.label"
-    offText="deviceEvents.toggle.off"
+    label="deviceEvents.toggleShowRawData.label"
+    offText="deviceEvents.toggleShowRawData.off"
     onChange={[Function]}
-    onText="deviceEvents.toggle.on"
+    onText="deviceEvents.toggleShowRawData.on"
   />
   <InfiniteScroll
     className="device-events-container"

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEvents.spec.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEvents.spec.tsx
@@ -5,6 +5,7 @@
 import 'jest';
 import * as React from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { CommandBar } from 'office-ui-fabric-react/lib/CommandBar';
 import DeviceEventsComponent, { DeviceEventsState } from './deviceEvents';
 import { mountWithLocalization, testSnapshot } from '../../../../shared/utils/testHelpers';
@@ -28,6 +29,7 @@ describe('components/devices/deviceEvents', () => {
 
     const getComponent = (overrides = {}) => {
         const props = {
+            addNotification: jest.fn(),
             connectionString: '',
             ...routerProps,
             ...overrides,
@@ -77,12 +79,12 @@ describe('components/devices/deviceEvents', () => {
         expect((wrapper.state() as DeviceEventsState).consumerGroup).toEqual('testGroup');
     });
 
-    it('changes state accordingly when custom event hub connection string value is changed', () => {
+    it('changes state accordingly when custom event hub boolean value is changed', () => {
         const wrapper = mountWithLocalization(getComponent());
-        const textField = wrapper.find(TextField).at(1);
-        textField.instance().props.onChange({ target: null}, 'sb://testeventhub');
+        const toggle = wrapper.find(Toggle).at(0);
+        toggle.instance().props.onChange({ target: null}, false);
         wrapper.update();
-        expect((wrapper.state() as DeviceEventsState).customEventHubConnectionString).toEqual('sb://testeventhub');
+        expect((wrapper.state() as DeviceEventsState).useBuiltInEventHub).toBeFalsy();
     });
 
     it('renders events', () => {

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsContainer.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsContainer.tsx
@@ -3,9 +3,12 @@
  * Licensed under the MIT License
  **********************************************************/
 import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
 import { StateType } from '../../../../shared/redux/state';
-import DeviceEventsComponent, { DeviceEventsDataProps } from './deviceEvents';
+import DeviceEventsComponent, { DeviceEventsDataProps, DeviceEventsActionProps } from './deviceEvents';
 import { getActiveAzureResourceConnectionStringSelector } from '../../../../azureResource/selectors';
+import { addNotificationAction } from '../../../../notifications/actions';
+import { Notification } from '../../../../api/models/notification';
 
 const mapStateToProps = (state: StateType): DeviceEventsDataProps => {
     return {
@@ -13,4 +16,10 @@ const mapStateToProps = (state: StateType): DeviceEventsDataProps => {
     };
 };
 
-export default connect(mapStateToProps)(DeviceEventsComponent);
+const mapDispatchToProps = (dispatch: Dispatch): DeviceEventsActionProps => {
+    return {
+        addNotification: (notification: Notification) => dispatch(addNotificationAction.started(notification)),
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeviceEventsComponent);

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.spec.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.spec.tsx
@@ -31,6 +31,7 @@ describe('components/devices/deviceEventsPerInterface', () => {
 
     const refreshMock = jest.fn();
     const deviceEventsDispatchProps: DeviceEventsDispatchProps = {
+        addNotification: jest.fn(),
         refresh: refreshMock,
         setComponentName: jest.fn()
     };
@@ -56,6 +57,7 @@ describe('components/devices/deviceEventsPerInterface', () => {
     const telemetrySchema: TelemetrySchema[] = [{
         parsedSchema: {
             description: 'Temperature /Current temperature on the device',
+            required: null,
             title: 'temp',
             type: 'number'
         },

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterface.tsx
@@ -26,6 +26,7 @@ import { SynchronizationStatus } from '../../../../api/models/synchronizationSta
 import { DEFAULT_CONSUMER_GROUP } from '../../../../constants/apiConstants';
 import ErrorBoundary from '../../../errorBoundary';
 import { getLocalizedData } from '../../../../api/dataTransforms/modelDefinitionTransform';
+import { Notification, NotificationType } from '../../../../api/models/notification';
 import MultiLineShimmer from '../../../../shared/components/multiLineShimmer';
 import LabelWithTooltip from '../../../../shared/components/labelWithTooltip';
 import { MILLISECONDS_IN_MINUTE } from '../../../../constants/shared';
@@ -47,6 +48,7 @@ export interface DeviceEventsDataProps {
 }
 
 export interface DeviceEventsDispatchProps {
+    addNotification: (notification: Notification) => void;
     setComponentName: (id: string) => void;
     refresh: (deviceId: string, interfaceId: string) => void;
 }
@@ -227,10 +229,10 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
             <Toggle
                 className="toggle-button"
                 checked={this.state.showRawEvent}
-                ariaLabel={context.t(ResourceKeys.deviceEvents.toggle.label)}
-                label={context.t(ResourceKeys.deviceEvents.toggle.label)}
-                onText={context.t(ResourceKeys.deviceEvents.toggle.on)}
-                offText={context.t(ResourceKeys.deviceEvents.toggle.off)}
+                ariaLabel={context.t(ResourceKeys.deviceEvents.toggleShowRawData.label)}
+                label={context.t(ResourceKeys.deviceEvents.toggleShowRawData.label)}
+                onText={context.t(ResourceKeys.deviceEvents.toggleShowRawData.on)}
+                offText={context.t(ResourceKeys.deviceEvents.toggleShowRawData.off)}
                 onChange={this.changeToggle}
             />
         );
@@ -566,6 +568,18 @@ export default class DeviceEventsPerInterfaceComponent extends React.Component<D
                                 startTime: new Date()});
                             this.stopMonitoringIfNecessary();
                         }
+                    })
+                    .catch (error => {
+                        this.props.addNotification({
+                            text: {
+                                translationKey: ResourceKeys.deviceEvents.error,
+                                translationOptions: {
+                                    error
+                                }
+                            },
+                            type: NotificationType.error
+                        });
+                        this.stopMonitoringIfNecessary();
                     });
                 },
                 LOADING_LOCK);

--- a/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterfaceContainer.tsx
+++ b/src/app/devices/deviceContent/components/deviceEvents/deviceEventsPerInterfaceContainer.tsx
@@ -14,6 +14,8 @@ import { SynchronizationStatus } from '../../../../api/models/synchronizationSta
 import { setComponentNameAction, getModelDefinitionAction } from '../../actions';
 import { getActiveAzureResourceConnectionStringSelector } from '../../../../azureResource/selectors';
 import { getComponentNameFromQueryString } from '../../../../shared/utils/queryStringHelper';
+import { addNotificationAction } from '../../../../notifications/actions';
+import { Notification } from '../../../../api/models/notification';
 
 const mapStateToProps = (state: StateType, ownProps: RouteComponentProps): DeviceEventsDataProps => {
     return {
@@ -26,6 +28,7 @@ const mapStateToProps = (state: StateType, ownProps: RouteComponentProps): Devic
 
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>): DeviceEventsDispatchProps => {
     return {
+        addNotification: (notification: Notification) => dispatch(addNotificationAction.started(notification)),
         refresh: (deviceId: string, interfaceId: string) => dispatch(getModelDefinitionAction.started({digitalTwinId: deviceId, interfaceId})),
         setComponentName: (id: string) => dispatch(setComponentNameAction(id))
     };

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -563,10 +563,14 @@
             "tooltip": "Consumer groups are used by applications to pull data from the IoT Hub. To change the current consumer group, stop monitoring telemetry."
         },
         "customEventHub": {
-            "label": "Custom event hub connection string",
-            "tooltip": "If you want to monitor telemetry from a custom event hub, enter the event hub connection string and start monitoring. Otherwise leave it blank.",
-            "placeHolder": "Endpoint=sb://<FQDN>/;SharedAccessKeyName=<KeyName>;SharedAccessKey=<KeyValue>",
-            "error": "Event hub connection string format should look like 'Endpoint=sb://<FQDN>/;SharedAccessKeyName=<KeyName>;SharedAccessKey=<KeyValue>'"
+            "connectionString": {
+                "label": "Custom event hub connection string",
+                "placeHolder": "Endpoint=sb://<FQDN>/;SharedAccessKeyName=<KeyName>;SharedAccessKey=<KeyValue>",
+                "error": "Event hub connection string format should look like 'Endpoint=sb://<FQDN>/;SharedAccessKeyName=<KeyName>;SharedAccessKey=<KeyValue>'"
+            },
+            "name": {
+                "label": "Custom event hub name"
+            }
         },
         "headerText": "Telemetry",
         "noEvent": "ComponentName {{componentName}} contains no telemetry definitions",
@@ -599,11 +603,17 @@
                 }
             }
         },
-        "toggle": {
+        "toggleShowRawData": {
             "label": "Show raw telemetry data",
             "on": "On",
             "off": "Off"
-        }
+        },
+        "toggleUseDefaultEventHub": {
+            "label": "Use built-in event hub",
+            "on": "Yes",
+            "off": "No"
+        },
+        "error": "Failed to monitor events. {{error}}"
     },
     "directMethod": {
         "headerText": "Direct method",

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -288,11 +288,16 @@ export class ResourceKeys {
          tooltip : "deviceEvents.consumerGroups.tooltip",
       },
       customEventHub : {
-         error : "deviceEvents.customEventHub.error",
-         label : "deviceEvents.customEventHub.label",
-         placeHolder : "deviceEvents.customEventHub.placeHolder",
-         tooltip : "deviceEvents.customEventHub.tooltip",
+         connectionString : {
+            error : "deviceEvents.customEventHub.connectionString.error",
+            label : "deviceEvents.customEventHub.connectionString.label",
+            placeHolder : "deviceEvents.customEventHub.connectionString.placeHolder",
+         },
+         name : {
+            label : "deviceEvents.customEventHub.name.label",
+         },
       },
+      error : "deviceEvents.error",
       event : {
          body : "deviceEvents.event.body",
          enqueuedTime : "deviceEvents.event.enqueuedTime",
@@ -307,10 +312,15 @@ export class ResourceKeys {
          placeHolder : "deviceEvents.interfaceDropDown.placeHolder",
       },
       noEvent : "deviceEvents.noEvent",
-      toggle : {
-         label : "deviceEvents.toggle.label",
-         off : "deviceEvents.toggle.off",
-         on : "deviceEvents.toggle.on",
+      toggleShowRawData : {
+         label : "deviceEvents.toggleShowRawData.label",
+         off : "deviceEvents.toggleShowRawData.off",
+         on : "deviceEvents.toggleShowRawData.on",
+      },
+      toggleUseDefaultEventHub : {
+         label : "deviceEvents.toggleUseDefaultEventHub.label",
+         off : "deviceEvents.toggleUseDefaultEventHub.off",
+         on : "deviceEvents.toggleUseDefaultEventHub.on",
       },
       tooltip : "deviceEvents.tooltip",
    };

--- a/src/server/serverBase.ts
+++ b/src/server/serverBase.ts
@@ -21,7 +21,7 @@ const receivers: ReceiveHandler[] = [];
 const IOTHUB_CONNECTION_DEVICE_ID = 'iothub-connection-device-id';
 
 let client: EventHubClient = null;
-let connectionString: string = '';
+let connectionString: string = ''; // would be the same as connection string or in the format of `${connectionString}/${hubName}`
 let eventHubClientStopping = false;
 
 interface Message {
@@ -212,15 +212,14 @@ export const eventHubProvider = async (res: any, body: any) =>  { // tslint:disa
         if (!eventHubClientStopping) {
             if (!client ||
                 body.hubConnectionString && body.hubConnectionString !== connectionString  ||
-                body.customEventHubConnectionString && body.customEventHubConnectionString !== connectionString)
+                body.customEventHubConnectionString && `${body.customEventHubConnectionString}/${body.customEventHubName}` !== connectionString)
             {
-
                 client = body.customEventHubConnectionString ?
-                    await EventHubClient.createFromConnectionString(body.customEventHubConnectionString) :
+                    await EventHubClient.createFromConnectionString(body.customEventHubConnectionString, body.customEventHubName) :
                     await EventHubClient.createFromIotHubConnectionString(body.hubConnectionString);
 
                 connectionString = body.customEventHubConnectionString ?
-                    body.customEventHubConnectionString :
+                    `${body.customEventHubConnectionString}/${body.customEventHubName}` :
                     body.hubConnectionString;
             }
 


### PR DESCRIPTION
Addressing issue #257 
The event hub sdk had the 'entity path' (which is event hub name) parameter specified as optional paratemeter, but it is actually required.
Added another input for users to input custom event hub name.