### PR TITLE
remove key value pair completely instead of set value to null

### DIFF
--- a/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
+++ b/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
@@ -128,13 +128,14 @@ export const DeviceSettingsPerInterfacePerSetting: React.FC<DeviceSettingDataPro
                                 settingSchema,
                                 t(ResourceKeys.deviceSettings.columns.error))}
                         </ErrorBoundary> :
+                        reportedTwin ?
                         <ActionButton
                             className="column-value-button"
                             ariaDescription={t(ResourceKeys.deviceSettings.command.openReportedValuePanel)}
                             onClick={onViewReportedValue}
                         >
                             {t(ResourceKeys.deviceSettings.command.openReportedValuePanel)}
-                        </ActionButton>
+                        </ActionButton> : <Label>--</Label>
                 }
             </>
         );

--- a/src/app/devices/shared/components/dataForm.tsx
+++ b/src/app/devices/shared/components/dataForm.tsx
@@ -142,7 +142,7 @@ export const DataForm: React.FC<DataFormDataProps & DataFormActionProps> = (prop
     const generatePayload = () => {
         return (parsingSchemaFailed) ?
             JSON.parse(jsonEditorData) :
-            dataToTwinConverter(formData, settingSchema, originalFormData).twin;
+            dataToTwinConverter(formData, settingSchema).twin;
     };
 
     const createPayloadPreview = () => {


### PR DESCRIPTION
As service is now using patch to update dt twin, we no longer need to explictly set key-value pair to be removed to {key:  null}. 
```
For example to remove key-value pair b -> 2 from map 'myMap', we had to do before
{ mayMap: {a:1, b:null}}
but now we can simply leave it as { mayMap: {a:1}}.
```
Completely removing the unnessary logic.