### PR TITLE
remove replace op for dt patch

### DIFF
--- a/src/app/api/parameters/deviceParameters.ts
+++ b/src/app/api/parameters/deviceParameters.ts
@@ -58,7 +58,6 @@ export interface FetchDigitalTwinParameters {
 
 export enum JsonPatchOperation {
     ADD = 'add',
-    REPLACE = 'replace',
     REMOVE = 'remove'
 }
 

--- a/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
+++ b/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
@@ -217,8 +217,7 @@ export const DeviceSettingsPerInterfacePerSetting: React.FC<DeviceSettingDataPro
             const path = componentName === DEFAULT_COMPONENT_FOR_DIGITAL_TWIN ?
                 `/${settingModelDefinition.name}` : `/${componentName}/${settingModelDefinition.name}`;
             const patchPayloadWithTwin = isValueDefined(twin) ? {
-                op: metadata && metadata.desiredValue ?
-                    JsonPatchOperation.REPLACE : JsonPatchOperation.ADD,
+                op: JsonPatchOperation.ADD,
                 path,
                 value: twin,
             } : {


### PR DESCRIPTION
To keep update todate with the service change, the 'add' patch operation is now able to smartly determine if its an add or replace when component is already added in the twin. We will simply not use 'replace' operation from now on.