### PR TITLE
 update error message so it doesn't look like an internal error from UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "This project welcomes contributions and suggestions. Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "public/electron.js",
   "build": {

--- a/src/server/dataPlaneHelper.spec.ts
+++ b/src/server/dataPlaneHelper.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License
  **********************************************************/
 import express = require('express');
-import { generateDataPlaneRequestBody, API_VERSION, processDataPlaneResponse } from './dataPlaneHelper'; // note: remove auto-generated dataPlaneHelper.js in order to run this test
+import { generateDataPlaneRequestBody, processDataPlaneResponse } from './dataPlaneHelper'; // note: remove auto-generated dataPlaneHelper.js in order to run this test
 
 describe('server', () => {
     const hostName = 'testHub.private.azure-devices-int.net';
@@ -30,33 +30,6 @@ describe('server', () => {
                 },
                 method: 'POST',
                 uri: `https://${hostName}/%2FdigitalTwins%2FtestDevice%2Finterfaces%2Fsensor%2Fcommands%2Fturnon?${queryString}&api-version=2019-07-01-preview`,
-            }
-        );
-    });
-
-    it('generates data plane request without API version or query string specified in body', () => {
-        const req =  {
-            body: {
-                body: '{"query":"\\n    SELECT deviceId as DeviceId,\\n    status as Status,\\n    FROM devices WHERE STARTSWITH(devices.deviceId, \'test\')"}',
-                headers: { 'x-ms-max-item-count': 20 },
-                hostName,
-                httpMethod: 'POST',
-                path: 'devices/query',
-                sharedAccessSignature: `SharedAccessSignature sr=${hostName}%2Fdevices%2Fquery&sig=123&se=456&skn=iothubowner`
-            }
-        };
-        const requestBody = generateDataPlaneRequestBody(req as express.Request);
-        expect(requestBody).toEqual(
-            {
-                body: '{"query":"\\n    SELECT deviceId as DeviceId,\\n    status as Status,\\n    FROM devices WHERE STARTSWITH(devices.deviceId, \'test\')"}',
-                headers: {
-                    'Accept': 'application/json',
-                    'Authorization': req.body.sharedAccessSignature,
-                    'Content-Type': 'application/json',
-                    'x-ms-max-item-count': 20
-                },
-                method: 'POST',
-                uri: `https://${hostName}/devices%2Fquery?api-version=${API_VERSION}`,
             }
         );
     });
@@ -105,7 +78,7 @@ describe('server', () => {
 
     it('generates data plane response with no httpResponse', () => {
         const response = processDataPlaneResponse(null, null);
-        expect(response.body).toEqual({body: {Message: `Cannot read property 'headers' of null`}});
+        expect(response.body).toEqual({body: {Message: 'Failed to get any response from iot hub service.'}});
     });
 
     it('generates data plane response using device status code', () => {

--- a/src/server/dataPlaneHelper.ts
+++ b/src/server/dataPlaneHelper.ts
@@ -34,6 +34,9 @@ export const generateDataPlaneResponse = (httpRes: request.Response, body: any, 
 // tslint:disable-next-line:cyclomatic-complexity
 export const processDataPlaneResponse = (httpRes: request.Response, body: any): {body: {body: any, headers?: any}, statusCode: number} => { // tslint:disable-line:no-any
     try {
+        if(!httpRes) {
+            throw new Error('Failed to get any response from iot hub service.');
+        }
         if (httpRes.headers && httpRes.headers[DEVICE_STATUS_HEADER]) { // handles happy failure cases when error code is returned as a header
             let deviceResponseBody;
             try {


### PR DESCRIPTION
Before this change, when hub response is empty, we are showing an error 'cannot get header of null' which looks like an internal error.
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the Azure IoT Explorer!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit tests?
- [x] Have **all** unit tests passed locally? (by running `npm run test` command)
- [x] Have you updated the README.md with new screenshots if significant changes have been made?
- [x] Have you update the package version if the current version in package.json is not higher than the version released?