### PR TITLE
some css debt paid

### DIFF
--- a/src/app/css/_deviceContent.scss
+++ b/src/app/css/_deviceContent.scss
@@ -16,11 +16,12 @@ $nav-width: 20%;
     .device-content-nav-bar.collapsed {
         width:$nav-collapsed-width;
 
-        .nav-links {
+        .ms-Nav-linkText {
             display:none;
         }
     }
     .device-content-nav-bar {
+        transition: all 0.5s;
         overflow-y: auto;
         display: flex;
         flex-Direction: column;
@@ -28,7 +29,7 @@ $nav-width: 20%;
         height: calc(100vh - 131px);
         float: left;
         @include themify($themes) {
-                border: {
+            border: {
                 right: {
                     width: 1px;
                     style: solid;
@@ -39,6 +40,7 @@ $nav-width: 20%;
         }
     }
     .device-content-detail {
+        transition: margin-left .5s;
         margin: 0;
         margin-left: $nav-width;
         .form-group {

--- a/src/app/css/_deviceDetail.scss
+++ b/src/app/css/_deviceDetail.scss
@@ -10,8 +10,6 @@
     overflow-y: auto;
     padding-left: 30px;
     padding-right: 20px;
-    width: calc(80% - 50px);
-    position: fixed;
 }
 
 .method-payload{

--- a/src/app/devices/deviceIdentity/components/__snapshots__/deviceContentNav.spec.tsx.snap
+++ b/src/app/devices/deviceIdentity/components/__snapshots__/deviceContentNav.spec.tsx.snap
@@ -10,26 +10,41 @@ exports[`deviceContentNav matches snapshot when the device is edge 1`] = `
         Object {
           "links": Array [
             Object {
+              "iconProps": Object {
+                "iconName": "Server",
+              },
               "key": "identity",
               "name": "deviceContent.navBar.identity",
               "url": "#/identity/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "ReopenPages",
+              },
               "key": "twin",
               "name": "deviceContent.navBar.twin",
               "url": "#/twin/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "Message",
+              },
               "key": "events",
               "name": "deviceContent.navBar.events",
               "url": "#/events/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "Remote",
+              },
               "key": "methods",
               "name": "deviceContent.navBar.methods",
               "url": "#/methods/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "Mail",
+              },
               "key": "cloudToDeviceMessage",
               "name": "deviceContent.navBar.cloudToDeviceMessage",
               "url": "#/cloudToDeviceMessage/?deviceId=test",
@@ -52,36 +67,57 @@ exports[`deviceContentNav matches snapshot when the device is not edge 1`] = `
         Object {
           "links": Array [
             Object {
+              "iconProps": Object {
+                "iconName": "Server",
+              },
               "key": "identity",
               "name": "deviceContent.navBar.identity",
               "url": "#/identity/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "ReopenPages",
+              },
               "key": "twin",
               "name": "deviceContent.navBar.twin",
               "url": "#/twin/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "Message",
+              },
               "key": "events",
               "name": "deviceContent.navBar.events",
               "url": "#/events/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "Remote",
+              },
               "key": "methods",
               "name": "deviceContent.navBar.methods",
               "url": "#/methods/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "Mail",
+              },
               "key": "cloudToDeviceMessage",
               "name": "deviceContent.navBar.cloudToDeviceMessage",
               "url": "#/cloudToDeviceMessage/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "TFVCLogo",
+              },
               "key": "moduleIdentity",
               "name": "deviceContent.navBar.moduleIdentity",
               "url": "#/moduleIdentity/?deviceId=test",
             },
             Object {
+              "iconProps": Object {
+                "iconName": "PlugDisconnected",
+              },
               "key": "ioTPlugAndPlay",
               "name": "deviceContent.navBar.ioTPlugAndPlay",
               "url": "#/ioTPlugAndPlay/?deviceId=test",

--- a/src/app/devices/deviceIdentity/components/deviceContent.tsx
+++ b/src/app/devices/deviceIdentity/components/deviceContent.tsx
@@ -55,8 +55,8 @@ export const DeviceContent: React.FC = () => {
                         <IconButton
                             tabIndex={0}
                             iconProps={{ iconName: NAV }}
-                            title={appMenuVisible ? t(ResourceKeys.deviceContent.navBar.collapse) : t(ResourceKeys.deviceContent.navBar.expand)}
-                            ariaLabel={appMenuVisible ? t(ResourceKeys.deviceContent.navBar.collapse) : t(ResourceKeys.deviceContent.navBar.expand)}
+                            title={appMenuVisible ? t(ResourceKeys.common.navigation.collapse) : t(ResourceKeys.common.navigation.expand)}
+                            ariaLabel={appMenuVisible ? t(ResourceKeys.common.navigation.collapse) : t(ResourceKeys.common.navigation.expand)}
                             onClick={collapseToggle}
                         />
                     </div>

--- a/src/app/devices/deviceIdentity/components/deviceContentNav.spec.tsx
+++ b/src/app/devices/deviceIdentity/components/deviceContentNav.spec.tsx
@@ -6,7 +6,7 @@ import 'jest';
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 import { Nav } from 'office-ui-fabric-react/lib/components/Nav';
-import { DeviceContentNavComponent, DeviceContentNavDataProps, NAV_LINK_ITEMS, NAV_LINK_ITEMS_NONEDGE } from './deviceContentNav';
+import { DeviceContentNavComponent, DeviceContentNavProps, NAV_LINK_ITEMS, NAV_LINK_ITEMS_NONEDGE } from './deviceContentNav';
 
 jest.mock('react-router-dom', () => ({
     useLocation: () => ({ search: '?deviceId=test' }),
@@ -15,7 +15,7 @@ jest.mock('react-router-dom', () => ({
 
 describe('deviceContentNav', () => {
     const getComponent = (overrides = {}) => {
-        const navDataProps: DeviceContentNavDataProps = {
+        const navDataProps: DeviceContentNavProps = {
             isEdgeDevice: true
         };
 

--- a/src/app/devices/deviceIdentity/components/deviceContentNav.tsx
+++ b/src/app/devices/deviceIdentity/components/deviceContentNav.tsx
@@ -11,14 +11,22 @@ import { ROUTE_PARTS, ROUTE_PARAMS } from '../../../constants/routes';
 import { getDeviceIdFromQueryString } from '../../../shared/utils/queryStringHelper';
 import '../../../css/_deviceContentNav.scss';
 
-export interface DeviceContentNavDataProps {
+export const NAV_LINK_ITEMS = [ROUTE_PARTS.IDENTITY, ROUTE_PARTS.TWIN, ROUTE_PARTS.EVENTS, ROUTE_PARTS.METHODS, ROUTE_PARTS.CLOUD_TO_DEVICE_MESSAGE];
+export const NAV_LINK_ITEMS_NONEDGE = [...NAV_LINK_ITEMS, ROUTE_PARTS.MODULE_IDENTITY, ROUTE_PARTS.DIGITAL_TWINS];
+// tslint:disable-next-line: no-any
+const navIcons = {} as any;
+navIcons[ROUTE_PARTS.IDENTITY] = 'Server';
+navIcons[ROUTE_PARTS.TWIN] = 'ReopenPages';
+navIcons[ROUTE_PARTS.EVENTS] = 'Message';
+navIcons[ROUTE_PARTS.METHODS] = 'Remote';
+navIcons[ROUTE_PARTS.CLOUD_TO_DEVICE_MESSAGE] = 'Mail';
+navIcons[ROUTE_PARTS.MODULE_IDENTITY] = 'TFVCLogo';
+navIcons[ROUTE_PARTS.DIGITAL_TWINS] = 'PlugDisconnected';
+
+export interface DeviceContentNavProps {
     isEdgeDevice: boolean;
 }
 
-export const NAV_LINK_ITEMS = [ROUTE_PARTS.IDENTITY, ROUTE_PARTS.TWIN, ROUTE_PARTS.EVENTS, ROUTE_PARTS.METHODS, ROUTE_PARTS.CLOUD_TO_DEVICE_MESSAGE];
-export const NAV_LINK_ITEMS_NONEDGE = [...NAV_LINK_ITEMS, ROUTE_PARTS.MODULE_IDENTITY, ROUTE_PARTS.DIGITAL_TWINS];
-
-export type DeviceContentNavProps = DeviceContentNavDataProps;
 export const DeviceContentNavComponent: React.FC<DeviceContentNavProps> =  (props: DeviceContentNavProps) => {
     const { t } = useTranslation();
     const { isEdgeDevice } = props;
@@ -28,6 +36,7 @@ export const DeviceContentNavComponent: React.FC<DeviceContentNavProps> =  (prop
 
     const navItems = isEdgeDevice ? NAV_LINK_ITEMS : NAV_LINK_ITEMS_NONEDGE;
     const navLinks = navItems.map((nav: string) => ({
+        iconProps: { iconName: navIcons[nav] },
         key: nav,
         name: t((ResourceKeys.deviceContent.navBar as any)[nav]), // tslint:disable-line:no-any
         url: `#${url}/${nav}/?${ROUTE_PARAMS.DEVICE_ID}=${encodeURIComponent(deviceId)}`

--- a/src/app/home/components/__snapshots__/homeView.spec.tsx.snap
+++ b/src/app/home/components/__snapshots__/homeView.spec.tsx.snap
@@ -9,7 +9,10 @@ exports[`HomeView matches snapshot 1`] = `
     <div
       className="nav"
     >
-      <Component />
+      <Component
+        appMenuVisible={true}
+        setAppMenuVisible={[Function]}
+      />
     </div>
     <div
       className="home-content"

--- a/src/app/home/components/__snapshots__/homeViewNavigation.spec.tsx.snap
+++ b/src/app/home/components/__snapshots__/homeViewNavigation.spec.tsx.snap
@@ -10,22 +10,43 @@ exports[`homeViewNavigation matches snapshot 1`] = `
     <nav
       role="navigation"
     >
-      <NavLink
-        activeClassName="nav-link-active"
-        className="nav-link"
-        title="breadcrumb.resources"
-        to="/home/resources"
-      >
-        breadcrumb.resources
-      </NavLink>
-      <NavLink
-        activeClassName="nav-link-active"
-        className="nav-link"
-        title="breadcrumb.repos"
-        to="/home/repos"
-      >
-        breadcrumb.repos
-      </NavLink>
+      <CustomizedIconButton
+        ariaLabel="common.navigation.expand"
+        iconProps={
+          Object {
+            "iconName": "GlobalNavButton",
+          }
+        }
+        onClick={[Function]}
+        tabIndex={0}
+        title="common.navigation.expand"
+      />
+      <StyledNavBase
+        groups={
+          Array [
+            Object {
+              "links": Array [
+                Object {
+                  "iconProps": Object {
+                    "iconName": "Org",
+                  },
+                  "key": "resources",
+                  "name": "breadcrumb.resources",
+                  "url": "#/home/resources",
+                },
+                Object {
+                  "iconProps": Object {
+                    "iconName": "PlugDisconnected",
+                  },
+                  "key": "repos",
+                  "name": "breadcrumb.repos",
+                  "url": "#/home/repos",
+                },
+              ],
+            },
+          ]
+        }
+      />
     </nav>
   </div>
 </div>

--- a/src/app/home/components/homeView.scss
+++ b/src/app/home/components/homeView.scss
@@ -13,13 +13,14 @@
     width: 100%;
 
     .nav{
+        transition: all 0.5s;
         overflow-y: auto;
         display: flex;
         flex-Direction: column;
         width: 20%;
         float: left;
         @include themify($themes) {
-                border: {
+            border: {
                 right: {
                     width: 1px;
                     style: solid;
@@ -29,9 +30,21 @@
             }
         }
     }
+    .nav.collapsed {
+        width: 40px;
+
+        .ms-Nav-linkText {
+            display:none;
+        }
+    }
 
     .home-content {
+        transition: margin-left .5s;
         margin: 0;
         margin-left: calc(20% + 1px);
+    }
+
+    .home-content.collapsed {
+        margin-left: calc(40px + 1px);
     }
 }

--- a/src/app/home/components/homeView.tsx
+++ b/src/app/home/components/homeView.tsx
@@ -12,14 +12,18 @@ import { ModelRepositoryLocationView } from '../../modelRepository/components/mo
 import './homeView.scss';
 
 export const HomeView: React.FC = () => {
+    const [ appMenuVisible, setAppMenuVisible ] = React.useState(true);
     return (
         <div>
             <AppVersionMessageBar/>
             <div className="view-content home-view">
-                <div className="nav">
-                    <HomeViewNavigation/>
+                <div className={'nav' + (!appMenuVisible ? ' collapsed' : '')}>
+                    <HomeViewNavigation
+                        appMenuVisible={appMenuVisible}
+                        setAppMenuVisible={setAppMenuVisible}
+                    />
                 </div>
-                <div className="home-content">
+                <div className={'home-content' + (!appMenuVisible ? ' collapsed' : '')}>
                     <Switch>
                         <Redirect from={`/${ROUTE_PARTS.HOME}`} to={`/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.RESOURCES}`} exact={true}/>
                         <Route path={`/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.RESOURCES}`} component={AzureResourcesView} exact={true} />

--- a/src/app/home/components/homeViewNavigation.tsx
+++ b/src/app/home/components/homeViewNavigation.tsx
@@ -4,35 +4,51 @@
  **********************************************************/
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { NavLink } from 'react-router-dom';
+import { Nav, INavLink } from 'office-ui-fabric-react/lib/components/Nav';
+import { IconButton } from 'office-ui-fabric-react/lib/components/Button';
+import { NAV } from '../../constants/iconNames';
 import { ROUTE_PARTS } from '../../constants/routes';
 import { ResourceKeys } from '../../../localization/resourceKeys';
 import '../../css/_layouts.scss';
 import './homeViewNavigation.scss';
 
-export const HomeViewNavigation: React.FC = () => {
+export interface HomeViewNavigationProps {
+    appMenuVisible: boolean;
+    setAppMenuVisible: (appMenuVisible: boolean) => void;
+}
+export const HomeViewNavigation: React.FC<HomeViewNavigationProps> = props => {
     const { t } = useTranslation();
+    const { appMenuVisible, setAppMenuVisible } = props;
+    const collapseToggle = () => {
+        setAppMenuVisible(!appMenuVisible);
+    };
 
+    const navLinks: INavLink[] = [
+        {
+            iconProps: { iconName: 'Org' },
+            key: ROUTE_PARTS.RESOURCES,
+            name: t(ResourceKeys.breadcrumb.resources),
+            url: `#/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.RESOURCES}`
+        },
+        {
+            iconProps: { iconName: 'PlugDisconnected' },
+            key: ROUTE_PARTS.MODEL_REPOS,
+            name: t(ResourceKeys.breadcrumb.repos),
+            url: `#/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.MODEL_REPOS}`
+        },
+    ];
     return (
         <div className="nav-link-bar view">
             <div className="view-scroll-vertical">
                 <nav role="navigation">
-                    <NavLink
-                        className="nav-link"
-                        activeClassName="nav-link-active"
-                        to={`/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.RESOURCES}`}
-                        title={t(ResourceKeys.breadcrumb.resources)}
-                    >
-                       {t(ResourceKeys.breadcrumb.resources)}
-                    </NavLink>
-                    <NavLink
-                        className="nav-link"
-                        activeClassName="nav-link-active"
-                        to={`/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.MODEL_REPOS}`}
-                        title={t(ResourceKeys.breadcrumb.repos)}
-                    >
-                         {t(ResourceKeys.breadcrumb.repos)}
-                    </NavLink>
+                    <IconButton
+                        tabIndex={0}
+                        iconProps={{ iconName: NAV }}
+                        title={appMenuVisible ? t(ResourceKeys.common.navigation.collapse) : t(ResourceKeys.common.navigation.expand)}
+                        ariaLabel={appMenuVisible ? t(ResourceKeys.common.navigation.collapse) : t(ResourceKeys.common.navigation.expand)}
+                        onClick={collapseToggle}
+                    />
+                    <Nav groups={[{ links: navLinks }]}/>
                 </nav>
             </div>
         </div>

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -28,7 +28,9 @@
             "no": "No"
         },
         "navigation": {
-            "confirm": "Your unsaved edits will be discarded."
+            "confirm": "Your unsaved edits will be discarded.",
+            "collapse": "Collapse navigation menu",
+            "expand": "Expand navigation menu"
         }
     },
     "collapsibleSection": {
@@ -125,8 +127,6 @@
             "cloudToDeviceMessage": "Cloud-to-device message",
             "ioTPlugAndPlay": "IoT Plug and Play components",
             "add": "Create device identity",
-            "collapse": "Collapse navigation menu",
-            "expand": "Expand navigation menu",
             "moduleIdentity": "Module identity",
             "addModuleIdentity": "Add module identity",
             "moduleDetail": "Module identity",

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -110,7 +110,9 @@ export class ResourceKeys {
          },
       },
       navigation : {
+         collapse : "common.navigation.collapse",
          confirm : "common.navigation.confirm",
+         expand : "common.navigation.expand",
       },
    };
    public static connectionStrings = {
@@ -248,11 +250,9 @@ export class ResourceKeys {
          add : "deviceContent.navBar.add",
          addModuleIdentity : "deviceContent.navBar.addModuleIdentity",
          cloudToDeviceMessage : "deviceContent.navBar.cloudToDeviceMessage",
-         collapse : "deviceContent.navBar.collapse",
          commands : "deviceContent.navBar.commands",
          events : "deviceContent.navBar.events",
          eventsPerInterface : "deviceContent.navBar.eventsPerInterface",
-         expand : "deviceContent.navBar.expand",
          identity : "deviceContent.navBar.identity",
          interfaces : "deviceContent.navBar.interfaces",
          ioTPlugAndPlay : "deviceContent.navBar.ioTPlugAndPlay",


### PR DESCRIPTION
- Make home nav also collapsible
- When nav is collapsed, the width on the right content used to still have the width fixed at 80%
- Move icon from deprecated property value to the new pattern
![image](https://user-images.githubusercontent.com/5489222/87612949-ce934580-c6c0-11ea-92d2-12933b398eec.png)
