### PR TITLE
Make telemetry ipc

### DIFF
--- a/public/constants.ts
+++ b/public/constants.ts
@@ -9,6 +9,8 @@ export const PLATFORMS = {
 export const MESSAGE_CHANNELS = {
     DEVICE_SEND_MESSAGE: 'device_sendMessage',
     DIRECTORY_GET_DIRECTORIES: 'directory_getDirectories',
+    EVENTHUB_START_MONITORING: 'eventhub_startMonitoring',
+    EVENTHUB_STOP_MONITORING: 'eventhub_stopMonitoring',
     MODEL_REPOSITORY_GET_DEFINITION: 'model_definition',
     SETTING_HIGH_CONTRAST: 'setting_highContrast',
 };
@@ -16,6 +18,7 @@ export const MESSAGE_CHANNELS = {
 export const API_INTERFACES = {
     DEVICE: 'api_device',
     DIRECTORY: 'api_directory',
+    EVENTHUB: 'api_eventhub',
     MODEL_DEFINITION: 'api_modelDefinition',
     SETTINGS: 'api_settings'
 };

--- a/public/contextBridge.ts
+++ b/public/contextBridge.ts
@@ -7,9 +7,11 @@ import { generateSettingsInterface } from './factories/settingsInterfaceFactory'
 import { generateDirectoryInterface } from './factories/directoryInterfaceFactory';
 import { generateModelRepositoryInterface } from './factories/modelRepositoryInterfaceFactory';
 import { generateDeviceInterface } from './factories/deviceInterfaceFactory';
+import { generateEventHubInterface } from './factories/eventHubInterfaceFactory';
 import { API_INTERFACES } from './constants';
 
 contextBridge.exposeInMainWorld(API_INTERFACES.DEVICE, generateDeviceInterface());
 contextBridge.exposeInMainWorld(API_INTERFACES.DIRECTORY, generateDirectoryInterface());
+contextBridge.exposeInMainWorld(API_INTERFACES.EVENTHUB, generateEventHubInterface());
 contextBridge.exposeInMainWorld(API_INTERFACES.MODEL_DEFINITION, generateModelRepositoryInterface());
 contextBridge.exposeInMainWorld(API_INTERFACES.SETTINGS, generateSettingsInterface());

--- a/public/electron.ts
+++ b/public/electron.ts
@@ -10,6 +10,7 @@ import { onSettingsHighContrast } from './handlers/settingsHandler';
 import { onGetInterfaceDefinition } from './handlers/modelRepositoryHandler';
 import { onGetDirectories } from './handlers/directoryHandler';
 import { onSendMessageToDevice } from './handlers/deviceHandler';
+import { onStartMonitoring, onStopMonitoring } from './handlers/eventHubHandler';
 import { formatError } from './utils/errorHelper';
 import '../dist/server/serverElectron';
 
@@ -31,6 +32,8 @@ class Main {
         Main.registerHandler(MESSAGE_CHANNELS.MODEL_REPOSITORY_GET_DEFINITION, onGetInterfaceDefinition);
         Main.registerHandler(MESSAGE_CHANNELS.DIRECTORY_GET_DIRECTORIES, onGetDirectories);
         Main.registerHandler(MESSAGE_CHANNELS.DEVICE_SEND_MESSAGE, onSendMessageToDevice);
+        Main.registerHandler(MESSAGE_CHANNELS.EVENTHUB_START_MONITORING, onStartMonitoring);
+        Main.registerHandler(MESSAGE_CHANNELS.EVENTHUB_STOP_MONITORING, onStopMonitoring);
     }
 
     private static setApplicationLock(): void {

--- a/public/factories/eventHubInterfaceFactory.ts
+++ b/public/factories/eventHubInterfaceFactory.ts
@@ -1,0 +1,18 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import { MESSAGE_CHANNELS } from '../constants';
+import { EventHubInterface, StartEventHubMonitoringParameters, Message } from '../interfaces/eventHubInterface';
+import { invokeInMainWorld } from '../utils/invokeHelper';
+
+export const generateEventHubInterface = (): EventHubInterface => {
+    return {
+        startEventHubMonitoring: async (params: StartEventHubMonitoringParameters): Promise<Message[]> => {
+            return invokeInMainWorld<Message[]>(MESSAGE_CHANNELS.EVENTHUB_START_MONITORING, params);
+        },
+        stopEventHubMonitoring: async (): Promise<void> => {
+            return invokeInMainWorld<void>(MESSAGE_CHANNELS.EVENTHUB_STOP_MONITORING);
+        }
+    };
+};

--- a/public/handlers/eventHubHandler.ts
+++ b/public/handlers/eventHubHandler.ts
@@ -14,13 +14,13 @@ let deviceId: string = '';
 
 const IOTHUB_CONNECTION_DEVICE_ID = 'iothub-connection-device-id';
 
-export const onStartMonitoring = async (event: IpcMainInvokeEvent, params: StartEventHubMonitoringParameters) => {
+export const onStartMonitoring = async (event: IpcMainInvokeEvent, params: StartEventHubMonitoringParameters): Promise<Message[]>=> {
     return eventHubProvider(params).then(result => {
         return result;
     });
 }
 
-export const onStopMonitoring = async () => {
+export const onStopMonitoring = async (): Promise<void> => {
     try {
         return stopClient();
     } catch (error) {

--- a/public/interfaces/eventHubInterface.ts
+++ b/public/interfaces/eventHubInterface.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
+import { Message as MessageInterface } from '../../src/app/api/models/messages';
 export interface StartEventHubMonitoringParameters {
     deviceId: string;
     consumerGroup: string;
@@ -13,12 +14,7 @@ export interface StartEventHubMonitoringParameters {
     hubConnectionString?: string;
 }
 
-export interface Message {
-    body: any; // tslint:disable-line:no-any
-    enqueuedTime: string;
-    properties?: any; // tslint:disable-line:no-any
-    systemProperties?: {[key: string]: string};
-}
+export type Message = MessageInterface;
 
 export interface EventHubInterface {
     startEventHubMonitoring(params: StartEventHubMonitoringParameters): Promise<Message[]>;

--- a/public/interfaces/eventHubInterface.ts
+++ b/public/interfaces/eventHubInterface.ts
@@ -1,0 +1,26 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+export interface StartEventHubMonitoringParameters {
+    deviceId: string;
+    consumerGroup: string;
+    startTime: string;
+    startListeners: boolean;
+
+    customEventHubName?: string;
+    customEventHubConnectionString?: string;
+    hubConnectionString?: string;
+}
+
+export interface Message {
+    body: any; // tslint:disable-line:no-any
+    enqueuedTime: string;
+    properties?: any; // tslint:disable-line:no-any
+    systemProperties?: {[key: string]: string};
+}
+
+export interface EventHubInterface {
+    startEventHubMonitoring(params: StartEventHubMonitoringParameters): Promise<Message[]>;
+    stopEventHubMonitoring(): Promise<void>;
+}

--- a/src/app/api/parameters/deviceParameters.ts
+++ b/src/app/api/parameters/deviceParameters.ts
@@ -31,11 +31,11 @@ export interface FetchDevicesParameters  {
 export interface MonitorEventsParameters {
     deviceId: string;
     consumerGroup: string;
+    startListeners: boolean;
 
     customEventHubName?: string;
     customEventHubConnectionString?: string;
     hubConnectionString?: string;
-
     startTime?: Date;
 }
 

--- a/src/app/api/shared/interfaceUtils.spec.ts
+++ b/src/app/api/shared/interfaceUtils.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License
  **********************************************************/
-import { appConfig, HostMode, H } from '../../../appConfig/appConfig';
+import { appConfig, HostMode } from '../../../appConfig/appConfig';
 import { HIGH_CONTRAST } from '../../constants/browserStorage';
 import { API_INTERFACES } from '../../../../public/constants';
 import * as interfaceUtils from './interfaceUtils';
@@ -91,5 +91,20 @@ describe('getLocalModelRepositoryInterface', () => {
 
         interfaceUtils.getLocalModelRepositoryInterface()
         expect(factory).toHaveBeenLastCalledWith(API_INTERFACES.MODEL_DEFINITION);
+    });
+});
+
+describe('getEventHubInterface', () => {
+    it('throws exception when mode is not electron', () => {
+        appConfig.hostMode = HostMode.Browser;
+        expect(() => interfaceUtils.getEventHubInterface()).toThrowError(interfaceUtils.NOT_AVAILABLE);
+    });
+
+    it('calls expected factory when mode is electron', () => {
+        appConfig.hostMode = HostMode.Electron;
+        const factory = jest.spyOn(interfaceUtils, 'getElectronInterface');
+
+        interfaceUtils.getEventHubInterface()
+        expect(factory).toHaveBeenLastCalledWith(API_INTERFACES.EVENTHUB);
     });
 });

--- a/src/app/api/shared/interfaceUtils.ts
+++ b/src/app/api/shared/interfaceUtils.ts
@@ -6,6 +6,7 @@ import { SettingsInterface } from '../../../../public/interfaces/settingsInterfa
 import { DeviceInterface } from '../../../../public/interfaces/deviceInterface';
 import { DirectoryInterface } from '../../../../public/interfaces/directoryInterface';
 import { ModelRepositoryInterface } from '../../../../public/interfaces/modelRepositoryInterface';
+import { EventHubInterface } from './../../../../public/interfaces/eventHubInterface';
 import { API_INTERFACES } from '../../../../public/constants';
 import { appConfig, HostMode } from '../../../appConfig/appConfig';
 import { HIGH_CONTRAST } from '../../constants/browserStorage';
@@ -48,6 +49,14 @@ export const getDirectoryInterface = (): DirectoryInterface => {
     }
 
     return getElectronInterface(API_INTERFACES.DIRECTORY);
+};
+
+export const getEventHubInterface = (): EventHubInterface => {
+    if (appConfig.hostMode !== HostMode.Electron) {
+        throw new Error(NOT_AVAILABLE);
+    }
+
+    return getElectronInterface(API_INTERFACES.EVENTHUB);
 };
 
 export const getElectronInterface = <T>(name: string): T => {

--- a/src/app/devices/deviceEvents/components/__snapshots__/deviceEvents.spec.tsx.snap
+++ b/src/app/devices/deviceEvents/components/__snapshots__/deviceEvents.spec.tsx.snap
@@ -66,7 +66,7 @@ exports[`deviceEvents deviceEvents in non-pnp context matches snapshot 1`] = `
         key="0"
       >
         <h5>
-          9:44:58 PM, 10/14/2019
+          Wed Feb 17 2021 16:06:00 GMT-0800 (Pacific Standard Time)
           :
         </h5>
         <pre>
@@ -74,7 +74,7 @@ exports[`deviceEvents deviceEvents in non-pnp context matches snapshot 1`] = `
   "body": {
     "humid": 123
   },
-  "enqueuedTime": "2019-10-14T21:44:58.397Z",
+  "enqueuedTime": "Wed Feb 17 2021 16:06:00 GMT-0800 (Pacific Standard Time)",
   "properties": {
     "iothub-message-schema": "humid"
   }

--- a/src/app/devices/deviceEvents/components/deviceEvents.spec.tsx
+++ b/src/app/devices/deviceEvents/components/deviceEvents.spec.tsx
@@ -7,11 +7,9 @@ import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { shallow, mount } from 'enzyme';
 import { TextField } from 'office-ui-fabric-react/lib/components/TextField';
-import { Toggle } from 'office-ui-fabric-react/lib/components/Toggle';
 import { CommandBar } from 'office-ui-fabric-react/lib/components/CommandBar';
 import { Shimmer } from 'office-ui-fabric-react/lib/components/Shimmer';
 import { DeviceEvents } from './deviceEvents';
-import { appConfig, HostMode } from '../../../../appConfig/appConfig';
 import { DEFAULT_CONSUMER_GROUP } from '../../../constants/apiConstants';
 import { startEventsMonitoringAction } from '../actions';
 import * as AsyncSagaReducer from '../../../shared/hooks/useAsyncSagaReducer';
@@ -36,7 +34,7 @@ describe('deviceEvents', () => {
             body: {
                 humid: 123
             },
-            enqueuedTime: '2019-10-14T21:44:58.397Z',
+            enqueuedTime: 'Wed Feb 17 2021 16:06:00 GMT-0800 (Pacific Standard Time)',
             properties: {
             'iothub-message-schema': 'humid'
             }
@@ -87,6 +85,7 @@ describe('deviceEvents', () => {
             expect(startEventsMonitoringSpy.mock.calls[0][0]).toEqual({
                 consumerGroup: DEFAULT_CONSUMER_GROUP,
                 deviceId: 'device1',
+                startListeners: true,
                 startTime: undefined
             });
         });
@@ -182,7 +181,7 @@ describe('deviceEvents', () => {
                 body: {
                     humid: '123' // intentionally set a value which type is double
                 },
-                enqueuedTime: '2019-10-14T21:44:58.397Z',
+                enqueuedTime: 'Wed Feb 17 2021 16:06:00 GMT-0800 (Pacific Standard Time)',
                 systemProperties: {
                 'iothub-message-schema': 'humid'
                 }
@@ -206,7 +205,7 @@ describe('deviceEvents', () => {
                 body: {
                     'non-matching-key': 0
                 },
-                enqueuedTime: '2019-10-14T21:44:58.397Z',
+                enqueuedTime: 'Wed Feb 17 2021 16:06:00 GMT-0800 (Pacific Standard Time)',
                 systemProperties: {
                 'iothub-message-schema': 'humid'
                 }
@@ -231,7 +230,7 @@ describe('deviceEvents', () => {
                     'humid': 0,
                     'humid-foo': 'test'
                 },
-                enqueuedTime: '2019-10-14T21:44:58.397Z',
+                enqueuedTime: 'Wed Feb 17 2021 16:06:00 GMT-0800 (Pacific Standard Time)',
                 systemProperties: {}
             }];
             jest.spyOn(AsyncSagaReducer, 'useAsyncSagaReducer').mockReturnValue([{
@@ -258,7 +257,7 @@ describe('deviceEvents', () => {
                 body: {
                     'non-matching-key': 0
                 },
-                enqueuedTime: '2019-10-14T21:44:58.397Z'
+                enqueuedTime: 'Wed Feb 17 2021 16:06:00 GMT-0800 (Pacific Standard Time)'
             }];
             jest.spyOn(AsyncSagaReducer, 'useAsyncSagaReducer').mockReturnValue([{
                 payload: events,

--- a/src/app/devices/deviceEvents/components/deviceEvents.tsx
+++ b/src/app/devices/deviceEvents/components/deviceEvents.tsx
@@ -342,7 +342,7 @@ export const DeviceEvents: React.FC = () => {
         return(
             <div className="col-sm2">
                 <Label aria-label={t(ResourceKeys.deviceEvents.columns.timestamp)}>
-                    {enqueuedTime && parseDateTimeString(enqueuedTime)}
+                    {enqueuedTime}
                 </Label>
             </div>
         );

--- a/src/app/devices/deviceEvents/components/deviceEvents.tsx
+++ b/src/app/devices/deviceEvents/components/deviceEvents.tsx
@@ -41,7 +41,7 @@ import { StartTime } from './startTime';
 import './deviceEvents.scss';
 
 const JSON_SPACES = 2;
-const LOADING_LOCK = 2000;
+const LOADING_LOCK = 8000;
 
 export const DeviceEvents: React.FC = () => {
     const { t } = useTranslation();
@@ -107,7 +107,7 @@ export const DeviceEvents: React.FC = () => {
                 if (monitoringData) {
                     setStartTime(new Date());
                     setTimeout(() => {
-                        fetchData();
+                        fetchData(false)();
                     },         LOADING_LOCK);
                 }
                 else {
@@ -140,7 +140,7 @@ export const DeviceEvents: React.FC = () => {
                 setShowPnpModeledEvents={setShowPnpModeledEvents}
                 setShowSimulationPanel={setShowSimulationPanel}
                 dispatch={dispatch}
-                fetchData={fetchData}
+                fetchData={fetchData(true)}
             />
         );
     };
@@ -222,7 +222,7 @@ export const DeviceEvents: React.FC = () => {
                     };
                     return (
                         <article key={index} className="device-events-content">
-                            {<h5>{parseDateTimeString(modifiedEvents.enqueuedTime)}:</h5>}
+                            {<h5>{modifiedEvents.enqueuedTime}:</h5>}
                             <pre>{JSON.stringify(modifiedEvents, undefined, JSON_SPACES)}</pre>
                         </article>
                     );
@@ -475,10 +475,11 @@ export const DeviceEvents: React.FC = () => {
         );
     };
 
-    const fetchData = () => {
+    const fetchData = (startListeners: boolean) => () => {
         let parameters: MonitorEventsParameters = {
             consumerGroup,
             deviceId,
+            startListeners,
             startTime
         };
 


### PR DESCRIPTION
* Refactor telemetry from express server to use IPC
* Changed how we start and stop receivers of event hub:
  * Basically, only when user click on 'start' would we initiate a bunch of receivers/listerns
  * Then each following poll just get the messages populated while the recievers are working asynchronously in the background. 
  * Relevant resources would get cleaned up when monitoring is stopped by the user, user switching hub connection strings, or switching device IDs

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit tests?
- [x] Have **all** unit tests passed locally? (by running `npm run test` command)
- [ ] Have you updated the README.md with new screenshots if significant changes have been made?
- [ ] Have you update the package version if the current version in package.json is not higher than the version released?