### PR TITLE
retrieve inline component as flattened model definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "This project welcomes contributions and suggestions. Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "public/electron.js",
   "build": {

--- a/src/app/api/models/modelDefinition.ts
+++ b/src/app/api/models/modelDefinition.ts
@@ -5,6 +5,12 @@
 export type ComplexSchema = ObjectSchema | MapSchema | EnumSchema | ArraySchema;
 export type ContentTypeUnion = PropertyContent | CommandContent | TelemetryContent | ComponentContent;
 
+interface ModelSchema {
+    '@type': string;
+    '@id': string;
+    contents: ContentTypeUnion[];
+}
+
 export interface ModelDefinition {
     '@context': string;
     '@id': string;
@@ -14,11 +20,7 @@ export interface ModelDefinition {
     description?: string | object;
     displayName?: string | object;
     schemas?: ComplexSchema[];
-    schema?: {
-        '@type': string;
-        '@id': string;
-        contents: ContentTypeUnion[];
-    };
+    schema?: ModelSchema;
 }
 
 export interface PropertyContent extends ContentBase {
@@ -37,11 +39,7 @@ export interface TelemetryContent extends ContentBase{
 }
 
 export interface ComponentContent extends ContentBase{
-    schema: string | {
-        '@type': string;
-        '@id': string;
-        contents: ContentTypeUnion[];
-    };
+    schema: string | ModelSchema;
 }
 
 interface ContentBase {

--- a/src/app/api/models/modelDefinition.ts
+++ b/src/app/api/models/modelDefinition.ts
@@ -3,16 +3,22 @@
  * Licensed under the MIT License
  **********************************************************/
 export type ComplexSchema = ObjectSchema | MapSchema | EnumSchema | ArraySchema;
+export type ContentTypeUnion = PropertyContent | CommandContent | TelemetryContent | ComponentContent;
 
 export interface ModelDefinition {
     '@context': string;
     '@id': string;
     '@type': string;
     comment?: string | object;
-    contents: Array<PropertyContent | CommandContent | TelemetryContent | ComponentContent>;
+    contents?: ContentTypeUnion[];
     description?: string | object;
     displayName?: string | object;
     schemas?: ComplexSchema[];
+    schema?: {
+        '@type': string;
+        '@id': string;
+        contents: ContentTypeUnion[];
+    };
 }
 
 export interface PropertyContent extends ContentBase {
@@ -31,7 +37,11 @@ export interface TelemetryContent extends ContentBase{
 }
 
 export interface ComponentContent extends ContentBase{
-    schema: string;
+    schema: string | {
+        '@type': string;
+        '@id': string;
+        contents: ContentTypeUnion[];
+    };
 }
 
 interface ContentBase {
@@ -42,6 +52,7 @@ interface ContentBase {
     description?: string | object;
     displayName?: string | object;
     unit?: string;
+    '@id'?: string;
 }
 
 export interface Schema {

--- a/src/app/devices/pnp/sagas/getModelDefinitionSaga.spec.ts
+++ b/src/app/devices/pnp/sagas/getModelDefinitionSaga.spec.ts
@@ -11,7 +11,6 @@ import { getModelDefinitionSaga,
     getModelDefinitionFromPublicRepo,
     getModelDefinitionFromLocalFile,
     validateModelDefinitionHelper,
-    getSplitedInterfaceId,
     getFlattenedModel
 } from './getModelDefinitionSaga';
 import { raiseNotificationToast } from '../../../notifications/components/notificationToast';
@@ -137,11 +136,6 @@ describe('modelDefinition sagas', () => {
         describe('getModelDefinitionFromPublicRepo ', () => {
             const getModelDefinitionFromPublicRepoGenerator = cloneableGenerator(getModelDefinitionFromPublicRepo)(action);
 
-            expect(getModelDefinitionFromPublicRepoGenerator.next()).toEqual({
-                done: false,
-                value: call(getSplitedInterfaceId, action.payload.interfaceId)
-            });
-
             expect(getModelDefinitionFromPublicRepoGenerator.next([action.payload.interfaceId])).toEqual({
                 done: false,
                 value: call(fetchModelDefinition, {
@@ -150,34 +144,19 @@ describe('modelDefinition sagas', () => {
                 })
             });
 
-            expect(getModelDefinitionFromPublicRepoGenerator.next(modelDefinition)).toEqual({
-                done: false,
-                value: call(getFlattenedModel, modelDefinition, [action.payload.interfaceId])
-            });
-
-            expect(getModelDefinitionFromPublicRepoGenerator.next().done).toEqual(true);
+            expect(getModelDefinitionFromPublicRepoGenerator.next(modelDefinition).done).toEqual(true);
         });
 
         describe('getModelDefinitionFromLocalFile ', () => {
             const getModelDefinitionFromLocalFolderGenerator = cloneableGenerator(getModelDefinitionFromLocalFile)
                 (action);
 
-            expect(getModelDefinitionFromLocalFolderGenerator.next()).toEqual({
-                done: false,
-                value: call(getSplitedInterfaceId, action.payload.interfaceId)
-            });
-
             expect(getModelDefinitionFromLocalFolderGenerator.next([action.payload.interfaceId])).toEqual({
                 done: false,
                 value: call(fetchLocalFile, 'f:', action.payload.interfaceId)
             });
 
-            expect(getModelDefinitionFromLocalFolderGenerator.next(modelDefinition)).toEqual({
-                done: false,
-                value: call(getFlattenedModel, modelDefinition, [action.payload.interfaceId])
-            });
-
-            expect(getModelDefinitionFromLocalFolderGenerator.next().done).toEqual(true);
+            expect(getModelDefinitionFromLocalFolderGenerator.next(modelDefinition).done).toEqual(true);
         });
 
         describe('getModelDefinition', () => {
@@ -201,12 +180,7 @@ describe('modelDefinition sagas', () => {
         });
 
         describe('getFlattenedModel ', () => {
-            const getFlattenedModelGenerator = cloneableGenerator(getFlattenedModel)(modelDefinition, [interfaceId]);
-
-            expect(getFlattenedModelGenerator.next()).toEqual({
-                done: true,
-                value: modelDefinition
-            });
+            expect(getFlattenedModel(modelDefinition, [interfaceId])).toEqual(modelDefinition);
         });
     });
 
@@ -251,11 +225,6 @@ describe('modelDefinition sagas', () => {
         describe('getModelDefinitionFromPublicRepo ', () => {
             const getModelDefinitionFromPublicRepoGenerator = cloneableGenerator(getModelDefinitionFromPublicRepo)(action);
 
-            expect(getModelDefinitionFromPublicRepoGenerator.next()).toEqual({
-                done: false,
-                value: call(getSplitedInterfaceId, action.payload.interfaceId)
-            });
-
             expect(getModelDefinitionFromPublicRepoGenerator.next([interfaceId, schemaId])).toEqual({
                 done: false,
                 value: call(fetchModelDefinition, {
@@ -264,43 +233,23 @@ describe('modelDefinition sagas', () => {
                 })
             });
 
-            expect(getModelDefinitionFromPublicRepoGenerator.next(modelDefinition)).toEqual({
-                done: false,
-                value: call(getFlattenedModel, modelDefinition, [interfaceId, schemaId])
-            });
-
-            expect(getModelDefinitionFromPublicRepoGenerator.next().done).toEqual(true);
+            expect(getModelDefinitionFromPublicRepoGenerator.next(modelDefinition).done).toEqual(true);
         });
 
         describe('getModelDefinitionFromLocalFile ', () => {
             const getModelDefinitionFromLocalFolderGenerator = cloneableGenerator(getModelDefinitionFromLocalFile)
                 (action);
 
-            expect(getModelDefinitionFromLocalFolderGenerator.next()).toEqual({
-                done: false,
-                value: call(getSplitedInterfaceId, action.payload.interfaceId)
-            });
-
             expect(getModelDefinitionFromLocalFolderGenerator.next([interfaceId, schemaId])).toEqual({
                 done: false,
                 value: call(fetchLocalFile, 'f:', interfaceId)
             });
 
-            expect(getModelDefinitionFromLocalFolderGenerator.next(modelDefinition)).toEqual({
-                done: false,
-                value: call(getFlattenedModel, modelDefinition, [interfaceId, schemaId])
-            });
-
-            expect(getModelDefinitionFromLocalFolderGenerator.next().done).toEqual(true);
+            expect(getModelDefinitionFromLocalFolderGenerator.next(modelDefinition).done).toEqual(true);
         });
 
         describe('getFlattenedModel ', () => {
-            const getFlattenedModelGenerator = cloneableGenerator(getFlattenedModel)(modelDefinition, [interfaceId, schemaId]);
-
-            expect(getFlattenedModelGenerator.next()).toEqual({
-                done: true,
-                value: modelDefinition.contents[0]
-            });
+            expect(getFlattenedModel(modelDefinition, [interfaceId, schemaId])).toEqual(modelDefinition.contents[0]);
         });
     });
 });

--- a/src/app/devices/pnp/sagas/getModelDefinitionSaga.spec.ts
+++ b/src/app/devices/pnp/sagas/getModelDefinitionSaga.spec.ts
@@ -3,10 +3,17 @@
  * Licensed under the MIT License
  **********************************************************/
 import 'jest';
-import { select, call, put } from 'redux-saga/effects';
+import { call, put } from 'redux-saga/effects';
 // tslint:disable-next-line: no-implicit-dependencies
 import { SagaIteratorClone, cloneableGenerator } from '@redux-saga/testing-utils';
-import { getModelDefinitionSaga, getModelDefinition, getModelDefinitionFromPublicRepo, getModelDefinitionFromLocalFile, validateModelDefinitionHelper } from './getModelDefinitionSaga';
+import { getModelDefinitionSaga,
+    getModelDefinition,
+    getModelDefinitionFromPublicRepo,
+    getModelDefinitionFromLocalFile,
+    validateModelDefinitionHelper,
+    getSplitedInterfaceId,
+    getFlattenedModel
+} from './getModelDefinitionSaga';
 import { raiseNotificationToast } from '../../../notifications/components/notificationToast';
 import { NotificationType } from '../../../api/models/notification';
 import { ResourceKeys } from '../../../../localization/resourceKeys';
@@ -14,161 +21,286 @@ import { getModelDefinitionAction, GetModelDefinitionActionParameters } from '..
 import { REPOSITORY_LOCATION_TYPE } from '../../../constants/repositoryLocationTypes';
 import { fetchLocalFile } from '../../../api/services/localRepoService';
 import { fetchModelDefinition } from '../../../api/services/publicDigitalTwinsModelRepoService';
+import { ModelDefinition } from './../../../api/models/modelDefinition';
 
 describe('modelDefinition sagas', () => {
-    const digitalTwinId = 'device_id';
-    const interfaceId = 'interface_id';
-    const params: GetModelDefinitionActionParameters = {
-        digitalTwinId,
-        interfaceId,
-        localFolderPath: 'f:/',
-        locations: [{ repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public }],
-    };
-    const action = getModelDefinitionAction.started(params);
-    /* tslint:disable */
-    const modelDefinition = {
-        "@id": "urn:azureiot:ModelDiscovery:DigitalTwin:1",
-        "@type": "Interface",
-        "contents": [
-            {
-                "@type": "Property",
-                "name": "modelInformation",
-                "displayName": "Model Information",
-                "description": "Providing model and optional interfaces information on a digital twin.",
-                "schema": {
-                    "@type": "Object",
-                    "fields": [
-                        {
-                            "name": "modelId",
-                            "schema": "string"
-                        },
-                        {
-                            "name": "interfaces",
-                            "schema": {
-                                "@type": "Map",
-                                "mapKey": {
-                                    "name": "name",
-                                    "schema": "string"
-                                },
-                                "mapValue": {
-                                    "name": "schema",
-                                    "schema": "string"
+    describe('modelDefinition saga flow with no inline component', () => {
+        const digitalTwinId = 'device_id';
+        const interfaceId = 'interface_id';
+        const params: GetModelDefinitionActionParameters = {
+            digitalTwinId,
+            interfaceId,
+            localFolderPath: 'f:/',
+            locations: [{ repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public }],
+        };
+        const action = getModelDefinitionAction.started(params);
+        /* tslint:disable */
+        const modelDefinition = {
+            "@id": "urn:azureiot:ModelDiscovery:DigitalTwin:1",
+            "@type": "Interface",
+            "contents": [
+                {
+                    "@type": "Property",
+                    "name": "modelInformation",
+                    "displayName": "Model Information",
+                    "description": "Providing model and optional interfaces information on a digital twin.",
+                    "schema": {
+                        "@type": "Object",
+                        "fields": [
+                            {
+                                "name": "modelId",
+                                "schema": "string"
+                            },
+                            {
+                                "name": "interfaces",
+                                "schema": {
+                                    "@type": "Map",
+                                    "mapKey": {
+                                        "name": "name",
+                                        "schema": "string"
+                                    },
+                                    "mapValue": {
+                                        "name": "schema",
+                                        "schema": "string"
+                                    }
                                 }
                             }
-                        }
-                    ]
-                }
-            }
-        ],
-        "@context": "http://azureiot.com/v1/contexts/Interface.json"
-    };
-    /* tslint:enable */
-
-    describe('getModelDefinitionSaga', () => {
-        let getModelDefinitionSagaGenerator: SagaIteratorClone;
-
-        beforeAll(() => {
-            getModelDefinitionSagaGenerator = cloneableGenerator(getModelDefinitionSaga)(action);
-        });
-
-        it('fetches the model definition', () => {
-            expect(getModelDefinitionSagaGenerator.next().value).toEqual(
-                call(getModelDefinition, action, { repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public })
-            );
-
-            expect(getModelDefinitionSagaGenerator.next(modelDefinition).value).toEqual(
-                call(validateModelDefinitionHelper, modelDefinition, { repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public })
-            );
-        });
-
-        it('puts the successful action', () => {
-            const success = getModelDefinitionSagaGenerator.clone();
-            expect(success.next(true)).toEqual({
-                done: false,
-                value: put((getModelDefinitionAction.done({
-                    params,
-                    result: {
-                        isModelValid: true,
-                        modelDefinition,
-                        source: REPOSITORY_LOCATION_TYPE.Public
+                        ]
                     }
-                })))
+                }
+            ],
+            "@context": "http://azureiot.com/v1/contexts/Interface.json"
+        };
+        /* tslint:enable */
+
+        describe('getModelDefinitionSaga', () => {
+            let getModelDefinitionSagaGenerator: SagaIteratorClone;
+
+            beforeAll(() => {
+                getModelDefinitionSagaGenerator = cloneableGenerator(getModelDefinitionSaga)(action);
             });
 
-            expect(success.next().done).toEqual(true);
+            it('fetches the model definition', () => {
+                expect(getModelDefinitionSagaGenerator.next().value).toEqual(
+                    call(getModelDefinition, action, { repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public })
+                );
+
+                expect(getModelDefinitionSagaGenerator.next(modelDefinition).value).toEqual(
+                    call(validateModelDefinitionHelper, modelDefinition, { repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public })
+                );
+            });
+
+            it('puts the successful action', () => {
+                const success = getModelDefinitionSagaGenerator.clone();
+                expect(success.next(true)).toEqual({
+                    done: false,
+                    value: put((getModelDefinitionAction.done({
+                        params,
+                        result: {
+                            isModelValid: true,
+                            modelDefinition,
+                            source: REPOSITORY_LOCATION_TYPE.Public
+                        }
+                    })))
+                });
+
+                expect(success.next().done).toEqual(true);
+            });
+
+            it('fails on error', () => {
+                const failure = getModelDefinitionSagaGenerator.clone();
+
+                expect(failure.throw()).toEqual({
+                    done: false,
+                    value: call(raiseNotificationToast, {
+                        text: {
+                            translationKey: ResourceKeys.notifications.getInterfaceModelOnError,
+                            translationOptions: {
+                                interfaceId: params.interfaceId
+                            },
+                        },
+                        type: NotificationType.error,
+                    })
+                });
+
+                expect(failure.next()).toEqual({
+                    done: false,
+                    value: put(getModelDefinitionAction.failed({
+                        error: undefined,
+                        params
+                    }))
+                });
+                expect(failure.next().done).toEqual(true);
+            });
         });
 
-        it('fails on error', () => {
-            const failure = getModelDefinitionSagaGenerator.clone();
+        describe('getModelDefinitionFromPublicRepo ', () => {
+            const getModelDefinitionFromPublicRepoGenerator = cloneableGenerator(getModelDefinitionFromPublicRepo)(action);
 
-            expect(failure.throw()).toEqual({
+            expect(getModelDefinitionFromPublicRepoGenerator.next()).toEqual({
                 done: false,
-                value: call(raiseNotificationToast, {
-                    text: {
-                        translationKey: ResourceKeys.notifications.getInterfaceModelOnError,
-                        translationOptions: {
-                            interfaceId: params.interfaceId
-                        },
-                    },
-                    type: NotificationType.error,
+                value: call(getSplitedInterfaceId, action.payload.interfaceId)
+            });
+
+            expect(getModelDefinitionFromPublicRepoGenerator.next([action.payload.interfaceId])).toEqual({
+                done: false,
+                value: call(fetchModelDefinition, {
+                    id: action.payload.interfaceId,
+                    token: ''
                 })
             });
 
-            expect(failure.next()).toEqual({
+            expect(getModelDefinitionFromPublicRepoGenerator.next(modelDefinition)).toEqual({
                 done: false,
-                value: put(getModelDefinitionAction.failed({
-                    error: undefined,
-                    params
-                }))
+                value: call(getFlattenedModel, modelDefinition, [action.payload.interfaceId])
             });
-            expect(failure.next().done).toEqual(true);
-        });
-    });
 
-    describe('getModelDefinitionFromPublicRepo ', () => {
-        const getModelDefinitionFromPublicRepoGenerator = cloneableGenerator(getModelDefinitionFromPublicRepo)
-            (action, {repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public});
-
-        expect(getModelDefinitionFromPublicRepoGenerator.next()).toEqual({
-            done: false,
-            value: call(fetchModelDefinition, {
-                id: params.interfaceId,
-                token: ''
-            })
-        });
-
-        expect(getModelDefinitionFromPublicRepoGenerator.next().done).toEqual(true);
-    });
-
-    describe('getModelDefinitionFromLocalFile ', () => {
-        const getModelDefinitionFromLocalFolderGenerator = cloneableGenerator(getModelDefinitionFromLocalFile)
-            (action);
-
-        expect(getModelDefinitionFromLocalFolderGenerator.next()).toEqual({
-            done: false,
-            value: call(fetchLocalFile, 'f:', action.payload.interfaceId)
-        });
-
-        expect(getModelDefinitionFromLocalFolderGenerator.next().done).toEqual(true);
-    });
-
-    describe('getModelDefinition', () => {
-        it('getModelDefinition from public repo', () => {
-            const getModelDefinitionFromPublicRepoGenerator = cloneableGenerator(getModelDefinition)(action, {repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public});
-            expect(getModelDefinitionFromPublicRepoGenerator.next()).toEqual({
-                done: false,
-                value: call(getModelDefinitionFromPublicRepo, action, {repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public})
-            });
             expect(getModelDefinitionFromPublicRepoGenerator.next().done).toEqual(true);
         });
 
-        it('getModelDefinition from local', () => {
-            const getModelDefinitionFromDeviceGenerator = cloneableGenerator(getModelDefinition)(action,  {repositoryLocationType: REPOSITORY_LOCATION_TYPE.Local});
-            expect(getModelDefinitionFromDeviceGenerator.next()).toEqual({
+        describe('getModelDefinitionFromLocalFile ', () => {
+            const getModelDefinitionFromLocalFolderGenerator = cloneableGenerator(getModelDefinitionFromLocalFile)
+                (action);
+
+            expect(getModelDefinitionFromLocalFolderGenerator.next()).toEqual({
                 done: false,
-                value: call(getModelDefinitionFromLocalFile, action)
+                value: call(getSplitedInterfaceId, action.payload.interfaceId)
             });
-            expect(getModelDefinitionFromDeviceGenerator.next().done).toEqual(true);
+
+            expect(getModelDefinitionFromLocalFolderGenerator.next([action.payload.interfaceId])).toEqual({
+                done: false,
+                value: call(fetchLocalFile, 'f:', action.payload.interfaceId)
+            });
+
+            expect(getModelDefinitionFromLocalFolderGenerator.next(modelDefinition)).toEqual({
+                done: false,
+                value: call(getFlattenedModel, modelDefinition, [action.payload.interfaceId])
+            });
+
+            expect(getModelDefinitionFromLocalFolderGenerator.next().done).toEqual(true);
+        });
+
+        describe('getModelDefinition', () => {
+            it('getModelDefinition from public repo', () => {
+                const getModelDefinitionFromPublicRepoGenerator = cloneableGenerator(getModelDefinition)(action, {repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public});
+                expect(getModelDefinitionFromPublicRepoGenerator.next()).toEqual({
+                    done: false,
+                    value: call(getModelDefinitionFromPublicRepo, action)
+                });
+                expect(getModelDefinitionFromPublicRepoGenerator.next().done).toEqual(true);
+            });
+
+            it('getModelDefinition from local', () => {
+                const getModelDefinitionFromDeviceGenerator = cloneableGenerator(getModelDefinition)(action,  {repositoryLocationType: REPOSITORY_LOCATION_TYPE.Local});
+                expect(getModelDefinitionFromDeviceGenerator.next()).toEqual({
+                    done: false,
+                    value: call(getModelDefinitionFromLocalFile, action)
+                });
+                expect(getModelDefinitionFromDeviceGenerator.next().done).toEqual(true);
+            });
+        });
+
+        describe('getFlattenedModel ', () => {
+            const getFlattenedModelGenerator = cloneableGenerator(getFlattenedModel)(modelDefinition, [interfaceId]);
+
+            expect(getFlattenedModelGenerator.next()).toEqual({
+                done: true,
+                value: modelDefinition
+            });
+        });
+    });
+
+    describe('modelDefinition saga flow with inline component', () => {
+        const digitalTwinId = 'device_id';
+        const interfaceId = 'interface_id';
+        const schemaId = 'dtmi:com:rido:inlineTests:inlineComp;2';
+        const fullInterfaceId = `${interfaceId}/${schemaId}`;
+        const params: GetModelDefinitionActionParameters = {
+            digitalTwinId,
+            interfaceId: fullInterfaceId,
+            localFolderPath: 'f:/',
+            locations: [{ repositoryLocationType: REPOSITORY_LOCATION_TYPE.Public }],
+        };
+        const action = getModelDefinitionAction.started(params);
+        /* tslint:disable */
+        const modelDefinition: ModelDefinition = {
+            "@context": "dtmi:dtdl:context;2",
+            "@id": "dtmi:com:rido:inlineTests;2",
+            "@type": "Interface",
+            "contents": [
+              {
+                "@id": "dtmi:com:rido:inlineComp;2",
+                "@type": "Component",
+                "name": "inLineComponent",
+                "schema": {
+                  "@type": "Interface",
+                  "@id": schemaId,
+                  "contents": [
+                    {
+                      "@type" : "Property",
+                      "name" : "inlineProp",
+                      "schema" : "string"
+                    }
+                  ]
+                }
+              }
+            ]
+          };
+        /* tslint:enable */
+
+        describe('getModelDefinitionFromPublicRepo ', () => {
+            const getModelDefinitionFromPublicRepoGenerator = cloneableGenerator(getModelDefinitionFromPublicRepo)(action);
+
+            expect(getModelDefinitionFromPublicRepoGenerator.next()).toEqual({
+                done: false,
+                value: call(getSplitedInterfaceId, action.payload.interfaceId)
+            });
+
+            expect(getModelDefinitionFromPublicRepoGenerator.next([interfaceId, schemaId])).toEqual({
+                done: false,
+                value: call(fetchModelDefinition, {
+                    id: interfaceId,
+                    token: ''
+                })
+            });
+
+            expect(getModelDefinitionFromPublicRepoGenerator.next(modelDefinition)).toEqual({
+                done: false,
+                value: call(getFlattenedModel, modelDefinition, [interfaceId, schemaId])
+            });
+
+            expect(getModelDefinitionFromPublicRepoGenerator.next().done).toEqual(true);
+        });
+
+        describe('getModelDefinitionFromLocalFile ', () => {
+            const getModelDefinitionFromLocalFolderGenerator = cloneableGenerator(getModelDefinitionFromLocalFile)
+                (action);
+
+            expect(getModelDefinitionFromLocalFolderGenerator.next()).toEqual({
+                done: false,
+                value: call(getSplitedInterfaceId, action.payload.interfaceId)
+            });
+
+            expect(getModelDefinitionFromLocalFolderGenerator.next([interfaceId, schemaId])).toEqual({
+                done: false,
+                value: call(fetchLocalFile, 'f:', interfaceId)
+            });
+
+            expect(getModelDefinitionFromLocalFolderGenerator.next(modelDefinition)).toEqual({
+                done: false,
+                value: call(getFlattenedModel, modelDefinition, [interfaceId, schemaId])
+            });
+
+            expect(getModelDefinitionFromLocalFolderGenerator.next().done).toEqual(true);
+        });
+
+        describe('getFlattenedModel ', () => {
+            const getFlattenedModelGenerator = cloneableGenerator(getFlattenedModel)(modelDefinition, [interfaceId, schemaId]);
+
+            expect(getFlattenedModelGenerator.next()).toEqual({
+                done: true,
+                value: modelDefinition.contents[0]
+            });
         });
     });
 });

--- a/src/app/devices/pnp/sagas/getModelDefinitionSaga.ts
+++ b/src/app/devices/pnp/sagas/getModelDefinitionSaga.ts
@@ -75,38 +75,38 @@ export function* validateModelDefinitionHelper(modelDefinition: ModelDefinition,
     }
 }
 
-export function* getSplitedInterfaceId(fullName: string) {
+export const getSplitInterfaceId = (fullName: string) => {
     // when component definition is inline, interfaceId is compose of parent file name and inline schema id concatenated with a slash
     return fullName.split('/');
-}
+};
 
-export function* getFlattenedModel(model: ModelDefinition, splitedInterfaceId: string[]) {
-    if (splitedInterfaceId.length === 1) {
+export const getFlattenedModel = (model: ModelDefinition, splitInterfaceId: string[]) => {
+    if (splitInterfaceId.length === 1) {
         return model;
     }
     else {
         // for inline component, the flattened model is defined under contents array's with matching schema @id
         const components = model.contents.filter((content: any) => // tslint:disable-line: no-any
-            content['@type'] === 'Component' && typeof content.schema !== 'string' && content.schema['@id'] === splitedInterfaceId[1]);
+            content['@type'] === 'Component' && typeof content.schema !== 'string' && content.schema['@id'] === splitInterfaceId[1]);
         return components[0];
     }
-}
+};
 
 export function* getModelDefinitionFromPublicRepo(action: Action<GetModelDefinitionActionParameters>) {
-    const splitedInterfaceId = yield call(getSplitedInterfaceId, action.payload.interfaceId);
+    const splitInterfaceId = getSplitInterfaceId(action.payload.interfaceId);
     const parameters: FetchModelParameters = {
-        id: splitedInterfaceId[0],
+        id: splitInterfaceId[0],
         token: ''
     };
     const model = yield call(fetchModelDefinition, parameters);
-    return yield call(getFlattenedModel, model, splitedInterfaceId);
+    return getFlattenedModel(model, splitInterfaceId);
 }
 
 export function* getModelDefinitionFromLocalFile(action: Action<GetModelDefinitionActionParameters>) {
     const path = (action.payload.localFolderPath || '').replace(/\/$/, ''); // remove trailing slash
-    const splitedInterfaceId = yield call(getSplitedInterfaceId, action.payload.interfaceId);
-    const model = yield call(fetchLocalFile, path, splitedInterfaceId[0]);
-    return yield call(getFlattenedModel, model, splitedInterfaceId);
+    const splitInterfaceId = getSplitInterfaceId(action.payload.interfaceId);
+    const model = yield call(fetchLocalFile, path, splitInterfaceId[0]);
+    return getFlattenedModel(model, splitInterfaceId);
 }
 
 export function* getModelDefinition(action: Action<GetModelDefinitionActionParameters>, location: RepositoryLocationSettings) {

--- a/src/app/devices/pnp/sagas/getModelDefinitionSaga.ts
+++ b/src/app/devices/pnp/sagas/getModelDefinitionSaga.ts
@@ -75,17 +75,38 @@ export function* validateModelDefinitionHelper(modelDefinition: ModelDefinition,
     }
 }
 
-export function* getModelDefinitionFromPublicRepo(action: Action<GetModelDefinitionActionParameters>, location: RepositoryLocationSettings) {
+export function* getSplitedInterfaceId(fullName: string) {
+    // when component definition is inline, interfaceId is compose of parent file name and inline schema id concatenated with a slash
+    return fullName.split('/');
+}
+
+export function* getFlattenedModel(model: ModelDefinition, splitedInterfaceId: string[]) {
+    if (splitedInterfaceId.length === 1) {
+        return model;
+    }
+    else {
+        // for inline component, the flattened model is defined under contents array's with matching schema @id
+        const components = model.contents.filter((content: any) => // tslint:disable-line: no-any
+            content['@type'] === 'Component' && typeof content.schema !== 'string' && content.schema['@id'] === splitedInterfaceId[1]);
+        return components[0];
+    }
+}
+
+export function* getModelDefinitionFromPublicRepo(action: Action<GetModelDefinitionActionParameters>) {
+    const splitedInterfaceId = yield call(getSplitedInterfaceId, action.payload.interfaceId);
     const parameters: FetchModelParameters = {
-        id: action.payload.interfaceId,
+        id: splitedInterfaceId[0],
         token: ''
     };
-    return yield call(fetchModelDefinition, parameters);
+    const model = yield call(fetchModelDefinition, parameters);
+    return yield call(getFlattenedModel, model, splitedInterfaceId);
 }
 
 export function* getModelDefinitionFromLocalFile(action: Action<GetModelDefinitionActionParameters>) {
     const path = (action.payload.localFolderPath || '').replace(/\/$/, ''); // remove trailing slash
-    return yield call(fetchLocalFile, path, action.payload.interfaceId);
+    const splitedInterfaceId = yield call(getSplitedInterfaceId, action.payload.interfaceId);
+    const model = yield call(fetchLocalFile, path, splitedInterfaceId[0]);
+    return yield call(getFlattenedModel, model, splitedInterfaceId);
 }
 
 export function* getModelDefinition(action: Action<GetModelDefinitionActionParameters>, location: RepositoryLocationSettings) {
@@ -93,6 +114,6 @@ export function* getModelDefinition(action: Action<GetModelDefinitionActionParam
         case REPOSITORY_LOCATION_TYPE.Local:
             return yield call(getModelDefinitionFromLocalFile, action);
         default:
-            return yield call(getModelDefinitionFromPublicRepo, action, location);
+            return yield call(getModelDefinitionFromPublicRepo, action);
     }
 }

--- a/src/app/shared/utils/jsonSchemaAdaptor.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.ts
@@ -54,8 +54,16 @@ export class JsonSchemaAdaptor implements JsonSchemaAdaptorInterface{
     private readonly model: ModelDefinition;
     private readonly definitions: any; // tslint:disable-line: no-any
 
+    // tslint:disable-next-line: cyclomatic-complexity
     constructor(model: ModelDefinition) {
-        this.model = model;
+        // preprocess model to flatten if content is within schema
+        if (model && !model.contents && model.schema) {
+            this.model = JSON.parse(JSON.stringify(model)); // important: needs this deep copy to prevent model got changed
+            this.model.contents = model.schema.contents;
+        }
+        else {
+            this.model = model;
+        }
         const reusableSchema = model && model.schemas || [];
         this.definitions = {} as any; // tslint:disable-line: no-any
         reusableSchema.forEach(schema => {


### PR DESCRIPTION
When component is defined inline, we are showing a composite interface id on the ui, `{interfaceid}/{inlineSchemaId}`
And thus, when we are retrieving corresponding model from local and repo, we retrieve interface with matching` {interfaceId} `and then fetch the corresponding component definition of `{inlineSchemaId}` as a flattened model definition