### PR TITLE
address a few bugs opened

### DIFF
--- a/src/app/connectionStrings/components/__snapshots__/connectionStringEditView.spec.tsx.snap
+++ b/src/app/connectionStrings/components/__snapshots__/connectionStringEditView.spec.tsx.snap
@@ -30,6 +30,11 @@ exports[`ConnectionStringEdit matches snapshot in Add Scenario 1`] = `
     >
       connectivityPane.connectionStringComboBox.linkText
     </StyledLinkBase>
+    <div>
+      <span>
+        connectivityPane.connectionStringComboBox.warning
+      </span>
+    </div>
   </div>
 </StyledPanelBase>
 `;
@@ -64,6 +69,11 @@ exports[`ConnectionStringEdit matches snapshot in Edit / invalid scenario 1`] = 
     >
       connectivityPane.connectionStringComboBox.linkText
     </StyledLinkBase>
+    <div>
+      <span>
+        connectivityPane.connectionStringComboBox.warning
+      </span>
+    </div>
   </div>
 </StyledPanelBase>
 `;
@@ -98,6 +108,11 @@ exports[`ConnectionStringEdit matches snapshot in Edit / valid scenario 1`] = `
     >
       connectivityPane.connectionStringComboBox.linkText
     </StyledLinkBase>
+    <div>
+      <span>
+        connectivityPane.connectionStringComboBox.warning
+      </span>
+    </div>
   </div>
 </StyledPanelBase>
 `;
@@ -132,6 +147,11 @@ exports[`ConnectionStringEdit matches snapshot in Edit Scenario 1`] = `
     >
       connectivityPane.connectionStringComboBox.linkText
     </StyledLinkBase>
+    <div>
+      <span>
+        connectivityPane.connectionStringComboBox.warning
+      </span>
+    </div>
   </div>
 </StyledPanelBase>
 `;

--- a/src/app/connectionStrings/components/connectionStringEditView.scss
+++ b/src/app/connectionStrings/components/connectionStringEditView.scss
@@ -2,26 +2,25 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
- .connection-string-edit-header {
-    margin-left: 20px;
-    margin-right: 20px;
- }
-
- .connection-string-edit-body {
-    margin-right: 20px;
-    margin-left: 20px;
-    .details {
-       margin-top: 10px;
-    }
- }
-
- .connection-string-edit-footer {
-    display: flex;
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-bottom: 10px;
-    button {
-        margin-right: 10px;
-    }
+.connection-string-edit-header {
+   margin-left: 20px;
+   margin-right: 20px;
 }
 
+.connection-string-edit-body {
+   margin-right: 20px;
+   margin-left: 20px;
+   .details {
+      margin-top: 10px;
+   }
+}
+
+.connection-string-edit-footer {
+   display: flex;
+   margin-left: 20px;
+   margin-right: 20px;
+   margin-bottom: 10px;
+   button {
+      margin-right: 10px;
+   }
+}

--- a/src/app/connectionStrings/components/connectionStringEditView.tsx
+++ b/src/app/connectionStrings/components/connectionStringEditView.tsx
@@ -143,6 +143,9 @@ export const ConnectionStringEditView: React.FC<ConnectionStringEditViewProps> =
                 >
                     {t(ResourceKeys.connectivityPane.connectionStringComboBox.linkText)}
                 </Link>
+                <div>
+                    <span>{t(ResourceKeys.connectivityPane.connectionStringComboBox.warning)}</span>
+                </div>
                 {showProperties() &&
                     <div className="details">
                         <ConnectionStringProperties

--- a/src/app/constants/iconNames.ts
+++ b/src/app/constants/iconNames.ts
@@ -32,6 +32,7 @@ export const DIRECT_METHOD = 'Remote';
 export const CLOUD_TO_DEVICE_MESSAGE = 'Mail';
 export const ITEM = 'LocationDot';
 export const NAVIGATE_BACK = 'NavigateBack';
+export const REPO = 'Repo';
 export const UNDO = 'Undo';
 
 export enum GroupedList {

--- a/src/app/modelRepository/components/__snapshots__/modelRepositoryLocationView.spec.tsx.snap
+++ b/src/app/modelRepository/components/__snapshots__/modelRepositoryLocationView.spec.tsx.snap
@@ -39,6 +39,7 @@ exports[`modelRepositoryLocationView matches snapshot when locations greater tha
           },
           Object {
             "ariaLabel": "modelRepository.commands.add.ariaLabel",
+            "disabled": false,
             "iconProps": Object {
               "iconName": "Add",
             },
@@ -48,6 +49,9 @@ exports[`modelRepositoryLocationView matches snapshot when locations greater tha
                 Object {
                   "ariaLabel": "modelRepository.commands.addPublicSource.ariaLabel",
                   "disabled": true,
+                  "iconProps": Object {
+                    "iconName": "Repo",
+                  },
                   "key": "PUBLIC",
                   "onClick": [Function],
                   "text": "modelRepository.commands.addPublicSource.label",
@@ -55,6 +59,9 @@ exports[`modelRepositoryLocationView matches snapshot when locations greater tha
                 Object {
                   "ariaLabel": "modelRepository.commands.addLocalSource.ariaLabel",
                   "disabled": true,
+                  "iconProps": Object {
+                    "iconName": "OpenFolderHorizontal",
+                  },
                   "key": "LOCAL",
                   "onClick": [Function],
                   "text": "modelRepository.commands.addLocalSource.labelInBrowser",
@@ -146,6 +153,7 @@ exports[`modelRepositoryLocationView matches snapshot when no locations 1`] = `
           },
           Object {
             "ariaLabel": "modelRepository.commands.add.ariaLabel",
+            "disabled": false,
             "iconProps": Object {
               "iconName": "Add",
             },
@@ -155,6 +163,9 @@ exports[`modelRepositoryLocationView matches snapshot when no locations 1`] = `
                 Object {
                   "ariaLabel": "modelRepository.commands.addPublicSource.ariaLabel",
                   "disabled": false,
+                  "iconProps": Object {
+                    "iconName": "Repo",
+                  },
                   "key": "PUBLIC",
                   "onClick": [Function],
                   "text": "modelRepository.commands.addPublicSource.label",
@@ -162,6 +173,9 @@ exports[`modelRepositoryLocationView matches snapshot when no locations 1`] = `
                 Object {
                   "ariaLabel": "modelRepository.commands.addLocalSource.ariaLabel",
                   "disabled": true,
+                  "iconProps": Object {
+                    "iconName": "OpenFolderHorizontal",
+                  },
                   "key": "LOCAL",
                   "onClick": [Function],
                   "text": "modelRepository.commands.addLocalSource.labelInBrowser",

--- a/src/app/modelRepository/components/modelRepositoryLocationView.tsx
+++ b/src/app/modelRepository/components/modelRepositoryLocationView.tsx
@@ -18,7 +18,7 @@ import { REPOSITORY_LOCATION_TYPE } from '../../constants/repositoryLocationType
 import { appConfig, HostMode } from '../../../appConfig/appConfig';
 import { StringMap } from '../../api/models/stringMap';
 import { ROUTE_PARAMS } from '../../constants/routes';
-import { SAVE, ADD, UNDO, HELP, NAVIGATE_BACK } from '../../constants/iconNames';
+import { SAVE, ADD, UNDO, HELP, NAVIGATE_BACK, REPO, FOLDER } from '../../constants/iconNames';
 import { ModelRepositoryInstruction } from './modelRepositoryInstruction';
 import '../../css/_layouts.scss';
 
@@ -53,6 +53,7 @@ export const ModelRepositoryLocationView: React.FC<ModelRepositoryLocationViewPr
             },
             {
                 ariaLabel: t(ResourceKeys.modelRepository.commands.add.ariaLabel),
+                disabled: repositoryLocationSettings.length === addItems.length,
                 iconProps: { iconName: ADD },
                 key: 'add',
                 subMenuProps: {
@@ -104,13 +105,19 @@ export const ModelRepositoryLocationView: React.FC<ModelRepositoryLocationViewPr
             {
                 ariaLabel: t(ResourceKeys.modelRepository.commands.addPublicSource.ariaLabel),
                 disabled: repositoryLocationSettings.some(item => item.repositoryLocationType === REPOSITORY_LOCATION_TYPE.Public),
+                iconProps: {
+                    iconName: REPO
+                },
                 key: REPOSITORY_LOCATION_TYPE.Public,
                 onClick: onAddRepositoryLocationPublic,
-                text: t(ResourceKeys.modelRepository.commands.addPublicSource.label)
+                text: t(ResourceKeys.modelRepository.commands.addPublicSource.label),
             },
             {
                 ariaLabel: t(ResourceKeys.modelRepository.commands.addLocalSource.ariaLabel),
                 disabled: hostModeNotElectron || repositoryLocationSettings.some(item => item.repositoryLocationType === REPOSITORY_LOCATION_TYPE.Local),
+                iconProps: {
+                    iconName: FOLDER
+                },
                 key: REPOSITORY_LOCATION_TYPE.Local,
                 onClick: onAddRepositoryLocationLocal,
                 text: t(hostModeNotElectron ?

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -231,7 +231,8 @@
                 "required": "Connection string is required",
                 "invalid": "Invalid connection string"
             },
-            "prompt": "Select a saved connection string or paste a new connection string here"
+            "prompt": "Select a saved connection string or paste a new connection string here",
+            "warning": "Please do not save your hub connection string to any unsafe locations"
         },
         "notes": "The most recent connection strings will be saved in application storage. You can open Settings at any time to remove saved connection strings or change other configuration options.",
         "saveButton": {
@@ -772,7 +773,7 @@
         "getDigitalTwinOnError": "Failed to get properties of the IoT Plug and Play device {{deviceId}}: {{error}}",
         "getModuleIdentitiesOnError": "Failed to get module identities of device {{deviceId}}: {{error}}",
         "getInterfaceModelOnError": "Failed to get interface model definition {{interfaceId}} from any of the sources configured",
-        "parseLocalInterfaceModelOnError": "{{interfaceId}} cannot be retrieved from local folder. The following json files in the local folder are invalid and cannot be parsed: {{files}}. Please note that trailing comma is not allowed in json files.",
+        "parseLocalInterfaceModelOnError": "{{interfaceId}} cannot be retrieved from local folder. Here is a list of json files with errors that we encountered while parsing: {{files}}. Please note that trailing comma is not allowed in json files.",
         "updateDeviceTwinOnError": "Failed to update device twin on device {{deviceId}}: {{error}}",
         "updateDeviceTwinOnSuccess": "Successfully updated device twin on device {{deviceId}}.",
         "invokeDigitalTwinCommandOnError": "Failed to invoke the IoT Plug and Play device command '{{commandName}}' for component '{{componentName}}' on device '{{deviceId}}': {{error}}",

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -210,6 +210,7 @@ export class ResourceKeys {
          link : "connectivityPane.connectionStringComboBox.link",
          linkText : "connectivityPane.connectionStringComboBox.linkText",
          prompt : "connectivityPane.connectionStringComboBox.prompt",
+         warning : "connectivityPane.connectionStringComboBox.warning",
       },
       dropDown : {
          copyButton : "connectivityPane.dropDown.copyButton",

--- a/src/server/serverBase.ts
+++ b/src/server/serverBase.ts
@@ -102,8 +102,8 @@ const findMatchingFile = (filePath: string, fileNames: string[], expectedFileNam
                     return data;
                 }
             }
-            catch {
-                filesWithParsingError.push(fileName); // swallow error and continue the loop
+            catch (error) {
+                filesWithParsingError.push(`${fileName}: ${error.message}`); // swallow error and continue the loop
             }
         }
     }


### PR DESCRIPTION
1. Security review request: text to warn user while copying hub cs to use in the app
2. User was not able to clearly tell model repo source cannot be added 
3. User wanted to see detailed parsing error while retrieving model definition from local folder