### PR TITLE
Allow custome Telemetry enqueue time

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+---
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+Thank you for contributing to the Azure IoT Explorer!
+
+This checklist is used to make sure that common guidelines for a pull request are followed.
+
+### General Guidelines
+
+- [ ] If introducing new functionality or modified behavior, are they backed by unit tests?
+- [ ] Have **all** unit tests passed locally? (by running `npm run test` command)
+- [ ] Have you updated the README.md with new screenshots if significant changes have been made?
+- [ ] Have you update the package version if the current version in package.json is not higher than the version released?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "This project welcomes contributions and suggestions. Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "public/electron.js",
   "build": {

--- a/src/app/devices/deviceEvents/components/__snapshots__/commands.spec.tsx.snap
+++ b/src/app/devices/deviceEvents/components/__snapshots__/commands.spec.tsx.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`commands matches snapshot in electron 1`] = `
+<StyledCommandBarBase
+  farItems={
+    Array [
+      Object {
+        "ariaLabel": "deviceEvents.command.close",
+        "iconProps": Object {
+          "iconName": "NavigateBack",
+        },
+        "key": "NavigateBack",
+        "name": "deviceEvents.command.close",
+        "onClick": [Function],
+      },
+    ]
+  }
+  items={
+    Array [
+      Object {
+        "ariaLabel": "deviceEvents.command.stop",
+        "disabled": true,
+        "iconProps": Object {
+          "iconName": "StopSolid",
+        },
+        "key": "StopSolid",
+        "name": "deviceEvents.command.stop",
+        "onClick": [Function],
+      },
+      Object {
+        "ariaLabel": "Show modeled events",
+        "iconProps": Object {
+          "iconName": "CheckboxComposite",
+        },
+        "key": "Checkbox",
+        "name": "Show modeled events",
+        "onClick": [Function],
+      },
+      Object {
+        "ariaLabel": "deviceEvents.command.showSystemProperties",
+        "disabled": true,
+        "iconProps": Object {
+          "iconName": "CheckboxComposite",
+        },
+        "key": "CheckboxComposite",
+        "name": "deviceEvents.command.showSystemProperties",
+        "onClick": [Function],
+      },
+      Object {
+        "ariaLabel": "deviceEvents.command.refresh",
+        "disabled": false,
+        "iconProps": Object {
+          "iconName": "Refresh",
+        },
+        "key": "Refresh",
+        "name": "deviceEvents.command.refresh",
+        "onClick": undefined,
+      },
+      Object {
+        "ariaLabel": "deviceEvents.command.clearEvents",
+        "iconProps": Object {
+          "iconName": "Delete",
+        },
+        "key": "Clear",
+        "name": "deviceEvents.command.clearEvents",
+        "onClick": [Function],
+      },
+    ]
+  }
+/>
+`;
+
+exports[`commands matches snapshot in hosted environment 1`] = `
+<StyledCommandBarBase
+  farItems={
+    Array [
+      Object {
+        "ariaLabel": "deviceEvents.command.close",
+        "iconProps": Object {
+          "iconName": "NavigateBack",
+        },
+        "key": "NavigateBack",
+        "name": "deviceEvents.command.close",
+        "onClick": [Function],
+      },
+    ]
+  }
+  items={
+    Array [
+      Object {
+        "ariaLabel": "deviceEvents.command.fetch",
+        "disabled": true,
+        "iconProps": Object {
+          "iconName": "Play",
+        },
+        "key": "Play",
+        "name": "deviceEvents.command.fetch",
+        "onClick": [Function],
+      },
+      Object {
+        "ariaLabel": "Show modeled events",
+        "iconProps": Object {
+          "iconName": "Checkbox",
+        },
+        "key": "Checkbox",
+        "name": "Show modeled events",
+        "onClick": [Function],
+      },
+      Object {
+        "ariaLabel": "deviceEvents.command.showSystemProperties",
+        "disabled": true,
+        "iconProps": Object {
+          "iconName": "Checkbox",
+        },
+        "key": "CheckboxComposite",
+        "name": "deviceEvents.command.showSystemProperties",
+        "onClick": [Function],
+      },
+      Object {
+        "ariaLabel": "deviceEvents.command.refresh",
+        "disabled": true,
+        "iconProps": Object {
+          "iconName": "Refresh",
+        },
+        "key": "Refresh",
+        "name": "deviceEvents.command.refresh",
+        "onClick": undefined,
+      },
+      Object {
+        "ariaLabel": "deviceEvents.command.clearEvents",
+        "iconProps": Object {
+          "iconName": "Delete",
+        },
+        "key": "Clear",
+        "name": "deviceEvents.command.clearEvents",
+        "onClick": [Function],
+      },
+    ]
+  }
+/>
+`;

--- a/src/app/devices/deviceEvents/components/__snapshots__/customEventHub.spec.tsx.snap
+++ b/src/app/devices/deviceEvents/components/__snapshots__/customEventHub.spec.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`customEventHub matches snapshot 1`] = `
+<Stack
+  horizontal={true}
+  horizontalAlign="space-between"
+>
+  <StyledToggleBase
+    ariaLabel="deviceEvents.toggleUseDefaultEventHub.label"
+    checked={false}
+    className="stack-first-column"
+    disabled={true}
+    label="deviceEvents.toggleUseDefaultEventHub.label"
+    offText="deviceEvents.toggleUseDefaultEventHub.off"
+    onChange={[Function]}
+    onText="deviceEvents.toggleUseDefaultEventHub.on"
+  />
+  <Stack
+    className="stack-second-column"
+    horizontal={false}
+  >
+    <StyledTextFieldBase
+      ariaLabel="deviceEvents.customEventHub.connectionString.label"
+      className="custom-text-field"
+      disabled={true}
+      label="deviceEvents.customEventHub.connectionString.label"
+      onChange={[Function]}
+      placeholder="deviceEvents.customEventHub.connectionString.placeHolder"
+      required={true}
+      underlined={true}
+    />
+    <StyledTextFieldBase
+      ariaLabel="deviceEvents.customEventHub.name.label"
+      className="custom-text-field"
+      disabled={true}
+      label="deviceEvents.customEventHub.name.label"
+      onChange={[Function]}
+      required={true}
+      underlined={true}
+    />
+  </Stack>
+</Stack>
+`;

--- a/src/app/devices/deviceEvents/components/__snapshots__/deviceEvents.spec.tsx.snap
+++ b/src/app/devices/deviceEvents/components/__snapshots__/deviceEvents.spec.tsx.snap
@@ -1,190 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`deviceEvents deviceEvents in non-pnp context matches snapshot in electron 1`] = `
+exports[`deviceEvents deviceEvents in non-pnp context matches snapshot 1`] = `
 <div
   className="device-events"
   key="device-events"
 >
-  <StyledCommandBarBase
-    className="command"
-    farItems={null}
-    items={
-      Array [
-        Object {
-          "ariaLabel": "deviceEvents.command.start",
-          "disabled": false,
-          "iconProps": Object {
-            "iconName": "Play",
-          },
-          "key": "Play",
-          "name": "deviceEvents.command.start",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.showSystemProperties",
-          "disabled": false,
-          "iconProps": Object {
-            "iconName": "Checkbox",
-          },
-          "key": "CheckboxComposite",
-          "name": "deviceEvents.command.showSystemProperties",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Delete",
-          },
-          "key": "Clear",
-          "name": "deviceEvents.command.clearEvents",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Code",
-          },
-          "key": "deviceEvents.command.simulate",
-          "name": "deviceEvents.command.simulate",
-          "onClick": [Function],
-        },
-      ]
-    }
+  <Component
+    dispatch={[MockFunction]}
+    fetchData={[Function]}
+    monitoringData={false}
+    setMonitoringData={[Function]}
+    setShowPnpModeledEvents={[Function]}
+    setShowSimulationPanel={[Function]}
+    setShowSystemProperties={[Function]}
+    showPnpModeledEvents={false}
+    showSimulationPanel={false}
+    showSystemProperties={false}
+    startDisabled={false}
+    synchronizationStatus={1}
   />
   <Component
     headerText="deviceEvents.headerText"
     tooltip="deviceEvents.tooltip"
-  />
-  <StyledTextFieldBase
-    ariaLabel="deviceEvents.consumerGroups.label"
-    className="consumer-group-text-field"
-    disabled={false}
-    label="deviceEvents.consumerGroups.label"
-    onChange={[Function]}
-    onRenderLabel={[Function]}
-    underlined={true}
-    value="$Default"
-  />
-  <StyledToggleBase
-    ariaLabel="deviceEvents.toggleUseDefaultEventHub.label"
-    checked={true}
-    className="toggle-button"
-    disabled={false}
-    label="deviceEvents.toggleUseDefaultEventHub.label"
-    offText="deviceEvents.toggleUseDefaultEventHub.off"
-    onChange={[Function]}
-    onText="deviceEvents.toggleUseDefaultEventHub.on"
-  />
-  <Component
-    onToggleSimulationPanel={[Function]}
-    showSimulationPanel={false}
   />
   <div
-    className="device-events-container"
+    className="horizontal-item"
   >
-    <div
-      className="scrollable-telemetry"
-    >
-      <article
-        className="device-events-content"
-        key="0"
-      >
-        <h5>
-          9:44:58 PM, 10/14/2019
-          :
-        </h5>
-        <pre>
-          {
-  "body": {
-    "humid": 123
-  },
-  "enqueuedTime": "2019-10-14T21:44:58.397Z",
-  "properties": {
-    "iothub-message-schema": "humid"
-  }
-}
-        </pre>
-      </article>
-    </div>
+    <Component
+      consumerGroup="$Default"
+      monitoringData={false}
+      setConsumerGroup={[Function]}
+    />
   </div>
-</div>
-`;
-
-exports[`deviceEvents deviceEvents in non-pnp context matches snapshot in hosted environment 1`] = `
-<div
-  className="device-events"
-  key="device-events"
->
-  <StyledCommandBarBase
-    className="command"
-    farItems={null}
-    items={
-      Array [
-        Object {
-          "ariaLabel": "deviceEvents.command.fetch",
-          "disabled": false,
-          "iconProps": Object {
-            "iconName": "Play",
-          },
-          "key": "Play",
-          "name": "deviceEvents.command.fetch",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.showSystemProperties",
-          "disabled": false,
-          "iconProps": Object {
-            "iconName": "Checkbox",
-          },
-          "key": "CheckboxComposite",
-          "name": "deviceEvents.command.showSystemProperties",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Delete",
-          },
-          "key": "Clear",
-          "name": "deviceEvents.command.clearEvents",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Code",
-          },
-          "key": "deviceEvents.command.simulate",
-          "name": "deviceEvents.command.simulate",
-          "onClick": [Function],
-        },
-      ]
-    }
-  />
   <Component
-    headerText="deviceEvents.headerText"
-    tooltip="deviceEvents.tooltip"
+    monitoringData={false}
+    setHasError={[Function]}
+    setSpecifyStartTime={[Function]}
+    setStartTime={[Function]}
+    specifyStartTime={false}
   />
-  <StyledTextFieldBase
-    ariaLabel="deviceEvents.consumerGroups.label"
-    className="consumer-group-text-field"
-    disabled={false}
-    label="deviceEvents.consumerGroups.label"
-    onChange={[Function]}
-    onRenderLabel={[Function]}
-    underlined={true}
-    value="$Default"
-  />
-  <StyledToggleBase
-    ariaLabel="deviceEvents.toggleUseDefaultEventHub.label"
-    checked={true}
-    className="toggle-button"
-    disabled={false}
-    label="deviceEvents.toggleUseDefaultEventHub.label"
-    offText="deviceEvents.toggleUseDefaultEventHub.off"
-    onChange={[Function]}
-    onText="deviceEvents.toggleUseDefaultEventHub.on"
-  />
+  <div
+    className="horizontal-item"
+  >
+    <Component
+      monitoringData={false}
+      setCustomEventHubConnectionString={[Function]}
+      setCustomEventHubName={[Function]}
+      setHasError={[Function]}
+      setUseBuiltInEventHub={[Function]}
+      useBuiltInEventHub={false}
+    />
+  </div>
   <Component
     onToggleSimulationPanel={[Function]}
     showSimulationPanel={false}
@@ -225,76 +91,52 @@ exports[`deviceEvents deviceEvents in pnp context matches snapshot while interfa
   className="device-events"
   key="device-events"
 >
-  <StyledCommandBarBase
-    className="command"
-    farItems={null}
-    items={
-      Array [
-        Object {
-          "ariaLabel": "deviceEvents.command.fetch",
-          "disabled": false,
-          "iconProps": Object {
-            "iconName": "Play",
-          },
-          "key": "Play",
-          "name": "deviceEvents.command.fetch",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.showSystemProperties",
-          "disabled": true,
-          "iconProps": Object {
-            "iconName": "Checkbox",
-          },
-          "key": "CheckboxComposite",
-          "name": "deviceEvents.command.showSystemProperties",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Delete",
-          },
-          "key": "Clear",
-          "name": "deviceEvents.command.clearEvents",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Code",
-          },
-          "key": "deviceEvents.command.simulate",
-          "name": "deviceEvents.command.simulate",
-          "onClick": [Function],
-        },
-      ]
-    }
+  <Component
+    dispatch={[Function]}
+    fetchData={[Function]}
+    monitoringData={false}
+    setMonitoringData={[Function]}
+    setShowPnpModeledEvents={[Function]}
+    setShowSimulationPanel={[Function]}
+    setShowSystemProperties={[Function]}
+    showPnpModeledEvents={true}
+    showSimulationPanel={false}
+    showSystemProperties={false}
+    startDisabled={false}
+    synchronizationStatus={2}
   />
   <Component
     headerText="deviceEvents.headerText"
     tooltip="deviceEvents.tooltip"
   />
-  <StyledTextFieldBase
-    ariaLabel="deviceEvents.consumerGroups.label"
-    className="consumer-group-text-field"
-    disabled={false}
-    label="deviceEvents.consumerGroups.label"
-    onChange={[Function]}
-    onRenderLabel={[Function]}
-    underlined={true}
-    value="$Default"
+  <div
+    className="horizontal-item"
+  >
+    <Component
+      consumerGroup="$Default"
+      monitoringData={false}
+      setConsumerGroup={[Function]}
+    />
+  </div>
+  <Component
+    monitoringData={false}
+    setHasError={[Function]}
+    setSpecifyStartTime={[Function]}
+    setStartTime={[Function]}
+    specifyStartTime={false}
   />
-  <StyledToggleBase
-    ariaLabel="deviceEvents.toggleUseDefaultEventHub.label"
-    checked={true}
-    className="toggle-button"
-    disabled={false}
-    label="deviceEvents.toggleUseDefaultEventHub.label"
-    offText="deviceEvents.toggleUseDefaultEventHub.off"
-    onChange={[Function]}
-    onText="deviceEvents.toggleUseDefaultEventHub.on"
-  />
+  <div
+    className="horizontal-item"
+  >
+    <Component
+      monitoringData={false}
+      setCustomEventHubConnectionString={[Function]}
+      setCustomEventHubName={[Function]}
+      setHasError={[Function]}
+      setUseBuiltInEventHub={[Function]}
+      useBuiltInEventHub={false}
+    />
+  </div>
   <Component
     onToggleSimulationPanel={[Function]}
     showSimulationPanel={false}
@@ -309,170 +151,57 @@ exports[`deviceEvents deviceEvents in pnp context matches snapshot while interfa
 </div>
 `;
 
-exports[`deviceEvents deviceEvents in pnp context matches snapshot while interface definition is retrieved in electron 1`] = `
+exports[`deviceEvents deviceEvents in pnp context matches snapshot while interface definition is retrieved 1`] = `
 <div
   className="device-events"
   key="device-events"
 >
-  <StyledCommandBarBase
-    className="command"
-    farItems={null}
-    items={
-      Array [
-        Object {
-          "ariaLabel": "deviceEvents.command.start",
-          "disabled": false,
-          "iconProps": Object {
-            "iconName": "Play",
-          },
-          "key": "Play",
-          "name": "deviceEvents.command.start",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.showSystemProperties",
-          "disabled": true,
-          "iconProps": Object {
-            "iconName": "Checkbox",
-          },
-          "key": "CheckboxComposite",
-          "name": "deviceEvents.command.showSystemProperties",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Delete",
-          },
-          "key": "Clear",
-          "name": "deviceEvents.command.clearEvents",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Code",
-          },
-          "key": "deviceEvents.command.simulate",
-          "name": "deviceEvents.command.simulate",
-          "onClick": [Function],
-        },
-      ]
-    }
+  <Component
+    dispatch={[Function]}
+    fetchData={[Function]}
+    monitoringData={false}
+    setMonitoringData={[Function]}
+    setShowPnpModeledEvents={[Function]}
+    setShowSimulationPanel={[Function]}
+    setShowSystemProperties={[Function]}
+    showPnpModeledEvents={true}
+    showSimulationPanel={false}
+    showSystemProperties={false}
+    startDisabled={false}
+    synchronizationStatus={2}
   />
   <Component
     headerText="deviceEvents.headerText"
     tooltip="deviceEvents.tooltip"
-  />
-  <StyledTextFieldBase
-    ariaLabel="deviceEvents.consumerGroups.label"
-    className="consumer-group-text-field"
-    disabled={false}
-    label="deviceEvents.consumerGroups.label"
-    onChange={[Function]}
-    onRenderLabel={[Function]}
-    underlined={true}
-    value="$Default"
-  />
-  <StyledToggleBase
-    ariaLabel="deviceEvents.toggleUseDefaultEventHub.label"
-    checked={true}
-    className="toggle-button"
-    disabled={false}
-    label="deviceEvents.toggleUseDefaultEventHub.label"
-    offText="deviceEvents.toggleUseDefaultEventHub.off"
-    onChange={[Function]}
-    onText="deviceEvents.toggleUseDefaultEventHub.on"
-  />
-  <Component
-    onToggleSimulationPanel={[Function]}
-    showSimulationPanel={false}
   />
   <div
-    className="device-events-container"
+    className="horizontal-item"
   >
-    <div
-      className="scrollable-telemetry"
+    <Component
+      consumerGroup="$Default"
+      monitoringData={false}
+      setConsumerGroup={[Function]}
     />
   </div>
-</div>
-`;
-
-exports[`deviceEvents deviceEvents in pnp context matches snapshot while interface definition is retrieved in hosted environment 1`] = `
-<div
-  className="device-events"
-  key="device-events"
->
-  <StyledCommandBarBase
-    className="command"
-    farItems={null}
-    items={
-      Array [
-        Object {
-          "ariaLabel": "deviceEvents.command.fetch",
-          "disabled": false,
-          "iconProps": Object {
-            "iconName": "Play",
-          },
-          "key": "Play",
-          "name": "deviceEvents.command.fetch",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.showSystemProperties",
-          "disabled": true,
-          "iconProps": Object {
-            "iconName": "Checkbox",
-          },
-          "key": "CheckboxComposite",
-          "name": "deviceEvents.command.showSystemProperties",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Delete",
-          },
-          "key": "Clear",
-          "name": "deviceEvents.command.clearEvents",
-          "onClick": [Function],
-        },
-        Object {
-          "ariaLabel": "deviceEvents.command.clearEvents",
-          "iconProps": Object {
-            "iconName": "Code",
-          },
-          "key": "deviceEvents.command.simulate",
-          "name": "deviceEvents.command.simulate",
-          "onClick": [Function],
-        },
-      ]
-    }
-  />
   <Component
-    headerText="deviceEvents.headerText"
-    tooltip="deviceEvents.tooltip"
+    monitoringData={false}
+    setHasError={[Function]}
+    setSpecifyStartTime={[Function]}
+    setStartTime={[Function]}
+    specifyStartTime={false}
   />
-  <StyledTextFieldBase
-    ariaLabel="deviceEvents.consumerGroups.label"
-    className="consumer-group-text-field"
-    disabled={false}
-    label="deviceEvents.consumerGroups.label"
-    onChange={[Function]}
-    onRenderLabel={[Function]}
-    underlined={true}
-    value="$Default"
-  />
-  <StyledToggleBase
-    ariaLabel="deviceEvents.toggleUseDefaultEventHub.label"
-    checked={true}
-    className="toggle-button"
-    disabled={false}
-    label="deviceEvents.toggleUseDefaultEventHub.label"
-    offText="deviceEvents.toggleUseDefaultEventHub.off"
-    onChange={[Function]}
-    onText="deviceEvents.toggleUseDefaultEventHub.on"
-  />
+  <div
+    className="horizontal-item"
+  >
+    <Component
+      monitoringData={false}
+      setCustomEventHubConnectionString={[Function]}
+      setCustomEventHubName={[Function]}
+      setHasError={[Function]}
+      setUseBuiltInEventHub={[Function]}
+      useBuiltInEventHub={false}
+    />
+  </div>
   <Component
     onToggleSimulationPanel={[Function]}
     showSimulationPanel={false}

--- a/src/app/devices/deviceEvents/components/__snapshots__/startTime.spec.tsx.snap
+++ b/src/app/devices/deviceEvents/components/__snapshots__/startTime.spec.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`startTime matches snapshot 1`] = `
+<Stack
+  horizontal={true}
+  horizontalAlign="space-between"
+>
+  <StyledToggleBase
+    ariaLabel="deviceEvents.toggleSpecifyStartingTime.label"
+    checked={true}
+    className="stack-first-column"
+    disabled={true}
+    label={
+      <Unknown
+        className="consumer-group-label"
+        tooltipText="deviceEvents.startTime.tooltip"
+      >
+        deviceEvents.toggleSpecifyStartingTime.label
+      </Unknown>
+    }
+    offText="deviceEvents.toggleSpecifyStartingTime.off"
+    onChange={[Function]}
+    onText="deviceEvents.toggleSpecifyStartingTime.on"
+  />
+  <div
+    className="stack-second-column"
+  >
+    <StyledTextFieldBase
+      ariaLabel="deviceEvents.startTime.label"
+      className="custom-text-field"
+      disabled={true}
+      label="deviceEvents.startTime.label"
+      onChange={[Function]}
+      placeholder="yyyy/mm/dd/hh/mm/ss"
+      required={true}
+      underlined={true}
+    />
+  </div>
+</Stack>
+`;

--- a/src/app/devices/deviceEvents/components/commands.spec.tsx
+++ b/src/app/devices/deviceEvents/components/commands.spec.tsx
@@ -1,0 +1,101 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import 'jest';
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { shallow, mount } from 'enzyme';
+import { CommandBar } from 'office-ui-fabric-react/lib/components/CommandBar';
+import { Commands } from './commands';
+import { SynchronizationStatus } from '../../../api/models/synchronizationStatus';
+import { appConfig, HostMode } from '../../../../appConfig/appConfig';
+
+const search = '?deviceId=test&componentName=DEFAULT_COMPONENT&interfaceId=dtmi:com:example:Thermostat;1';
+const pathname = `#devices/deviceDetail/ioTPlugAndPlay/ioTPlugAndPlayDetail/events/${search}`;
+jest.mock('react-router-dom', () => ({
+    useHistory: () => ({ push: jest.fn() }),
+    useLocation: () => ({ search, pathname, push: jest.fn() })
+}));
+
+describe('commands', () => {
+    it('matches snapshot in electron', () => {
+        appConfig.hostMode = HostMode.Electron;
+        expect(shallow(
+            <Commands
+                startDisabled={true}
+                synchronizationStatus={SynchronizationStatus.fetched}
+                monitoringData={true}
+                showSystemProperties={true}
+                showPnpModeledEvents={true}
+                showSimulationPanel={true}
+                setMonitoringData={jest.fn()}
+                setShowSystemProperties={jest.fn()}
+                setShowPnpModeledEvents={jest.fn()}
+                setShowSimulationPanel={jest.fn()}
+                dispatch={jest.fn()}
+                fetchData={jest.fn()}
+            />)).toMatchSnapshot();
+    });
+
+    it('matches snapshot in hosted environment', () => {
+        appConfig.hostMode = HostMode.Browser;
+        expect(shallow(
+            <Commands
+                startDisabled={false}
+                synchronizationStatus={SynchronizationStatus.updating}
+                monitoringData={false}
+                showSystemProperties={false}
+                showPnpModeledEvents={false}
+                showSimulationPanel={false}
+                setMonitoringData={jest.fn()}
+                setShowSystemProperties={jest.fn()}
+                setShowPnpModeledEvents={jest.fn()}
+                setShowSimulationPanel={jest.fn()}
+                dispatch={jest.fn()}
+                fetchData={jest.fn()}
+            />)).toMatchSnapshot();
+    });
+
+    it('makes expected calls', () => {
+        const mockSetMonitoringData = jest.fn();
+        const mockSetShowPnpModeledEvents = jest.fn();
+        const mockSetShowSystemProperties = jest.fn();
+        const mockDispatch = jest.fn();
+        const wrapper = mount(
+            <Commands
+                startDisabled={false}
+                synchronizationStatus={SynchronizationStatus.fetched}
+                monitoringData={true}
+                showSystemProperties={true}
+                showPnpModeledEvents={true}
+                showSimulationPanel={true}
+                setMonitoringData={mockSetMonitoringData}
+                setShowSystemProperties={mockSetShowSystemProperties}
+                setShowPnpModeledEvents={mockSetShowPnpModeledEvents}
+                setShowSimulationPanel={jest.fn()}
+                dispatch={jest.fn()}
+                fetchData={jest.fn()}
+            />);
+
+            expect(wrapper.find(CommandBar).props().items.length).toEqual(5);
+            act(() => {
+                wrapper.find(CommandBar).props().items[0].onClick(undefined);
+            });
+            wrapper.update();
+            expect(mockSetMonitoringData).toBeCalledWith(false);
+
+            act(() => {
+                wrapper.find(CommandBar).props().items[1].onClick(undefined);
+            });
+            wrapper.update();
+            expect(mockSetShowPnpModeledEvents).toBeCalledWith(false);
+
+
+            act(() => {
+                wrapper.find(CommandBar).props().items[2].onClick(undefined);
+            });
+            wrapper.update();
+            expect(mockSetShowSystemProperties).toBeCalledWith(false);
+    });
+});

--- a/src/app/devices/deviceEvents/components/commands.tsx
+++ b/src/app/devices/deviceEvents/components/commands.tsx
@@ -1,0 +1,209 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useHistory } from 'react-router-dom';
+import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/components/CommandBar';
+import { ResourceKeys } from '../../../../localization/resourceKeys';
+import { CLEAR, CHECKED_CHECKBOX, EMPTY_CHECKBOX, START, STOP, NAVIGATE_BACK, REFRESH, REMOVE, CODE } from '../../../constants/iconNames';
+import { SynchronizationStatus } from '../../../api/models/synchronizationStatus';
+import { appConfig, HostMode } from '../../../../appConfig/appConfig';
+import { clearMonitoringEventsAction } from './../actions';
+import { ROUTE_PARAMS } from '../../../constants/routes';
+import { getComponentNameFromQueryString, getDeviceIdFromQueryString } from '../../../shared/utils/queryStringHelper';
+import { usePnpStateContext } from '../../../shared/contexts/pnpStateContext';
+import './deviceEvents.scss';
+
+export interface CommandsProps {
+    startDisabled: boolean;
+    synchronizationStatus: SynchronizationStatus;
+    monitoringData: boolean;
+    showSystemProperties: boolean;
+    showPnpModeledEvents: boolean;
+    showSimulationPanel: boolean;
+    setMonitoringData: (monitoringData: boolean) => void;
+    setShowSystemProperties: (showSystemProperties: boolean) => void;
+    setShowPnpModeledEvents: (showPnpModeledEvents: boolean) => void;
+    setShowSimulationPanel: (showSimulationPanel: boolean) => void;
+    dispatch(action: any): void; // tslint:disable-line: no-any
+    fetchData(): void;
+}
+
+export const Commands: React.FC<CommandsProps> = ({
+    startDisabled,
+    synchronizationStatus,
+    monitoringData,
+    showSystemProperties,
+    showPnpModeledEvents,
+    showSimulationPanel,
+    setMonitoringData,
+    setShowSystemProperties,
+    setShowPnpModeledEvents,
+    setShowSimulationPanel,
+    dispatch,
+    fetchData}) => {
+
+    const {t} = useTranslation();
+    const { search, pathname } = useLocation();
+    const history = useHistory();
+    const { pnpState, getModelDefinition } = usePnpStateContext();
+    const componentName = getComponentNameFromQueryString(search); // if component name exist, we are in pnp context
+    const deviceId = getDeviceIdFromQueryString(search);
+
+    const createCommandBarItems = (): ICommandBarItemProps[] => {
+        if (componentName) {
+            return [createStartMonitoringCommandItem(),
+                createPnpModeledEventsCommandItem(),
+                createSystemPropertiesCommandItem(),
+                createRefreshCommandItem(),
+                createClearCommandItem()
+            ];
+        }
+        else {
+            return [createStartMonitoringCommandItem(),
+                createSystemPropertiesCommandItem(),
+                createClearCommandItem(),
+                createSimulationCommandItem()
+            ];
+        }
+    };
+
+    const createClearCommandItem = (): ICommandBarItemProps => {
+        return {
+            ariaLabel: t(ResourceKeys.deviceEvents.command.clearEvents),
+            iconProps: {
+                iconName: REMOVE
+            },
+            key: CLEAR,
+            name: t(ResourceKeys.deviceEvents.command.clearEvents),
+            onClick: onClearData
+        };
+    };
+
+    const createSystemPropertiesCommandItem = (): ICommandBarItemProps => {
+        return {
+            ariaLabel: t(ResourceKeys.deviceEvents.command.showSystemProperties),
+            disabled: synchronizationStatus === SynchronizationStatus.updating || showPnpModeledEvents,
+            iconProps: {
+                iconName: showSystemProperties ? CHECKED_CHECKBOX : EMPTY_CHECKBOX
+            },
+            key: CHECKED_CHECKBOX,
+            name: t(ResourceKeys.deviceEvents.command.showSystemProperties),
+            onClick: onShowSystemProperties
+        };
+    };
+
+    const createPnpModeledEventsCommandItem = (): ICommandBarItemProps => {
+        return {
+            ariaLabel: 'Show modeled events',
+            iconProps: {
+                iconName: showPnpModeledEvents ? CHECKED_CHECKBOX : EMPTY_CHECKBOX
+            },
+            key: EMPTY_CHECKBOX,
+            name: 'Show modeled events',
+            onClick: onShowPnpModeledEvents
+        };
+    };
+
+    // tslint:disable-next-line: cyclomatic-complexity
+    const createStartMonitoringCommandItem = (): ICommandBarItemProps => {
+        if (appConfig.hostMode === HostMode.Electron) {
+            const label = monitoringData ? t(ResourceKeys.deviceEvents.command.stop) : t(ResourceKeys.deviceEvents.command.start);
+            const icon = monitoringData ? STOP : START;
+            return {
+                ariaLabel: label,
+                disabled: startDisabled,
+                iconProps: {
+                    iconName: icon
+                },
+                key: icon,
+                name: label,
+                onClick: onToggleStart
+            };
+        }
+        else {
+            return {
+                ariaLabel: t(ResourceKeys.deviceEvents.command.fetch),
+                disabled: synchronizationStatus === SynchronizationStatus.updating || monitoringData,
+                iconProps: {
+                    iconName: START
+                },
+                key: START,
+                name: t(ResourceKeys.deviceEvents.command.fetch),
+                onClick: onToggleStart
+            };
+        }
+    };
+
+    const createSimulationCommandItem = (): ICommandBarItemProps => {
+        return {
+            ariaLabel: t(ResourceKeys.deviceEvents.command.clearEvents),
+            iconProps: {
+                iconName: CODE
+            },
+            key: t(ResourceKeys.deviceEvents.command.simulate),
+            name: t(ResourceKeys.deviceEvents.command.simulate),
+            onClick: onToggleSimulationPanel
+        };
+    };
+
+    const createRefreshCommandItem = (): ICommandBarItemProps => {
+        return {
+            ariaLabel: t(ResourceKeys.deviceEvents.command.refresh),
+            disabled: synchronizationStatus === SynchronizationStatus.updating,
+            iconProps: {iconName: REFRESH},
+            key: REFRESH,
+            name: t(ResourceKeys.deviceEvents.command.refresh),
+            onClick: getModelDefinition
+        };
+    };
+
+    const createNavigateBackCommandItem = (): ICommandBarItemProps => {
+        return {
+            ariaLabel: t(ResourceKeys.deviceEvents.command.close),
+            iconProps: {iconName: NAVIGATE_BACK},
+            key: NAVIGATE_BACK,
+            name: t(ResourceKeys.deviceEvents.command.close),
+            onClick: handleClose
+        };
+    };
+
+    const handleClose = () => {
+        const path = pathname.replace(/\/ioTPlugAndPlayDetail\/events\/.*/, ``);
+        history.push(`${path}/?${ROUTE_PARAMS.DEVICE_ID}=${encodeURIComponent(deviceId)}`);
+    };
+
+    const onToggleStart = () => {
+        if (monitoringData) {
+            setMonitoringData(false);
+        } else {
+            fetchData();
+            setMonitoringData(true);
+        }
+    };
+
+    const onClearData = () => {
+        dispatch(clearMonitoringEventsAction());
+    };
+
+    const onShowSystemProperties = () => {
+        setShowSystemProperties(!showSystemProperties);
+    };
+
+    const onShowPnpModeledEvents = () => {
+        setShowPnpModeledEvents(!showPnpModeledEvents);
+    };
+
+    const onToggleSimulationPanel = () => {
+        setShowSimulationPanel(!showSimulationPanel);
+    };
+
+    return (
+        <CommandBar
+            items={createCommandBarItems()}
+            farItems={componentName && [createNavigateBackCommandItem()]}
+        />
+    );
+};

--- a/src/app/devices/deviceEvents/components/consumerGroup.tsx
+++ b/src/app/devices/deviceEvents/components/consumerGroup.tsx
@@ -1,0 +1,46 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ITextFieldProps, TextField } from 'office-ui-fabric-react/lib/components/TextField';
+import { ResourceKeys } from '../../../../localization/resourceKeys';
+import { LabelWithTooltip } from '../../../shared/components/labelWithTooltip';
+import './deviceEvents.scss';
+
+export interface ConsumerGroupProps {
+    monitoringData: boolean;
+    consumerGroup: string;
+    setConsumerGroup: (consumerGroup: string) => void;
+}
+
+export const ConsumerGroup: React.FC<ConsumerGroupProps> = ({monitoringData, consumerGroup, setConsumerGroup}) => {
+
+    const { t } = useTranslation();
+    const renderConsumerGroupLabel = (textFieldProps: ITextFieldProps) => (
+        <LabelWithTooltip
+            className={'consumer-group-label'}
+            tooltipText={t(ResourceKeys.deviceEvents.consumerGroups.tooltip)}
+        >
+            {textFieldProps.label}
+        </LabelWithTooltip>
+    );
+
+    const consumerGroupChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+        setConsumerGroup(newValue);
+    };
+
+    return (
+        <TextField
+            className={'consumer-group-text-field'}
+            onRenderLabel={renderConsumerGroupLabel}
+            label={t(ResourceKeys.deviceEvents.consumerGroups.label)}
+            ariaLabel={t(ResourceKeys.deviceEvents.consumerGroups.label)}
+            underlined={true}
+            value={consumerGroup}
+            disabled={monitoringData}
+            onChange={consumerGroupChange}
+        />
+    );
+};

--- a/src/app/devices/deviceEvents/components/customEventHub.spec.tsx
+++ b/src/app/devices/deviceEvents/components/customEventHub.spec.tsx
@@ -1,0 +1,61 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import 'jest';
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { shallow, mount } from 'enzyme';
+import { Toggle } from 'office-ui-fabric-react/lib/components/Toggle';
+import { TextField } from 'office-ui-fabric-react/lib/components/TextField';
+import { CustomEventHub } from './customEventHub';
+
+const search = '?deviceId=test&componentName=DEFAULT_COMPONENT&interfaceId=dtmi:com:example:Thermostat;1';
+const pathname = `#devices/deviceDetail/ioTPlugAndPlay/ioTPlugAndPlayDetail/events/${search}`;
+jest.mock('react-router-dom', () => ({
+    useHistory: () => ({ push: jest.fn() }),
+    useLocation: () => ({ search, pathname, push: jest.fn() })
+}));
+
+describe('customEventHub', () => {
+    it('matches snapshot', () => {
+        expect(shallow(
+            <CustomEventHub
+                monitoringData={true}
+                useBuiltInEventHub={false}
+                customEventHubName={undefined}
+                customEventHubConnectionString={undefined}
+                setUseBuiltInEventHub={jest.fn()}
+                setCustomEventHubName={jest.fn()}
+                setCustomEventHubConnectionString={jest.fn()}
+                setHasError={jest.fn()}
+            />)).toMatchSnapshot();
+    });
+
+    it('specifies custom strings', () => {
+        const mockSetUseBuiltInEventHub = jest.fn();
+        const mockSetCustomEventHubName = jest.fn();
+        const mockSetCustomEventHubConnectionString = jest.fn();
+        const wrapper = mount(
+            <CustomEventHub
+                monitoringData={true}
+                useBuiltInEventHub={false}
+                customEventHubName={undefined}
+                customEventHubConnectionString={undefined}
+                setUseBuiltInEventHub={mockSetUseBuiltInEventHub}
+                setCustomEventHubName={mockSetCustomEventHubName}
+                setCustomEventHubConnectionString={mockSetCustomEventHubConnectionString}
+                setHasError={jest.fn()}
+            />);
+
+        act(() => wrapper.find(Toggle).first().props().onChange(undefined, false));
+        wrapper.update();
+        expect(mockSetUseBuiltInEventHub).toBeCalledWith(true);
+
+        act(() => wrapper.find(TextField).first().props().onChange(undefined, 'connectionString'));
+        act(() => wrapper.find(TextField).at(1).props().onChange(undefined, 'hubName'));
+        wrapper.update();
+        expect(mockSetCustomEventHubConnectionString).toBeCalledWith('connectionString');
+        expect(mockSetCustomEventHubName).toBeCalledWith('hubName');
+    });
+});

--- a/src/app/devices/deviceEvents/components/customEventHub.tsx
+++ b/src/app/devices/deviceEvents/components/customEventHub.tsx
@@ -1,0 +1,101 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Toggle } from 'office-ui-fabric-react/lib/components/Toggle';
+import { TextField } from 'office-ui-fabric-react/lib/components/TextField';
+import { Stack } from 'office-ui-fabric-react/lib/components/Stack';
+import { ResourceKeys } from '../../../../localization/resourceKeys';
+import { isValidEventHubConnectionString } from '../../../shared/utils/hubConnectionStringHelper';
+import './deviceEvents.scss';
+
+export interface CustomEventHubProps {
+    monitoringData: boolean;
+    useBuiltInEventHub: boolean;
+    customEventHubName: string;
+    customEventHubConnectionString: string;
+    setUseBuiltInEventHub: (monitoringData: boolean) => void;
+    setCustomEventHubName: (customEventHubName: string) => void;
+    setCustomEventHubConnectionString: (customEventHubConnectionString: string) => void;
+    setHasError: (hasError: boolean) => void;
+}
+
+export const CustomEventHub: React.FC<CustomEventHubProps> = ({
+    monitoringData,
+    useBuiltInEventHub,
+    customEventHubName,
+    customEventHubConnectionString,
+    setUseBuiltInEventHub,
+    setCustomEventHubName,
+    setCustomEventHubConnectionString,
+    setHasError}) => {
+
+    const { t } = useTranslation();
+    const [ error, setError ] = React.useState<string>();
+
+    React.useEffect(() => {
+        if (!isValidEventHubConnectionString(customEventHubConnectionString)) {
+            setError(t(ResourceKeys.deviceEvents.customEventHub.connectionString.error));
+            setHasError(true);
+        }
+        else {
+            setError('');
+            setHasError(false);
+        }
+    },              [customEventHubConnectionString]);
+
+    const toggleChange = () => {
+        setUseBuiltInEventHub(!useBuiltInEventHub);
+    };
+
+    const customEventHubConnectionStringChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+        setCustomEventHubConnectionString(newValue);
+    };
+
+    const customEventHubNameChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+        setCustomEventHubName(newValue);
+    };
+
+    return (
+        <Stack horizontal={true} horizontalAlign="space-between">
+            <Toggle
+                className="stack-first-column"
+                checked={useBuiltInEventHub}
+                ariaLabel={t(ResourceKeys.deviceEvents.toggleUseDefaultEventHub.label)}
+                label={t(ResourceKeys.deviceEvents.toggleUseDefaultEventHub.label)}
+                onText={t(ResourceKeys.deviceEvents.toggleUseDefaultEventHub.on)}
+                offText={t(ResourceKeys.deviceEvents.toggleUseDefaultEventHub.off)}
+                onChange={toggleChange}
+                disabled={monitoringData}
+            />
+            {!useBuiltInEventHub &&
+                <Stack horizontal={false} className="stack-second-column">
+                    <TextField
+                        className="custom-text-field"
+                        label={t(ResourceKeys.deviceEvents.customEventHub.connectionString.label)}
+                        ariaLabel={t(ResourceKeys.deviceEvents.customEventHub.connectionString.label)}
+                        underlined={true}
+                        value={customEventHubConnectionString}
+                        disabled={monitoringData}
+                        onChange={customEventHubConnectionStringChange}
+                        placeholder={t(ResourceKeys.deviceEvents.customEventHub.connectionString.placeHolder)}
+                        errorMessage={error}
+                        required={true}
+                    />
+                    <TextField
+                        className="custom-text-field"
+                        label={t(ResourceKeys.deviceEvents.customEventHub.name.label)}
+                        ariaLabel={t(ResourceKeys.deviceEvents.customEventHub.name.label)}
+                        underlined={true}
+                        value={customEventHubName}
+                        disabled={monitoringData}
+                        onChange={customEventHubNameChange}
+                        required={true}
+                    />
+                </Stack>
+            }
+        </Stack>
+    );
+};

--- a/src/app/devices/deviceEvents/components/deviceEvents.scss
+++ b/src/app/devices/deviceEvents/components/deviceEvents.scss
@@ -7,17 +7,13 @@
 
 .device-events {
     .device-events-container {
-        margin-left: 15px;
-        .events-loader {
-            padding: 0 25px;
-            .ms-Spinner {
-                float: left;
-                padding-right: 5px;
-            }
+        @include themify($themes) {
+            border-top: 1px solid themed('contrastBorder');
         }
+        margin-left: 15px;
         .device-events-content {
             @include themify($themes) {
-                border-top: 1px solid themed('contrastBorder');
+                border-bottom: 1px solid themed('contrastBorder');
             }
             padding: 0 25px;
             width: 100%;
@@ -42,7 +38,7 @@
         @include themify($themes) {
             color: themed('textColor');
         }
-        width: 80%;
+        width: 85%;
     }
 
     .custom-event-hub-label {
@@ -53,36 +49,14 @@
         }
     }
 
-    .custom-event-hub-text-field {
-        display: grid;
-        padding-left: 24px;
-        padding-bottom: 10px;
-        @include themify($themes) {
-            color: themed('textColor');
-        }
-        width: 80%;
-    }
-
-    .toggle-button {
-        padding-left: 24px;
-    }
-
     .scrollable-telemetry {
-        height: calc(100vh - 390px);
+        height: calc(100vh - 480px);
         overflow-y: auto;
         overflow-x: hidden;
     }
 
-    .scrollable-telemetry-custom {
-        height: calc(100vh - 482px) !important;
-    }
-
-    .scrollable-pnp-telemetry-custom {
-        height: calc(100vh - 525px) !important;
-    }
-
     .scrollable-pnp-telemetry {
-        height: calc(100vh - 433px);
+        height: calc(100vh - 520px);
         overflow-y: auto;
         overflow-x: hidden;
         .column-value-text {
@@ -117,5 +91,23 @@
         @include themify($themes) {
             border-bottom-color: themed('borderColor');
         }
+    }
+
+    .stack-first-column {
+        padding-left: 24px;
+        min-width: 22%;
+    }
+
+    .stack-second-column {
+        .custom-text-field {
+            display: grid;
+            padding-left: 24px;
+            padding-bottom: 10px;
+            @include themify($themes) {
+                color: themed('textColor');
+            }
+            width: 80%;
+        }
+        width: 100%;
     }
 }

--- a/src/app/devices/deviceEvents/components/deviceEvents.spec.tsx
+++ b/src/app/devices/deviceEvents/components/deviceEvents.spec.tsx
@@ -25,7 +25,6 @@ import { ResourceKeys } from '../../../../localization/resourceKeys';
 import * as TransformHelper from '../../../api/dataTransforms/transformHelper';
 
 const pathname = `#/devices/detail/events/?id=device1`;
-const currentTime = new Date();
 jest.mock('react-router-dom', () => ({
     useHistory: () => ({ push: jest.fn() }),
     useLocation: () => ({ search: `?deviceId=device1`, pathname, push: jest.fn() })
@@ -42,19 +41,23 @@ describe('deviceEvents', () => {
             'iothub-message-schema': 'humid'
             }
         }];
+
         beforeEach(() => {
             jest.spyOn(AsyncSagaReducer, 'useAsyncSagaReducer').mockReturnValue([{
                 payload: events,
                 synchronizationStatus: SynchronizationStatus.fetched
             }, jest.fn()]);
+
             const realUseState = React.useState;
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(DEFAULT_CONSUMER_GROUP));
-            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
-            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
-            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(currentTime));
-            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(true));
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
             jest.spyOn(TransformHelper, 'parseDateTimeString').mockImplementationOnce(parameters => {
@@ -67,13 +70,7 @@ describe('deviceEvents', () => {
             jest.restoreAllMocks();
         });
 
-        it('matches snapshot in electron', () => {
-            appConfig.hostMode = HostMode.Electron;
-            expect(shallow(<DeviceEvents/>)).toMatchSnapshot();
-        });
-
-        it('matches snapshot in hosted environment', () => {
-            appConfig.hostMode = HostMode.Browser;
+        it('matches snapshot', () => {
             expect(shallow(<DeviceEvents/>)).toMatchSnapshot();
         });
 
@@ -90,15 +87,8 @@ describe('deviceEvents', () => {
             expect(startEventsMonitoringSpy.mock.calls[0][0]).toEqual({
                 consumerGroup: DEFAULT_CONSUMER_GROUP,
                 deviceId: 'device1',
-                startTime: currentTime
+                startTime: undefined
             });
-
-            // click the show system property button
-            expect(commandBar.props().items[1].iconProps.iconName).toEqual('Checkbox');
-            act(() => commandBar.props().items[1].onClick(null)); // tslint:disable-line:no-magic-numbers
-            wrapper.update();
-            const updatedCommandBar = wrapper.find(CommandBar).first();
-            expect(updatedCommandBar.props().items[1].iconProps.iconName).toEqual('CheckboxComposite');
         });
 
         it('changes state accordingly when consumer group value is changed', () => {
@@ -107,16 +97,6 @@ describe('deviceEvents', () => {
             act(() => textField.props().onChange(undefined, 'testGroup'));
             wrapper.update();
             expect(wrapper.find(TextField).first().props().value).toEqual('testGroup');
-        });
-
-        it('changes state accordingly when custom event hub boolean value is changed', () => {
-            const wrapper = mount(<DeviceEvents/>);
-            expect(wrapper.find('.custom-event-hub-text-field').length).toEqual(0);
-            const toggle = wrapper.find(Toggle).at(0);
-            act(() => toggle.props().onChange(undefined, false));
-            wrapper.update();
-            // tslint:disable-next-line: no-magic-numbers
-            expect(wrapper.find('.custom-event-hub-text-field').length).toEqual(6);
         });
 
         it('renders events', () => {
@@ -148,12 +128,14 @@ describe('deviceEvents', () => {
         beforeEach(() => {
             const realUseState = React.useState;
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(DEFAULT_CONSUMER_GROUP));
-            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
-            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
-            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(currentTime));
-            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(true));
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(undefined));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(false));
             jest.spyOn(React, 'useState').mockImplementationOnce(() => realUseState(true));
             jest.spyOn(TransformHelper, 'parseDateTimeString').mockImplementationOnce(parameters => {
@@ -190,14 +172,7 @@ describe('deviceEvents', () => {
             expect(shallow(<DeviceEvents/>)).toMatchSnapshot();
         });
 
-        it('matches snapshot while interface definition is retrieved in electron', () => {
-            appConfig.hostMode = HostMode.Electron;
-            mockFetchedState();
-            expect(shallow(<DeviceEvents/>)).toMatchSnapshot();
-        });
-
-        it('matches snapshot while interface definition is retrieved in hosted environment', () => {
-            appConfig.hostMode = HostMode.Browser;
+        it('matches snapshot while interface definition is retrieved', () => {
             mockFetchedState();
             expect(shallow(<DeviceEvents/>)).toMatchSnapshot();
         });

--- a/src/app/devices/deviceEvents/components/startTime.spec.tsx
+++ b/src/app/devices/deviceEvents/components/startTime.spec.tsx
@@ -1,0 +1,57 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import 'jest';
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { shallow, mount } from 'enzyme';
+import { Toggle } from 'office-ui-fabric-react/lib/components/Toggle';
+import { TextField } from 'office-ui-fabric-react/lib/components/TextField';
+import { StartTime } from './startTime';
+
+const search = '?deviceId=test&componentName=DEFAULT_COMPONENT&interfaceId=dtmi:com:example:Thermostat;1';
+const pathname = `#devices/deviceDetail/ioTPlugAndPlay/ioTPlugAndPlayDetail/events/${search}`;
+jest.mock('react-router-dom', () => ({
+    useHistory: () => ({ push: jest.fn() }),
+    useLocation: () => ({ search, pathname, push: jest.fn() })
+}));
+
+describe('startTime', () => {
+    it('matches snapshot', () => {
+        expect(shallow(
+            <StartTime
+                monitoringData={true}
+                specifyStartTime={true}
+                startTime={new Date(0)}
+                setSpecifyStartTime={jest.fn()}
+                setStartTime={jest.fn()}
+                setHasError={jest.fn()}
+            />)).toMatchSnapshot();
+    });
+
+    it('specifies start time string', () => {
+        const mockSetSpecifyStartTime = jest.fn();
+        const mockSetStartTime = jest.fn();
+        const MockSetHasError = jest.fn();
+        const wrapper = mount(
+            <StartTime
+                monitoringData={false}
+                specifyStartTime={true}
+                startTime={new Date(0)}
+                setSpecifyStartTime={mockSetSpecifyStartTime}
+                setStartTime={mockSetStartTime}
+                setHasError={MockSetHasError}
+            />);
+
+        act(() => wrapper.find(Toggle).first().props().onChange(undefined, false));
+        wrapper.update();
+        expect(mockSetSpecifyStartTime).toBeCalledWith(false);
+
+        act(() => wrapper.find(TextField).props().onChange(undefined, '2020/12/16/12/58/00'));
+        wrapper.update();
+        expect(mockSetStartTime).toBeCalledTimes(2);
+        expect(mockSetStartTime.mock.calls[1][0]).toEqual(new Date(2020, 11, 16, 12, 58, 0));
+        expect(MockSetHasError).toBeCalledWith(false);
+    });
+});

--- a/src/app/devices/deviceEvents/components/startTime.tsx
+++ b/src/app/devices/deviceEvents/components/startTime.tsx
@@ -1,0 +1,97 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TextField } from 'office-ui-fabric-react/lib/components/TextField';
+import { Toggle } from 'office-ui-fabric-react/lib/components/Toggle';
+import { Stack } from 'office-ui-fabric-react/lib/components/Stack';
+import { ResourceKeys } from '../../../../localization/resourceKeys';
+import { LabelWithTooltip } from '../../../shared/components/labelWithTooltip';
+import './deviceEvents.scss';
+
+export interface StartTimeProps {
+    monitoringData: boolean;
+    specifyStartTime: boolean;
+    startTime: Date;
+    setSpecifyStartTime: (specifyStartTime: boolean) => void;
+    setStartTime: (date: Date) => void;
+    setHasError: (hasError: boolean) => void;
+}
+
+export const StartTime: React.FC<StartTimeProps> = ({monitoringData, specifyStartTime, startTime, setSpecifyStartTime, setStartTime, setHasError}) => {
+
+    const { t } = useTranslation();
+    const [ error, setError ] = React.useState<string>();
+    const [ startTimeString, setStartTimeString ] = React.useState<string>();
+
+    React.useEffect(() => {
+        setStartTimeString(startTime &&
+            `${startTime.getFullYear()}/${startTime.getMonth() + 1}/${startTime.getDate()}/${startTime.getHours()}/${startTime.getMinutes()}/${startTime.getSeconds()}`);
+    },              [startTime]);
+
+    React.useEffect(() => {
+        const pattern = new RegExp('^[0-9]{4}\/(0?[1-9]|1[0-2])\/(0?[1-9]|[12][0-9]|3[01])\/(00|[0-9]|1[0-9]|2[0-3])\/([0-9]|[0-5][0-9])\/([0-9]|[0-5][0-9])$');
+        if (pattern.test(startTimeString)) {
+            const dateStringSplit = startTimeString.split('/');
+            const dateSplit = dateStringSplit.map(date => parseInt(date)); // tslint:disable-line:radix
+            // with the regex check, the date is guaranteed to be in yyyy/mm/dd/hh/mm/ss format
+            setStartTime(new Date(dateSplit[0], dateSplit[1] - 1, dateSplit[2], dateSplit[3], dateSplit[4], dateSplit[5])); // tslint:disable-line:no-magic-numbers
+            setError('');
+            setHasError(false);
+        }
+        else {
+            setError(t(ResourceKeys.deviceEvents.startTime.error));
+            setHasError(true);
+        }
+    },              [startTimeString]);
+
+    const toggleChange = () => {
+        setSpecifyStartTime(!specifyStartTime);
+    };
+
+    const renderToggleLabel = () => (
+        <LabelWithTooltip
+            className={'consumer-group-label'}
+            tooltipText={t(ResourceKeys.deviceEvents.startTime.tooltip)}
+        >
+            {t(ResourceKeys.deviceEvents.toggleSpecifyStartingTime.label)}
+        </LabelWithTooltip>
+    );
+
+    const startTimeChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+        setStartTimeString(newValue);
+    };
+
+    return (
+        <Stack horizontal={true} horizontalAlign="space-between">
+            <Toggle
+                className="stack-first-column"
+                checked={specifyStartTime}
+                ariaLabel={t(ResourceKeys.deviceEvents.toggleSpecifyStartingTime.label)}
+                label={renderToggleLabel()}
+                onText={t(ResourceKeys.deviceEvents.toggleSpecifyStartingTime.on)}
+                offText={t(ResourceKeys.deviceEvents.toggleSpecifyStartingTime.off)}
+                onChange={toggleChange}
+                disabled={monitoringData}
+            />
+            <div className="stack-second-column">
+                {specifyStartTime &&
+                    <TextField
+                        className="custom-text-field"
+                        label={t(ResourceKeys.deviceEvents.startTime.label)}
+                        ariaLabel={t(ResourceKeys.deviceEvents.startTime.label)}
+                        underlined={true}
+                        value={startTimeString}
+                        disabled={monitoringData}
+                        onChange={startTimeChange}
+                        errorMessage={error}
+                        placeholder={'yyyy/mm/dd/hh/mm/ss'}
+                        required={true}
+                    />
+                }
+            </div>
+        </Stack>
+    );
+};

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -572,6 +572,11 @@
             "label": "Consumer group",
             "tooltip": "Consumer groups are used by applications to pull data from the IoT Hub. To change the current consumer group, stop monitoring telemetry."
         },
+        "startTime": {
+            "error": "Please enter datetime format in yyyy/mm/dd/hh/mm/ss",
+            "label": "Start time",
+            "tooltip": "Indicates the local enqueue time that should be used to read messages from the event hub. If not specified, the enqueue time would be the moment you click on the 'Start' button."
+        },
         "customEventHub": {
             "connectionString": {
                 "label": "Custom event hub connection string",
@@ -621,6 +626,11 @@
         },
         "toggleUseDefaultEventHub": {
             "label": "Use built-in event hub",
+            "on": "Yes",
+            "off": "No"
+        },
+        "toggleSpecifyStartingTime": {
+            "label": "Specify enqueue time",
             "on": "Yes",
             "off": "No"
         },

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -363,10 +363,20 @@ export class ResourceKeys {
             tooltiop : "deviceEvents.simulation.prerequisite.tooltiop",
          },
       },
+      startTime : {
+         error : "deviceEvents.startTime.error",
+         label : "deviceEvents.startTime.label",
+         tooltip : "deviceEvents.startTime.tooltip",
+      },
       toggleShowRawData : {
          label : "deviceEvents.toggleShowRawData.label",
          off : "deviceEvents.toggleShowRawData.off",
          on : "deviceEvents.toggleShowRawData.on",
+      },
+      toggleSpecifyStartingTime : {
+         label : "deviceEvents.toggleSpecifyStartingTime.label",
+         off : "deviceEvents.toggleSpecifyStartingTime.off",
+         on : "deviceEvents.toggleSpecifyStartingTime.on",
       },
       toggleUseDefaultEventHub : {
          label : "deviceEvents.toggleUseDefaultEventHub.label",


### PR DESCRIPTION
allow user to specify start time (enqueue time) of messages per requested #351
also refactored this event component a bit to seperate controls into smaller files for better test coverage and readability 

![image](https://user-images.githubusercontent.com/5489222/102413992-a464ed00-3faa-11eb-9124-afbb382b1925.png)
leaving everything as default vs specify enqueue time and custom event hub values
![image](https://user-images.githubusercontent.com/5489222/102414033-b181dc00-3faa-11eb-9018-66f34b356df0.png)