### PR TITLE
update dataplane api version

### DIFF
--- a/src/app/api/services/devicesService.ts
+++ b/src/app/api/services/devicesService.ts
@@ -16,7 +16,6 @@ import {
 } from '../parameters/deviceParameters';
 import { CONTROLLER_API_ENDPOINT,
     EVENTHUB,
-    DIGITAL_TWIN_API_VERSION,
     MONITOR,
     STOP,
     HEADERS,

--- a/src/app/constants/apiConstants.ts
+++ b/src/app/constants/apiConstants.ts
@@ -28,10 +28,9 @@ export const PUBLIC_REPO_HOSTNAME = 'repo.azureiotrepository.com';
 export const MONITOR = '/monitor';
 export const STOP = '/stop';
 
-export const DIGITAL_TWIN_API_VERSION = '2019-07-01-preview';
 export const DIGITAL_TWIN_API_VERSION_PREVIEW = '2020-05-31-preview';
 export const MODEL_REPO_API_VERSION = '2020-05-01-preview';
-export const HUB_DATA_PLANE_API_VERSION = '2019-10-01';
+export const HUB_DATA_PLANE_API_VERSION = '2020-06-30-preview';
 
 export const HEADERS = {
     CONTINUATION_TOKEN: 'x-ms-continuation',


### PR DESCRIPTION
new dataplane api version to allow showing model id from device twin