### PR TITLE
MacOS agent update and electron-builder package updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "7zip-bin": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.0.3.tgz",
-      "integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/7zip-bin/-/7zip-bin-5.0.3.tgz",
+      "integrity": "sha1-vFtVMuyv2SOmHy+wl+OxCMAQaj8=",
       "dev": true
     },
     "@azure/amqp-common": {
@@ -99,16 +99,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "semver": {
           "version": "5.7.1",
@@ -445,20 +445,20 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8=",
           "dev": true
         }
       }
     },
     "@develar/schema-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.1.0.tgz",
-      "integrity": "sha512-qjCqB4ctMig9Gz5bd6lkdFr3bO6arOdQqptdBSpF1ZpCnjofieCciEzkoS9ujY9cMGyllYSCSmBJ3x9OKHXzoA==",
+      "version": "2.6.5",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha1-Ps4ixYOEAkGabgQl+FdCuWHZtsY=",
       "dev": true,
       "requires": {
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0"
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
       }
     },
     "@electron/get": {
@@ -1038,8 +1038,8 @@
     },
     "@types/debug": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha1-sU76iFK3do2JiQZhPCP2iHE+As0=",
       "dev": true
     },
     "@types/enzyme": {
@@ -1089,6 +1089,15 @@
       "dev": true,
       "requires": {
         "form-data": "*"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/@types/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha1-kcj8TFH21dvkTCypqwkxC9AMeRg=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/history": {
@@ -1188,9 +1197,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-      "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+      "version": "14.0.27",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha1-oVGHOvWl6FG1GzsGXJ5jOQqeDrE=",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -1718,6 +1728,13 @@
         "uuid": "^3.1.0",
         "xmldom": ">= 0.1.x",
         "xpath.js": "~1.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.62",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/@types/node/-/node-8.10.62.tgz",
+          "integrity": "sha1-jQ0NtEpGrnZ52S4uNtQb8cNiXWo="
+        }
       }
     },
     "airbnb-prop-types": {
@@ -1866,45 +1883,45 @@
       }
     },
     "app-builder-bin": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.5.1.tgz",
-      "integrity": "sha512-71FeTdKU+L4/afnKYeCS9S9g6wa2AyiMLxGtYms6sPnnzUEd81wBhfvRb8/O/f4tLrU1MDbkjA8aGGiK9/ZT6A==",
+      "version": "3.5.9",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/app-builder-bin/-/app-builder-bin-3.5.9.tgz",
+      "integrity": "sha1-o6wMJShrrGg1cyHLLq9xKLC8Ck8=",
       "dev": true
     },
     "app-builder-lib": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.3.0.tgz",
-      "integrity": "sha512-cig8VGCcSG/T0Xz3esIB02D4PpIBvV5FdS7DRnKUmAwb4q/MjNp+pO1Tk0jqKWytEQcipC2AiUMb/7SjLhzByg==",
+      "version": "22.8.0",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/app-builder-lib/-/app-builder-lib-22.8.0.tgz",
+      "integrity": "sha1-NCqJdvUK41z9B0Etv9T2yJWzLqw=",
       "dev": true,
       "requires": {
         "7zip-bin": "~5.0.3",
-        "@develar/schema-utils": "~2.1.0",
+        "@develar/schema-utils": "~2.6.5",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.3.0",
-        "builder-util-runtime": "8.6.0",
+        "builder-util": "22.8.0",
+        "builder-util-runtime": "8.7.2",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.1.1",
-        "ejs": "^3.0.1",
-        "electron-publish": "22.3.0",
-        "fs-extra": "^8.1.0",
-        "hosted-git-info": "^3.0.2",
+        "ejs": "^3.1.3",
+        "electron-publish": "22.8.0",
+        "fs-extra": "^9.0.1",
+        "hosted-git-info": "^3.0.5",
         "is-ci": "^2.0.0",
-        "isbinaryfile": "^4.0.4",
-        "js-yaml": "^3.13.1",
+        "isbinaryfile": "^4.0.6",
+        "js-yaml": "^3.14.0",
         "lazy-val": "^1.0.4",
         "minimatch": "^3.0.4",
         "normalize-package-data": "^2.5.0",
-        "read-config-file": "5.0.1",
+        "read-config-file": "6.0.0",
         "sanitize-filename": "^1.6.3",
-        "semver": "^7.1.1",
-        "temp-file": "^3.3.6"
+        "semver": "^7.3.2",
+        "temp-file": "^3.3.7"
       },
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -1912,26 +1929,58 @@
         },
         "ejs": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.3.tgz",
-          "integrity": "sha512-wmtrUGyfSC23GC/B1SMv2ogAUgbQEtDmTIhfqielrG5ExIM9TP4UoYdi90jLF1aTcsWCJNEO0UrgKzP0y3nTSg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/ejs/-/ejs-3.1.3.tgz",
+          "integrity": "sha1-UU2WeoiUCE0Y09R70WmhwFYPCT0=",
           "dev": true,
           "requires": {
             "jake": "^10.6.1"
           }
         },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha1-kQ2gBiQ3ukw5/t2GPxZ1zP78ufw=",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
         "hosted-git-info": {
           "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-          "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
+          "integrity": "sha1-vqh5Be9zF0QujfMIf6o8hCOX3wM=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha1-mJZsuiFDeMjIS4LghZB7QL9hQXk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
         "lru-cache": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -1939,14 +1988,20 @@
         },
         "semver": {
           "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
+          "dev": true
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha1-thodoXPoQ1sv48Z9Kbmt+FlL0W0=",
           "dev": true
         },
         "yallist": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
           "dev": true
         }
       }
@@ -2145,8 +2200,8 @@
     },
     "async-exit-hook": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
-      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha1-i9iwJLDsmxwBzMua+dspvXF9+vM=",
       "dev": true
     },
     "async-foreach": {
@@ -2169,6 +2224,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha1-YCzUtG6EStTv/JKoARo8RuAjjcI=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -2235,13 +2296,13 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -2249,8 +2310,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -2618,8 +2679,8 @@
     },
     "bluebird-lst": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
-      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha1-pkoOQ2Vli5q1/odeud+2lBibtBw=",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5"
@@ -2700,8 +2761,8 @@
     },
     "boxen": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/boxen/-/boxen-4.2.0.tgz",
+      "integrity": "sha1-5BG2I1fW1tNlh8isPV2XTaoHDmQ=",
       "dev": true,
       "requires": {
         "ansi-align": "^3.0.0",
@@ -2716,20 +2777,20 @@
       "dependencies": {
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -2739,8 +2800,8 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -2748,8 +2809,8 @@
         },
         "type-fest": {
           "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
           "dev": true
         }
       }
@@ -2977,41 +3038,100 @@
       "dev": true
     },
     "builder-util": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.3.0.tgz",
-      "integrity": "sha512-kLAeX4q4LEAHsg9P7xXdGYxp9kQfHpVrmj9GxXojA7muqfILJG1SMExezniPT85oI9uxRzT7BevEucAVS/0ZOw==",
+      "version": "22.8.0",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/builder-util/-/builder-util-22.8.0.tgz",
+      "integrity": "sha1-AWhAhdHyNwsb0YL2nL0AdCb2P2Q=",
       "dev": true,
       "requires": {
         "7zip-bin": "~5.0.3",
         "@types/debug": "^4.1.5",
-        "app-builder-bin": "3.5.1",
+        "@types/fs-extra": "^9.0.1",
+        "app-builder-bin": "3.5.9",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.6.0",
-        "chalk": "^3.0.0",
+        "builder-util-runtime": "8.7.2",
+        "chalk": "^4.1.0",
         "debug": "^4.1.1",
-        "fs-extra": "^8.1.0",
+        "fs-extra": "^9.0.1",
         "is-ci": "^2.0.0",
-        "js-yaml": "^3.13.1",
-        "source-map-support": "^0.5.16",
+        "js-yaml": "^3.14.0",
+        "source-map-support": "^0.5.19",
         "stat-mode": "^1.0.0",
-        "temp-file": "^3.3.6"
+        "temp-file": "^3.3.7"
       },
       "dependencies": {
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha1-kQ2gBiQ3ukw5/t2GPxZ1zP78ufw=",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha1-mJZsuiFDeMjIS4LghZB7QL9hQXk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha1-thodoXPoQ1sv48Z9Kbmt+FlL0W0=",
+          "dev": true
         }
       }
     },
     "builder-util-runtime": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.6.0.tgz",
-      "integrity": "sha512-WTDhTUVrm7zkFyd6Qn7AXgmWifjpZ/fYnEdV3XCOIDMNNb/KPddBTbQ8bUlxxVeuOYlhGpcLUypG+4USdGL1ww==",
+      "version": "8.7.2",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/builder-util-runtime/-/builder-util-runtime-8.7.2.tgz",
+      "integrity": "sha1-2Tr8cUKKEnibQ34ThQ4fp9qVbXI=",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -3020,8 +3140,8 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -3076,6 +3196,28 @@
           "dev": true,
           "requires": {
             "yallist": "^3.0.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.3",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
+        },
+        "mkdirp": {
+          "version": "0.5.3",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+              "dev": true
+            }
           }
         },
         "rimraf": {
@@ -3776,8 +3918,8 @@
     },
     "configstore": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha1-02UCG130uYzdGH1qOw4/anzF7ZY=",
       "dev": true,
       "requires": {
         "dot-prop": "^5.2.0",
@@ -3865,13 +4007,13 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -3879,8 +4021,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -4007,8 +4149,8 @@
     },
     "crypto-random-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha1-7yp6lm7BEIM4g2m6oC6+rSKbMNU=",
       "dev": true
     },
     "css-color-names": {
@@ -4805,28 +4947,65 @@
       "dev": true
     },
     "dmg-builder": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.3.0.tgz",
-      "integrity": "sha512-t+23y4qLAI8yDhCwy+GBlhK/fYV0UeD0HxMhlnZmmj22pZF06zAApYRLGGzWclGG9qgdFlkgaigRWEhUFUnujw==",
+      "version": "22.8.0",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/dmg-builder/-/dmg-builder-22.8.0.tgz",
+      "integrity": "sha1-KxcSeDftRE2zCGMX7aXPiRL25qk=",
       "dev": true,
       "requires": {
-        "app-builder-lib": "~22.3.0",
-        "bluebird-lst": "^1.0.9",
-        "builder-util": "~22.3.0",
-        "fs-extra": "^8.1.0",
-        "iconv-lite": "^0.5.1",
-        "js-yaml": "^3.13.1",
+        "app-builder-lib": "22.8.0",
+        "builder-util": "22.8.0",
+        "fs-extra": "^9.0.1",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^3.14.0",
         "sanitize-filename": "^1.6.3"
       },
       "dependencies": {
-        "iconv-lite": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-          "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha1-kQ2gBiQ3ukw5/t2GPxZ1zP78ufw=",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
           }
+        },
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha1-zhPRh1sMOmdL1qBLf3awGxtt7QE=",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha1-mJZsuiFDeMjIS4LghZB7QL9hQXk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha1-thodoXPoQ1sv48Z9Kbmt+FlL0W0=",
+          "dev": true
         }
       }
     },
@@ -4924,8 +5103,8 @@
     },
     "dot-prop": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/dot-prop/-/dot-prop-5.2.0.tgz",
+      "integrity": "sha1-w07MKVVtxF8fTCJpe29JBODMT8s=",
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
@@ -4933,14 +5112,14 @@
     },
     "dotenv": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha1-l+YZJZradQ7qPk6j4mvO6lQksWo=",
       "dev": true
     },
     "dotenv-expand": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha1-P7rwIL/XlIhAcuomsel5HUWmKfA=",
       "dev": true
     },
     "duplexer": {
@@ -5014,30 +5193,50 @@
       }
     },
     "electron-builder": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.3.0.tgz",
-      "integrity": "sha512-rkqdqkpKpHH/7XAAkAjlQ3FOXFtUVqZGZ5JykgOB9MC3jEp9glJTtnivI8SX413Rn1SXdIJ7sbdJVP89LYZz3g==",
+      "version": "22.8.0",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/electron-builder/-/electron-builder-22.8.0.tgz",
+      "integrity": "sha1-0sn8VDjINOQf15SicfyiABZaO60=",
       "dev": true,
       "requires": {
-        "app-builder-lib": "22.3.0",
+        "@types/yargs": "^15.0.5",
+        "app-builder-lib": "22.8.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.3.0",
-        "builder-util-runtime": "8.6.0",
-        "chalk": "^3.0.0",
-        "dmg-builder": "22.3.0",
-        "fs-extra": "^8.1.0",
+        "builder-util": "22.8.0",
+        "builder-util-runtime": "8.7.2",
+        "chalk": "^4.1.0",
+        "dmg-builder": "22.8.0",
+        "fs-extra": "^9.0.1",
         "is-ci": "^2.0.0",
         "lazy-val": "^1.0.4",
-        "read-config-file": "5.0.1",
+        "read-config-file": "6.0.0",
         "sanitize-filename": "^1.6.3",
-        "update-notifier": "^4.0.0",
-        "yargs": "^15.1.0"
+        "update-notifier": "^4.1.0",
+        "yargs": "^15.3.1"
       },
       "dependencies": {
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha1-lH6aZWFIO97prf/Jg+kaaQKvi3k=",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
@@ -5047,36 +5246,58 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
           "dev": true
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
         },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha1-kQ2gBiQ3ukw5/t2GPxZ1zP78ufw=",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha1-mJZsuiFDeMjIS4LghZB7QL9hQXk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
@@ -5084,8 +5305,8 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
@@ -5093,20 +5314,20 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -5116,17 +5337,23 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
         },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha1-thodoXPoQ1sv48Z9Kbmt+FlL0W0=",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -5136,8 +5363,8 @@
         },
         "yargs": {
           "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
           "dev": true,
           "requires": {
             "cliui": "^6.0.0",
@@ -5155,8 +5382,8 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -5166,24 +5393,63 @@
       }
     },
     "electron-publish": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.3.0.tgz",
-      "integrity": "sha512-c/XLfPJg2q+bcNuUCoBNniNbv1SakgB/+mQUS7e1sx+bKiuten/gOwVz0Xu77Es8KV09B82E8e1xAV4EourWGw==",
+      "version": "22.8.0",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/electron-publish/-/electron-publish-22.8.0.tgz",
+      "integrity": "sha1-f0EP4EOrxdPYlsTunup6Q+o1LH0=",
       "dev": true,
       "requires": {
+        "@types/fs-extra": "^9.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "~22.3.0",
-        "builder-util-runtime": "8.6.0",
-        "chalk": "^3.0.0",
-        "fs-extra": "^8.1.0",
+        "builder-util": "22.8.0",
+        "builder-util-runtime": "8.7.2",
+        "chalk": "^4.1.0",
+        "fs-extra": "^9.0.1",
         "lazy-val": "^1.0.4",
-        "mime": "^2.4.4"
+        "mime": "^2.4.6"
       },
       "dependencies": {
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha1-kQ2gBiQ3ukw5/t2GPxZ1zP78ufw=",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha1-mJZsuiFDeMjIS4LghZB7QL9hQXk=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
         "mime": {
           "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE=",
+          "dev": true
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha1-thodoXPoQ1sv48Z9Kbmt+FlL0W0=",
           "dev": true
         }
       }
@@ -5828,25 +6094,8 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-              "dev": true
-            }
-          }
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "ms": {
           "version": "2.0.0",
@@ -5928,8 +6177,8 @@
     },
     "filelist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
-      "integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/filelist/-/filelist-1.0.1.tgz",
+      "integrity": "sha1-8Q0aOuhsFpSAjo8gkG9D1MkTLbs=",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -6160,8 +6409,8 @@
     },
     "fsevents": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
       "dev": true,
       "optional": true
     },
@@ -6179,13 +6428,13 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -6193,8 +6442,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -6408,8 +6657,8 @@
     },
     "global-dirs": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/global-dirs/-/global-dirs-2.0.1.tgz",
+      "integrity": "sha1-rN87tmhbzVXLNeigUiZlaelGkgE=",
       "dev": true,
       "requires": {
         "ini": "^1.3.5"
@@ -7333,8 +7582,8 @@
     },
     "is-installed-globally": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "integrity": "sha1-/T76ee5nDRGHIzGC1bCh3QAxMUE=",
       "dev": true,
       "requires": {
         "global-dirs": "^2.0.1",
@@ -7343,16 +7592,16 @@
       "dependencies": {
         "is-path-inside": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-          "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/is-path-inside/-/is-path-inside-3.0.2.tgz",
+          "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc=",
           "dev": true
         }
       }
     },
     "is-npm": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-      "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/is-npm/-/is-npm-4.0.0.tgz",
+      "integrity": "sha1-yQ3YOAaW34enptgjwg0LErvjyE0=",
       "dev": true
     },
     "is-number": {
@@ -7389,8 +7638,8 @@
     },
     "is-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha1-Rz+wXZc3BeP9liBUUBjKjiLvSYI=",
       "dev": true
     },
     "is-path-cwd": {
@@ -7519,8 +7768,8 @@
     },
     "isbinaryfile": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
-      "integrity": "sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
+      "integrity": "sha1-7ctisiTitHEIMLZ0mMjk5aTSYQs=",
       "dev": true
     },
     "isexe": {
@@ -7617,8 +7866,8 @@
     },
     "jake": {
       "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/jake/-/jake-10.8.2.tgz",
+      "integrity": "sha1-68nehVgWCmbYLQ6txqLlj7xQCns=",
       "dev": true,
       "requires": {
         "async": "0.9.x",
@@ -7629,8 +7878,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -7644,8 +7893,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -7655,8 +7904,8 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -7676,8 +7925,8 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -8530,13 +8779,13 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -8544,8 +8793,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -8590,13 +8839,13 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -8604,8 +8853,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -8785,8 +9034,8 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8=",
           "dev": true
         }
       }
@@ -8888,8 +9137,8 @@
     },
     "lazy-val": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.4.tgz",
-      "integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/lazy-val/-/lazy-val-1.0.4.tgz",
+      "integrity": "sha1-iCY2pyRcLP5uCk47psXWihN+XGU=",
       "dev": true
     },
     "lcid": {
@@ -9192,8 +9441,8 @@
     },
     "make-dir": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
@@ -9332,8 +9581,8 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8=",
           "dev": true
         }
       }
@@ -9479,8 +9728,8 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "mississippi": {
@@ -9542,8 +9791,8 @@
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
@@ -9576,13 +9825,13 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -9590,8 +9839,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -9788,13 +10037,13 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -9802,8 +10051,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -9961,13 +10210,13 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -9975,8 +10224,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -10996,13 +11245,13 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -11010,8 +11259,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -13808,8 +14057,8 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8=",
           "dev": true
         }
       }
@@ -13979,23 +14228,22 @@
       }
     },
     "read-config-file": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-5.0.1.tgz",
-      "integrity": "sha512-75zp4PDbvtBlECoZK1KEkNlesr9OWdMWL8oi4xq+HXAM+kKHKU+Cx2ksFt+ie2BkrmkLBOKSfONDuz+WIKWoXA==",
+      "version": "6.0.0",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/read-config-file/-/read-config-file-6.0.0.tgz",
+      "integrity": "sha1-Iktdympb3B+xnmP4nzQmgO/bkpk=",
       "dev": true,
       "requires": {
         "dotenv": "^8.2.0",
         "dotenv-expand": "^5.1.0",
-        "fs-extra": "^8.1.0",
         "js-yaml": "^3.13.1",
-        "json5": "^2.1.1",
+        "json5": "^2.1.2",
         "lazy-val": "^1.0.4"
       },
       "dependencies": {
         "json5": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -14003,8 +14251,8 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
           "dev": true
         }
       }
@@ -14553,8 +14801,8 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8=",
           "dev": true
         },
         "normalize-path": {
@@ -14816,8 +15064,8 @@
     },
     "semver-diff": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha1-Bfd85Z8yXgDicGr9Z7tQbdscoys=",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -15446,8 +15694,8 @@
     },
     "stat-mode": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
-      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha1-aLVcth6mOf9XE282shaikYANFGU=",
       "dev": true
     },
     "static-extend": {
@@ -15923,13 +16171,13 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -15937,8 +16185,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -15984,8 +16232,8 @@
     },
     "temp-file": {
       "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.7.tgz",
-      "integrity": "sha512-9tBJKt7GZAQt/Rg0QzVWA8Am8c1EFl+CAv04/aBVqlx5oyfQ508sFIABshQ0xbZu6mBrFLWIUXO/bbLYghW70g==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/temp-file/-/temp-file-3.3.7.tgz",
+      "integrity": "sha1-aGiF1jX4cnSOOE6HGFWVhHCusYo=",
       "dev": true,
       "requires": {
         "async-exit-hook": "^2.0.1",
@@ -15994,8 +16242,8 @@
     },
     "term-size": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/term-size/-/term-size-2.2.0.tgz",
+      "integrity": "sha1-Hxat7f6b3BiADhd2ghc0CG/MZ1M=",
       "dev": true
     },
     "terminal-link": {
@@ -16420,8 +16668,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -16438,13 +16686,13 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
           "dev": true
         },
         "pretty-format": {
@@ -16584,13 +16832,13 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -16598,8 +16846,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -16882,8 +17130,8 @@
     },
     "unique-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha1-OcZFH4GvsnSd4rIz4/fF6IQ72J0=",
       "dev": true,
       "requires": {
         "crypto-random-string": "^2.0.0"
@@ -16960,8 +17208,8 @@
     },
     "update-notifier": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
-      "integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/update-notifier/-/update-notifier-4.1.0.tgz",
+      "integrity": "sha1-SGa5jDvFtUc8AgsSUFg2KPmjKPM=",
       "dev": true,
       "requires": {
         "boxen": "^4.2.0",
@@ -17250,8 +17498,8 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17378,13 +17626,13 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-              "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+              "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
             },
             "mkdirp": {
               "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-              "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+              "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
               "dev": true,
               "requires": {
                 "minimist": "^1.2.5"
@@ -17392,8 +17640,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.5",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                  "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                  "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+                  "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
                   "dev": true
                 }
               }
@@ -17454,13 +17702,13 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -17468,8 +17716,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -17619,13 +17867,13 @@
         },
         "minimist": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.3.tgz",
+          "integrity": "sha1-PbXAdlVFq4Y3vnHzM6EEqWWpyj8="
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -17633,8 +17881,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
               "dev": true
             }
           }
@@ -17902,8 +18150,8 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18225,8 +18473,8 @@
     },
     "widest-line": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha1-gpIzO79my0X/DeFgOxNreuFJbso=",
       "dev": true,
       "requires": {
         "string-width": "^4.0.0"
@@ -18234,20 +18482,20 @@
       "dependencies": {
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -18257,8 +18505,8 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -18336,8 +18584,8 @@
     },
     "write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
@@ -18356,8 +18604,8 @@
     },
     "xdg-basedir": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AzurePortal/npm/registry/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha1-S8jZmEQDaWIl74OhVzy7y0552xM=",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -99,10 +99,6 @@
     "typescript-fsa-reducers": "1.0.0",
     "uuid": "3.3.3"
   },
-  "resolutions": {
-    "minimist": "1.2.3",
-    "mkdirp": "0.5.3"
-  },
   "devDependencies": {
     "@redux-saga/testing-utils": "1.1.3",
     "@types/async-lock": "1.1.0",
@@ -114,6 +110,7 @@
     "@types/i18next": "8.4.4",
     "@types/jest": "24.0.15",
     "@types/jest-plugin-context": "2.9.0",
+    "@types/node": "14.0.27",
     "@types/react": "16.9.35",
     "@types/react-dom": "16.9.8",
     "@types/react-jsonschema-form": "1.0.10",
@@ -129,7 +126,7 @@
     "concurrently": "4.1.0",
     "css-loader": "1.0.0",
     "electron": "7.2.4",
-    "electron-builder": "22.3.0",
+    "electron-builder": "22.8.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.1",
     "enzyme-to-json": "3.3.5",

--- a/pipelines/release-pipeline.yml
+++ b/pipelines/release-pipeline.yml
@@ -52,7 +52,7 @@ stages:
       displayName: "Package for MacOS"
 
       pool:
-        vmImage: 'macOS-10.14'
+        vmImage: 'macOS-10.15'
 
       steps:
       - task: NodeTool@0


### PR DESCRIPTION
This also removes our `npm-force-resolutions` hack for `minimist` and `mkdirp` vulnerabilities