### PR TITLE
bug bash fixes round 1

### DIFF
--- a/src/app/css/_deviceDetail.scss
+++ b/src/app/css/_deviceDetail.scss
@@ -16,6 +16,9 @@
 
 .method-payload{
     padding-top: 10px;
+    .payload-input {
+        margin-bottom: 20px;
+    }
 }
 
 .direct-method-json-editor {
@@ -55,6 +58,9 @@
         @include themify($themes) {
             color: themed('linkColor');
         }
+    }
+    .no-device {
+        padding-left: 25px;
     }
 }
 

--- a/src/app/css/_deviceSettings.scss
+++ b/src/app/css/_deviceSettings.scss
@@ -40,8 +40,3 @@ span[class^='status-'] {
     max-width: 40%;
     min-width: 20px;
 }
-.reported-status-error {
-    @include themify($themes) {
-        color: themed('errorText');
-    }
-}

--- a/src/app/devices/addDevice/components/addDevice.tsx
+++ b/src/app/devices/addDevice/components/addDevice.tsx
@@ -20,12 +20,13 @@ import { MaskedCopyableTextField } from '../../../shared/components/maskedCopyab
 import { useAsyncSagaReducer } from '../../../shared/hooks/useAsyncSagaReducer';
 import { SynchronizationStatus } from '../../../api/models/synchronizationStatus';
 import { SAVE, CANCEL } from '../../../constants/iconNames';
-import '../../../css/_addDevice.scss';
-import '../../../css/_layouts.scss';
 import { addDeviceSaga } from '../saga';
 import { addDeviceReducer } from '../reducer';
 import { addDeviceStateInitial } from '../state';
 import { addDeviceAction } from '../actions';
+import { ROUTE_PARTS, ROUTE_PARAMS } from '../../../constants/routes';
+import '../../../css/_addDevice.scss';
+import '../../../css/_layouts.scss';
 
 const initialKeyValue = {
     error: '',
@@ -55,7 +56,7 @@ export const AddDevice: React.FC = () => {
     },              [synchronizationStatus]);
 
     const navigateToDeviceList = () => {
-        const path = pathname.replace(/\/add/, ``);
+        const path = pathname.replace(/\/add/, `/${ROUTE_PARTS.DEVICE_DETAIL}/${ROUTE_PARTS.IDENTITY}/?${ROUTE_PARAMS.DEVICE_ID}=${device.id}`);
         history.push(path);
     };
 

--- a/src/app/devices/cloudToDeviceMessage/components/__snapshots__/cloudToDeviceMessage.spec.tsx.snap
+++ b/src/app/devices/cloudToDeviceMessage/components/__snapshots__/cloudToDeviceMessage.spec.tsx.snap
@@ -31,16 +31,12 @@ exports[`cloudToDeviceMessage matches snapshot 1`] = `
     >
       cloudToDeviceMessage.body
     </Component>
-    <div
+    <StyledTextFieldBase
       className="cloud-to-device-message-text-field"
-    >
-      <StyledTextFieldBase
-        className="cloud-to-device-message-text-field"
-        multiline={true}
-        onChange={[Function]}
-        rows={5}
-      />
-    </div>
+      multiline={true}
+      onChange={[Function]}
+      rows={5}
+    />
     <StyledCheckboxBase
       ariaLabel="cloudToDeviceMessage.addTimestamp"
       label="cloudToDeviceMessage.addTimestamp"

--- a/src/app/devices/cloudToDeviceMessage/components/cloudToDeviceMessage.tsx
+++ b/src/app/devices/cloudToDeviceMessage/components/cloudToDeviceMessage.tsx
@@ -197,9 +197,7 @@ export const CloudToDeviceMessage: React.FC = () => {
                 >
                     {t(ResourceKeys.cloudToDeviceMessage.body)}
                 </LabelWithTooltip>
-                <div className="cloud-to-device-message-text-field">
-                    <TextField className="cloud-to-device-message-text-field" multiline={true} rows={textFieldRows} onChange={onTextFieldChange}/>
-                </div>
+                <TextField className="cloud-to-device-message-text-field" multiline={true} rows={textFieldRows} onChange={onTextFieldChange}/>
                 <Checkbox
                     label={t(ResourceKeys.cloudToDeviceMessage.addTimestamp)}
                     ariaLabel={t(ResourceKeys.cloudToDeviceMessage.addTimestamp)}

--- a/src/app/devices/deviceList/components/deviceList.tsx
+++ b/src/app/devices/deviceList/components/deviceList.tsx
@@ -104,7 +104,7 @@ export const DeviceList: React.FC = () => {
                                 />
                             </MarqueeSelection> :
                             <>
-                                <h3>{t(ResourceKeys.deviceLists.noDevice)}</h3>
+                                <span className="no-device">{t(ResourceKeys.deviceLists.noDevice)}</span>
                                 <Announced
                                     message={t(ResourceKeys.deviceLists.noDevice)}
                                 />

--- a/src/app/devices/directMethod/actions.ts
+++ b/src/app/devices/directMethod/actions.ts
@@ -12,6 +12,6 @@ export interface InvokeMethodActionParameters {
     connectTimeoutInSeconds: number;
     deviceId: string;
     methodName: string;
-    payload?: object;
+    payload?: string;
     responseTimeoutInSeconds: number;
 }

--- a/src/app/devices/directMethod/components/__snapshots__/directMethod.spec.tsx.snap
+++ b/src/app/devices/directMethod/components/__snapshots__/directMethod.spec.tsx.snap
@@ -42,10 +42,11 @@ exports[`directMethod matches snapshot 1`] = `
       >
         directMethod.payload
       </Component>
-      <Component
-        className="direct-method-json-editor"
-        content=""
+      <StyledTextFieldBase
+        className="payload-input"
+        multiline={true}
         onChange={[Function]}
+        rows={5}
       />
       <Component
         tooltipText="directMethod.connectionTimeoutTooltip"

--- a/src/app/devices/directMethod/components/directMethod.tsx
+++ b/src/app/devices/directMethod/components/directMethod.tsx
@@ -8,12 +8,10 @@ import { useLocation } from 'react-router-dom';
 import { TextField } from 'office-ui-fabric-react/lib/components/TextField';
 import { CommandBar } from 'office-ui-fabric-react/lib/components/CommandBar';
 import { Slider } from 'office-ui-fabric-react/lib/components/Slider';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/components/Spinner';
 import { ResourceKeys } from '../../../../localization/resourceKeys';
 import { getDeviceIdFromQueryString } from '../../../shared/utils/queryStringHelper';
 import { DIRECT_METHOD } from '../../../constants/iconNames';
 import { LabelWithTooltip } from '../../../shared/components/labelWithTooltip';
-import { useThemeContext } from '../../../shared/contexts/themeContext';
 import { HeaderView } from '../../../shared/components/headerView';
 import { useAsyncSagaReducer } from '../../../shared/hooks/useAsyncSagaReducer';
 import { JSONEditor } from '../../../shared/components/jsonEditor';
@@ -26,7 +24,6 @@ const DEFAULT_TIMEOUT = 10;
 
 export const DirectMethod: React.FC = () => {
     const { t } = useTranslation();
-    const { editorTheme } = useThemeContext();
     const { search } = useLocation();
     const deviceId = getDeviceIdFromQueryString(search);
 
@@ -54,14 +51,13 @@ export const DirectMethod: React.FC = () => {
         );
     };
 
-    const formReady = (): boolean => !!methodName && (!payload || isValidJson(payload));
-
-    const isValidJson = (content: string) => {
+    const formReady = (): boolean => !!methodName;
+    const getPayload = (content: string) => {
+        // payload could be json or simply string
         try {
-            JSON.parse(content);
-            return true;
+            return JSON.parse(content);
         } catch {
-            return false;
+            return content;
         }
     };
 
@@ -70,7 +66,7 @@ export const DirectMethod: React.FC = () => {
             connectTimeoutInSeconds: connectionTimeOut,
             deviceId,
             methodName,
-            payload: payload ? JSON.parse(payload) : {},
+            payload: getPayload(payload),
             responseTimeoutInSeconds: responseTimeOut
         }));
     };
@@ -89,6 +85,7 @@ export const DirectMethod: React.FC = () => {
     };
 
     const renderMethodsPayloadSection = () => {
+        const textFieldRows = 5;
         return (
             <div className="method-payload">
                 <LabelWithTooltip
@@ -96,11 +93,7 @@ export const DirectMethod: React.FC = () => {
                 >
                     {t(ResourceKeys.directMethod.payload)}
                 </LabelWithTooltip>
-                <JSONEditor
-                    className="direct-method-json-editor"
-                    content={payload}
-                    onChange={onEditorChange}
-                />
+                <TextField className="payload-input" multiline={true} rows={textFieldRows} onChange={onTextFieldChange}/>
                 <LabelWithTooltip
                     tooltipText={t(ResourceKeys.directMethod.connectionTimeoutTooltip)}
                 >
@@ -129,7 +122,7 @@ export const DirectMethod: React.FC = () => {
         );
     };
 
-    const onEditorChange = (value: string) => setPayload(value);
+    const onTextFieldChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newText: string) => setPayload(newText);
 
     const onConnectionTimeoutChange = (value: number) => {
         setConnectionTimeOut(value);

--- a/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
+++ b/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
@@ -111,12 +111,6 @@ export const DeviceSettingsPerInterfacePerSetting: React.FC<DeviceSettingDataPro
                     <Stack.Item align="start">
                         {t(ResourceKeys.deviceSettings.ackStatus.version, {version: metadata && metadata.ackVersion || '--'})}
                     </Stack.Item>
-                    {/* if reported twin has value but metadata ack code or ack version is not provided, show conformant error*/}
-                    {(isValueDefined(props.reportedTwin) && (!metadata || !metadata.ackCode || !metadata.ackVersion)) &&
-                        <Stack.Item align="start" className="reported-status-error">
-                            {t(ResourceKeys.deviceSettings.ackStatus.error)}
-                        </Stack.Item>
-                    }
                 </Stack>
             </div>
         );

--- a/src/app/devices/pnp/components/digitalTwinInterfacesList.spec.tsx
+++ b/src/app/devices/pnp/components/digitalTwinInterfacesList.spec.tsx
@@ -8,7 +8,7 @@ import { mount, shallow } from 'enzyme';
 import { Label } from 'office-ui-fabric-react/lib/components/Label';
 import { Announced } from 'office-ui-fabric-react/lib/components/Announced';
 import { MessageBar } from 'office-ui-fabric-react/lib/components/MessageBar';
-import { Pivot } from 'office-ui-fabric-react/lib/components/Pivot';
+import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/components/Pivot';
 import { DigitalTwinInterfacesList } from './digitalTwinInterfacesList';
 import { ResourceKeys } from '../../../../localization/resourceKeys';
 import { MultiLineShimmer } from '../../../shared/components/multiLineShimmer';
@@ -216,5 +216,8 @@ describe('DigitalTwinInterfacesList', () => {
         expect((list.props() as any).items[0].interfaceId).toEqual('dtmi:__DeviceManagement:DeviceInformation;1'); // tslint:disable-line:no-any
         expect((list.props() as any).items[1].interfaceId).toEqual('dtmi:__Client:SDKInformation;1'); // tslint:disable-line:no-magic-numbers, no-any
         expect((list.props() as any).items[2].interfaceId).toEqual('dtmi:__Contoso:EnvironmentalSensor;1'); // tslint:disable-line:no-magic-numbers, no-any
+
+        // tslint:disable-next-line: no-magic-numbers
+        expect(wrapper.find(PivotItem)).toHaveLength(3);
     });
 });

--- a/src/app/devices/pnp/components/digitalTwinInterfacesList.tsx
+++ b/src/app/devices/pnp/components/digitalTwinInterfacesList.tsx
@@ -178,6 +178,12 @@ export const DigitalTwinInterfacesList: React.FC = () => {
                             content={JSON.stringify(modelDefinitionWithSource.modelDefinition, null, '\t')}
                         />
                     </PivotItem>
+                    <PivotItem headerText={t(ResourceKeys.digitalTwin.pivot.digitalTwin)}>
+                        <JSONEditor
+                            className="interface-definition-json-editor"
+                            content={JSON.stringify(digitalTwin, null, '\t')}
+                        />
+                    </PivotItem>
                 </Pivot>
             </>
         );

--- a/src/app/devices/shared/components/__snapshots__/dataForm.spec.tsx.snap
+++ b/src/app/devices/shared/components/__snapshots__/dataForm.spec.tsx.snap
@@ -101,7 +101,8 @@ exports[`dataForm matches snapshot with unsupported type 1`] = `
     </Component>
     <Component
       className="json-editor"
-      content={123}
+      content="123"
+      onChange={[Function]}
     />
     <CustomizedPrimaryButton
       className="submit-button"

--- a/src/app/devices/shared/components/complexReportedFormPanel.tsx
+++ b/src/app/devices/shared/components/complexReportedFormPanel.tsx
@@ -31,14 +31,8 @@ export interface ReportedFormActionProps {
     handleDismiss: () => void;
 }
 
-export interface ReportedFormState {
-    formData: any; // tslint:disable-line:no-any
-    parseMapTypeError?: Exception;
-}
-
 export const ComplexReportedFormPanel: React.FC<ReportedFormDataProps & ReportedFormActionProps> = (props: ReportedFormDataProps & ReportedFormActionProps) => {
     const { t } = useTranslation();
-    const { editorTheme } = useThemeContext();
 
     const { schema, modelDefinition, showPanel } = props;
     const twinData = twinToFormDataConverter(props.formData, schema);
@@ -56,7 +50,7 @@ export const ComplexReportedFormPanel: React.FC<ReportedFormDataProps & Reported
     };
 
     const createForm = () => {
-        if (parseMapTypeError || !schema) { // Not able to parse interface definition, render raw json editor instead
+        if (parseMapTypeError || !schema || !schema.type) { // Not able to parse interface definition, render raw json editor instead
             return createJsonEditor();
         }
         else {
@@ -83,7 +77,7 @@ export const ComplexReportedFormPanel: React.FC<ReportedFormDataProps & Reported
         return (
             <form>
                 <Label>{t(ResourceKeys.deviceProperties.editor.label, {schema: getSettingSchema()})}</Label>
-                <JSONEditor className="json-editor" content={formData}/>
+                <JSONEditor className="json-editor" content={JSON.stringify(formData, null, '\t')}/>
             </form>
         );
     };

--- a/src/app/devices/shared/components/dataForm.tsx
+++ b/src/app/devices/shared/components/dataForm.tsx
@@ -33,14 +33,6 @@ export interface DataFormActionProps {
     craftPayload?: (payload: object) => object;
 }
 
-export interface DataFormState {
-    formData: any; // tslint:disable-line:no-any
-    originalFormData: any; // tslint:disable-line:no-any
-    stringifiedFormData: string;
-    parseMapTypeError?: Exception;
-    showPayloadDialog?: boolean;
-    payloadPreviewData?: any; // tslint:disable-line: no-any
-}
 export const DataForm: React.FC<DataFormDataProps & DataFormActionProps> = (props: DataFormDataProps & DataFormActionProps) => {
     const { t } = useTranslation();
 
@@ -48,10 +40,11 @@ export const DataForm: React.FC<DataFormDataProps & DataFormActionProps> = (prop
     const twinData = twinToFormDataConverter(props.formData, settingSchema);
     const originalFormData = twinData.formData;
     const [ formData, setFormData ] = React.useState(originalFormData);
+    const [ jsonEditorData, setJsonEditorData ] = React.useState(JSON.stringify(originalFormData || {}, null, '\t'));
     const [ showPayloadDialog, setShowPlayloadDialog ] = React.useState<boolean>(false);
     const parseMapTypeError = twinData.error;
     const [ payloadPreviewData, setPayloadPreviewData ] = React.useState(undefined);
-    const [ stringifiedFormData ] = React.useState(JSON.stringify(twinData.formData, null, '\t'));
+    const [ isPayloadValid, setIsPayloadValid ] = React.useState<boolean>(true);
 
     const renderDialog = () => {
         return (
@@ -94,7 +87,7 @@ export const DataForm: React.FC<DataFormDataProps & DataFormActionProps> = (prop
     };
 
     const createForm = () => {
-        if (parseMapTypeError || !settingSchema) { // Not able to parse interface definition, render raw json in editor instead
+        if (parseMapTypeError || !settingSchema || !settingSchema.type) { // Not able to parse interface definition, render raw json in editor instead
             return createJsonEditor();
         }
         else {
@@ -130,10 +123,21 @@ export const DataForm: React.FC<DataFormDataProps & DataFormActionProps> = (prop
                 >
                     {t(ResourceKeys.deviceContent.value)}
                 </LabelWithTooltip>
-                <JSONEditor className="json-editor" content={stringifiedFormData ? JSON.parse(stringifiedFormData) : {}}/>
+                <JSONEditor className="json-editor" content={jsonEditorData} onChange={onChange}/>
                 {createActionButtons()}
             </form>
         );
+    };
+
+    const onChange = (data: string) => {
+        setIsPayloadValid(true);
+        try {
+            JSON.parse(data);
+        }
+        catch  {
+            setIsPayloadValid(false);
+        }
+        setJsonEditorData(data);
     };
 
     const onChangeForm = (data: any) => { // tslint:disable-line: no-any
@@ -141,8 +145,8 @@ export const DataForm: React.FC<DataFormDataProps & DataFormActionProps> = (prop
     };
 
     const generatePayload = () => {
-        return (parseMapTypeError || !settingSchema) ?
-            stringifiedFormData && JSON.parse(stringifiedFormData) :
+        return (parseMapTypeError || !settingSchema || !settingSchema.type) ?
+            JSON.parse(jsonEditorData) :
             dataToTwinConverter(formData, settingSchema, originalFormData).twin;
     };
 
@@ -176,14 +180,14 @@ export const DataForm: React.FC<DataFormDataProps & DataFormActionProps> = (prop
                     onClick={handleSave(payload)}
                     text={t(buttonText)}
                     iconProps={{ iconName: SUBMIT }}
-                    disabled={buttonDisabled}
+                    disabled={buttonDisabled || !isPayloadValid}
                 />
                 <ActionButton
                     className="preview-payload-button"
                     onClick={createPayloadPreview}
                     text={t(ResourceKeys.deviceSettings.previewPayloadButtonText)}
                     iconProps={{ iconName: CODE }}
-                    disabled={buttonDisabled}
+                    disabled={buttonDisabled || !isPayloadValid}
                 />
             </>
         );

--- a/src/app/notifications/components/notificationToast.tsx
+++ b/src/app/notifications/components/notificationToast.tsx
@@ -39,7 +39,7 @@ const NotificationEntry = (props: { notification: Notification }): JSX.Element =
 
     React.useEffect(() => {
         dispatch!(addNotificationAction(props.notification));
-    },              []);
+    },              [props.notification]);
 
     return <NotificationListEntry notification={props.notification} showAnnoucement={true}/>;
 };

--- a/src/app/shared/hooks/sagaReducerLogger.ts
+++ b/src/app/shared/hooks/sagaReducerLogger.ts
@@ -3,9 +3,9 @@ import { useCallback } from 'react';
 export const sagaReducerLogger = <S, A>(reducer: React.Reducer<S, A>, stateName: string) => useCallback((state, action) => {
     const next = reducer(state, action);
     // tslint:disable
-    console.log(`%cPrevious ${stateName}:`, 'color: #9E9E9E; font-weight: 700;', state.toJS());
+    console.log(`%cPrevious ${stateName}:`, 'color: #9E9E9E; font-weight: 700;', state && state.toJS());
     console.log('%cAction:', 'color: #00A7F7; font-weight: 700;', action);
-    console.log(`%cNext ${stateName}:`, 'color: #47B04B; font-weight: 700;', (next as any).toJS());
+    console.log(`%cNext ${stateName}:`, 'color: #47B04B; font-weight: 700;', next && (next as any).toJS());
     // tslint:enable
     return next;
   },                                                                                                    [reducer]);

--- a/src/app/shared/utils/jsonSchemaAdaptor.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.ts
@@ -256,8 +256,7 @@ export class JsonSchemaAdaptor implements JsonSchemaAdaptorInterface{
         }
 
         return {
-            required: [],
-            type: 'string'
+            required: [] // for unsupported complex type, we return a schema that matches to anything for now
         };
     }
 

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -332,7 +332,7 @@
             "pages": "Pages:"
         },
         "loadingDevice": "Loading devices",
-        "noDevice": "No devices",
+        "noDevice": "No devices to display",
         "noData": "None",
         "columns": {
             "deviceId": {
@@ -462,7 +462,8 @@
             "ariaLabel": "Model component and content pivot",
             "components" :"Components",
             "content": "Model content",
-            "defaultComponent": "Default component"
+            "defaultComponent": "Default component",
+            "digitalTwin": "Digital twin content"
         },
         "interfaceId": "Model ID"
     },
@@ -504,8 +505,7 @@
         "ackStatus": {
             "code": "Ack code: {{code}}",
             "description": "Ack description: {{description}}",
-            "version": "Ack version: {{version}}",
-            "error": "Reported value is not conformant as ack information is required. It will prevent you from being able to update desired value."
+            "version": "Ack version: {{version}}"
         },
         "columns": {
             "name": "Name (Display Name / Description)",

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -569,7 +569,6 @@ export class ResourceKeys {
       ackStatus : {
          code : "deviceSettings.ackStatus.code",
          description : "deviceSettings.ackStatus.description",
-         error : "deviceSettings.ackStatus.error",
          version : "deviceSettings.ackStatus.version",
       },
       columns : {
@@ -619,6 +618,7 @@ export class ResourceKeys {
          components : "digitalTwin.pivot.components",
          content : "digitalTwin.pivot.content",
          defaultComponent : "digitalTwin.pivot.defaultComponent",
+         digitalTwin : "digitalTwin.pivot.digitalTwin",
       },
       steps : {
          explanation : "digitalTwin.steps.explanation",

--- a/src/server/dataPlaneHelper.spec.ts
+++ b/src/server/dataPlaneHelper.spec.ts
@@ -105,7 +105,7 @@ describe('server', () => {
 
     it('generates data plane response with no httpResponse', () => {
         const response = processDataPlaneResponse(null, null);
-        expect(response.body).toEqual({body: null});
+        expect(response.body).toEqual(undefined);
     });
 
     it('generates data plane response using device status code', () => {

--- a/src/server/dataPlaneHelper.ts
+++ b/src/server/dataPlaneHelper.ts
@@ -32,25 +32,18 @@ export const generateDataPlaneResponse = (httpRes: request.Response, body: any, 
 };
 
 // tslint:disable-next-line:cyclomatic-complexity
-export const processDataPlaneResponse = (httpRes: request.Response, body: any): {body: {body: any, headers?: any}, statusCode?: number} => { // tslint:disable-line:no-any
+export const processDataPlaneResponse = (httpRes: request.Response, body: any): {body: {body: any, headers?: any}, statusCode: number} => { // tslint:disable-line:no-any
     try {
-        if (httpRes) {
-            if (httpRes.headers && httpRes.headers[DEVICE_STATUS_HEADER]) { // handles happy failure cases when error code is returned as a header
-                return {
-                    body: {body: body && JSON.parse(body)},
-                    statusCode: parseInt(httpRes.headers[DEVICE_STATUS_HEADER] as string) // tslint:disable-line:radix
-                };
-            }
-            else {
-                return {
-                    body: {body: body && JSON.parse(body), headers: httpRes.headers},
-                    statusCode: httpRes.statusCode
-                };
-            }
+        if (httpRes.headers && httpRes.headers[DEVICE_STATUS_HEADER]) { // handles happy failure cases when error code is returned as a header
+            return {
+                body: {body: body && JSON.parse(body)},
+                statusCode: parseInt(httpRes.headers[DEVICE_STATUS_HEADER] as string) // tslint:disable-line:radix
+            };
         }
         else {
             return {
-                body: {body: body && JSON.parse(body)}
+                body: {body: body && JSON.parse(body), headers: httpRes.headers},
+                statusCode: httpRes.statusCode
             };
         }
     }


### PR DESCRIPTION
- add raw digital twin view per request
- remove warning message on device settings per dicussion
- fix unsupported type of dtdl in writable json editor
- allow direct method to accept non-json payload (not using json editor specifically)
- api response should all have headers and status code. if not should go to catch case. before we are incorrectly returning with null status code.
- fix useeffect hook of notification
- auto redirect user to newly added device page if creation is successful