### PR TITLE
Notification center and bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16032,12 +16032,22 @@
       }
     },
     "react-i18next": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.5.0.tgz",
-      "integrity": "sha512-V6rUT7MzYBdFCgUrhfr78FHRfnY3CFoR75ET9EP5Py5UPHKyaGiK1MvPx03TesLwsmIaVHlRFU/WLzqCedXevA==",
+      "version": "11.8.10",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.8.10.tgz",
+      "integrity": "sha512-ckjNzMjYkmx4fQ8zzuaYTosYN3Co6ebrgCQJzuZCcGFYSR/kGHZzSu0xw9VhtnbjJVKx0gEMV3DLRvzi4xDZUw==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "html-parse-stringify2": "2.0.1"
+        "@babel/runtime": "^7.13.6",
+        "html-parse-stringify2": "^2.0.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react": "16.13.1",
     "react-collapsible": "2.3.2",
     "react-dom": "16.13.1",
-    "react-i18next": "11.5.0",
+    "react-i18next": "11.8.10",
     "react-jsonschema-form": "1.7.0",
     "react-router-dom": "5.2.0",
     "react-smooth-dnd": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "This project welcomes contributions and suggestions. Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "host/electron.js",
   "build": {

--- a/src/app/api/models/interfaceJsonParserOutput.ts
+++ b/src/app/api/models/interfaceJsonParserOutput.ts
@@ -17,7 +17,7 @@ export interface ParsedJsonSchema {
     properties?: {};
     title?: string;
     type?: string | string[];
-    $ref?: any; // tslint:disable-line: no-any
+    $ref?: string;
 }
 
 export interface ParsedCommandSchema {

--- a/src/app/api/services/localRepoService.ts
+++ b/src/app/api/services/localRepoService.ts
@@ -18,6 +18,9 @@ export const fetchLocalFile = async (path: string, fileName: string): Promise<ob
             path
         });
 
+        if (!result) {
+            throw new ModelDefinitionNotFound();
+        }
         return result;
     } catch (error) {
         if (error.message === MODEL_PARSE_ERROR) {

--- a/src/app/constants/routes.ts
+++ b/src/app/constants/routes.ts
@@ -15,6 +15,7 @@ export enum ROUTE_PARTS {
     IDENTITY = 'identity',
     INTERFACES = 'interfaces',
     IOT_HUB = 'microsoft.devices',
+    NOTIFICATIONS = 'notifications',
     METHODS = 'methods',
     MODULE_IDENTITY = 'moduleIdentity',
     MODULE_DETAIL = 'moduleDetail',

--- a/src/app/css/_headerPane.scss
+++ b/src/app/css/_headerPane.scss
@@ -4,7 +4,7 @@
  **********************************************************/
 @import 'themes';
 
-.settingsPane {
+.headerPane {
     .ms-Panel-scrollableContent {
         overflow-x: hidden;
     }
@@ -42,7 +42,7 @@
         }
     }
 
-    .settings-footer {
+    .header-footer {
         .footer-buttons {
             h3[role="heading"] {
                 font-weight: normal;

--- a/src/app/css/_notification.scss
+++ b/src/app/css/_notification.scss
@@ -22,7 +22,6 @@
 
 .notification-list-entry {
     display: flex;
-    // width: 250px;
     margin-top: 10px;
     margin-right: 5px;
     padding-top: 5px;

--- a/src/app/css/_notification.scss
+++ b/src/app/css/_notification.scss
@@ -20,29 +20,14 @@
     }
 }
 
-.notification-list-divider {
-    height: 0px;
-    border: 0;
-    @include themify($themes) {
-        border-top: 1px solid themed('notificationBorderColor');
-    }
-}
-
-.notification-list-header {
-    margin-left: 40px;
-    margin-right: 40px;
-    .commands {
-        text-align: right;
-    }
-}
-
 .notification-list-entry {
     display: flex;
-    width: 250px;
+    // width: 250px;
     margin-top: 10px;
     margin-right: 5px;
     padding-top: 5px;
     padding-bottom: 5px;
+    padding-left: 10px;
 
     .success {
         @include themify($themes) {
@@ -69,10 +54,9 @@
     }
 
     .body {
-        width: 225px;
         padding-left: 10px;
         text-overflow: ellipsis;
-        
+
         .title {
             font-weight: 550;
             text-overflow: ellipsis;

--- a/src/app/devices/deviceList/components/deviceList.tsx
+++ b/src/app/devices/deviceList/components/deviceList.tsx
@@ -266,7 +266,6 @@ export const DeviceList: React.FC = () => {
         return (
             <div role="dialog">
                 <Dialog
-                    className="delete-dialog"
                     hidden={!showDeleteConfirmation}
                     onDismiss={closeDeleteDialog}
                     dialogContentProps={{
@@ -275,7 +274,8 @@ export const DeviceList: React.FC = () => {
                         type: DialogType.close,
                     }}
                     modalProps={{
-                        isBlocking: true,
+                        className: 'delete-dialog',
+                        isBlocking: true
                     }}
                 >
                     <ul className="deleting-devices">

--- a/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterface.spec.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterface.spec.tsx
@@ -52,7 +52,7 @@ describe('components/devices/deviceCommandsPerInterface', () => {
         expect(wrapper.find('.collapse-button').find(IconButton).first().props().title).toEqual('deviceCommands.command.collapseAll');
 
         const button = wrapper.find(IconButton).first();
-        act(() => button.simulate('click'));
+        button.simulate('click');
         wrapper.update();
         expect(wrapper.find('.collapse-button').find(IconButton).first().props().title).toEqual('deviceCommands.command.expandAll');
     });

--- a/src/app/devices/pnp/components/deviceProperties/devicePropertiesPerInterface.tsx
+++ b/src/app/devices/pnp/components/deviceProperties/devicePropertiesPerInterface.tsx
@@ -83,7 +83,7 @@ export const DevicePropertiesPerInterface: React.FC<DevicePropertiesDataProps> =
         return (
             <div aria-label={ariaLabel}>
                 {
-                    item.propertySchema && isSchemaSimpleType(item.propertyModelDefinition.schema) ?
+                    item.propertySchema && isSchemaSimpleType(item.propertyModelDefinition.schema, item.propertySchema.$ref) ?
                         RenderSimplyTypeValue(
                             item.reportedTwin,
                             item.propertySchema,

--- a/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
+++ b/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterfacePerSetting.tsx
@@ -105,7 +105,7 @@ export const DeviceSettingsPerInterfacePerSetting: React.FC<DeviceSettingDataPro
         return (
             <ErrorBoundary error={t(ResourceKeys.errorBoundary.text)}>
                 {
-                    settingSchema && isSchemaSimpleType(settingModelDefinition.schema) ?
+                    settingSchema && isSchemaSimpleType(settingModelDefinition.schema, settingSchema.$ref) ?
                         RenderSimplyTypeValue(
                             reportedSection?.value,
                             settingSchema,

--- a/src/app/devices/pnp/components/digitalTwinInterfacesList.tsx
+++ b/src/app/devices/pnp/components/digitalTwinInterfacesList.tsx
@@ -253,7 +253,7 @@ export const DigitalTwinInterfacesList: React.FC = () => {
                             {renderModelDefinition()}
                         </> :
                         <>
-                            <span>{t(ResourceKeys.digitalTwin.steps.zero)}</span>
+                            <span>{moduleId ? t(ResourceKeys.digitalTwin.steps.zeroModule) : t(ResourceKeys.digitalTwin.steps.zero)}</span>
                             <Link
                                 href={t(ResourceKeys.settings.questions.questions.documentation.link)}
                                 target="_blank"

--- a/src/app/devices/pnp/sagas/invokeCommandSaga.spec.ts
+++ b/src/app/devices/pnp/sagas/invokeCommandSaga.spec.ts
@@ -79,7 +79,7 @@ describe('digitalTwinInterfaceCommandSaga', () => {
                                 commandName,
                                 deviceId,
                                 response: JSON.stringify(response),
-                                validationResult: false
+                                validationResult: null
                             },
                         },
                         type: NotificationType.success

--- a/src/app/devices/pnp/sagas/invokeCommandSaga.ts
+++ b/src/app/devices/pnp/sagas/invokeCommandSaga.ts
@@ -77,6 +77,6 @@ export function* notifyMethodInvoked(toastId: number, action: Action<InvokeComma
 }
 
 const getValidationResult = (response: any, schema: ParsedJsonSchema) => { // tslint:disable-line:no-any
-    const errors = getSchemaValidationErrors(response, schema, true);
-    return errors.length !== 0 && errors.map(element => element.message).join(', ');
+    const errors = getSchemaValidationErrors(response?.payload, schema, true);
+    return errors.length !== 0 ? errors.map(element => element.message).join(', ') : null;
 };

--- a/src/app/home/components/__snapshots__/homeView.spec.tsx.snap
+++ b/src/app/home/components/__snapshots__/homeView.spec.tsx.snap
@@ -33,6 +33,11 @@ exports[`HomeView matches snapshot 1`] = `
           exact={true}
           path="/home/repos"
         />
+        <Route
+          component={[Function]}
+          exact={true}
+          path="/home/notifications"
+        />
       </Switch>
     </div>
   </div>

--- a/src/app/home/components/__snapshots__/homeViewNavigation.spec.tsx.snap
+++ b/src/app/home/components/__snapshots__/homeViewNavigation.spec.tsx.snap
@@ -42,6 +42,14 @@ exports[`homeViewNavigation matches snapshot 1`] = `
                   "name": "breadcrumb.repos",
                   "url": "#/home/repos",
                 },
+                Object {
+                  "iconProps": Object {
+                    "iconName": "Ringer",
+                  },
+                  "key": "notifications",
+                  "name": "breadcrumb.notificationCenter",
+                  "url": "#/home/notifications",
+                },
               ],
             },
           ]

--- a/src/app/home/components/homeView.tsx
+++ b/src/app/home/components/homeView.tsx
@@ -9,6 +9,7 @@ import { AppVersionMessageBar } from './appVersionMessageBar';
 import { HomeViewNavigation } from './homeViewNavigation';
 import { ConnectionStringsView } from '../../connectionStrings/components/connectionStringsView';
 import { ModelRepositoryLocationView } from '../../modelRepository/components/modelRepositoryLocationView';
+import { NotificationList } from './../../notifications/components/notificationList';
 import './homeView.scss';
 
 export const HomeView: React.FC = () => {
@@ -28,6 +29,7 @@ export const HomeView: React.FC = () => {
                         <Redirect from={`/${ROUTE_PARTS.HOME}`} to={`/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.RESOURCES}`} exact={true}/>
                         <Route path={`/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.RESOURCES}`} component={ConnectionStringsView} exact={true} />
                         <Route path={`/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.MODEL_REPOS}`} component={ModelRepositoryLocationView} exact={true} />
+                        <Route path={`/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.NOTIFICATIONS}`} component={NotificationList} exact={true} />
                     </Switch>
                 </div>
             </div>

--- a/src/app/home/components/homeViewNavigation.tsx
+++ b/src/app/home/components/homeViewNavigation.tsx
@@ -36,6 +36,12 @@ export const HomeViewNavigation: React.FC<HomeViewNavigationProps> = props => {
             name: t(ResourceKeys.breadcrumb.repos),
             url: `#/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.MODEL_REPOS}`
         },
+        {
+            iconProps: { iconName: 'Ringer' },
+            key: ROUTE_PARTS.NOTIFICATIONS,
+            name: t(ResourceKeys.breadcrumb.notificationCenter),
+            url: `#/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.NOTIFICATIONS}`
+        },
     ];
     return (
         <div className="nav-link-bar view">

--- a/src/app/modelRepository/components/__snapshots__/modelRepositoryLocationListItem.spec.tsx.snap
+++ b/src/app/modelRepository/components/__snapshots__/modelRepositoryLocationListItem.spec.tsx.snap
@@ -46,15 +46,19 @@ exports[`components/settings/modelRepositoryLocationListItem matches snapshot fo
         role="dialog"
       >
         <Dialog
-          className="folder-picker-dialog"
+          dialogContentProps={
+            Object {
+              "subText": "modelRepository.types.local.folderPicker.dialog.subText",
+            }
+          }
           hidden={true}
           modalProps={
             Object {
+              "className": "folder-picker-dialog",
               "isBlocking": false,
             }
           }
           onDismiss={[Function]}
-          subText="modelRepository.types.local.folderPicker.dialog.subText"
           title="modelRepository.types.local.folderPicker.dialog.title"
         >
           <div
@@ -153,15 +157,19 @@ exports[`components/settings/modelRepositoryLocationListItem matches snapshot fo
         role="dialog"
       >
         <Dialog
-          className="folder-picker-dialog"
+          dialogContentProps={
+            Object {
+              "subText": "modelRepository.types.local.folderPicker.dialog.subText",
+            }
+          }
           hidden={true}
           modalProps={
             Object {
+              "className": "folder-picker-dialog",
               "isBlocking": false,
             }
           }
           onDismiss={[Function]}
-          subText="modelRepository.types.local.folderPicker.dialog.subText"
           title="modelRepository.types.local.folderPicker.dialog.title"
         >
           <div

--- a/src/app/modelRepository/components/__snapshots__/modelRepositoryLocationView.spec.tsx.snap
+++ b/src/app/modelRepository/components/__snapshots__/modelRepositoryLocationView.spec.tsx.snap
@@ -12,19 +12,6 @@ exports[`modelRepositoryLocationView matches snapshot when locations greater tha
     className="view-command"
   >
     <StyledCommandBarBase
-      farItems={
-        Array [
-          Object {
-            "ariaLabel": "modelRepository.commands.help.ariaLabel",
-            "iconProps": Object {
-              "iconName": "Help",
-            },
-            "key": "help",
-            "onClick": [Function],
-            "text": "modelRepository.commands.help.label",
-          },
-        ]
-      }
       items={
         Array [
           Object {
@@ -90,6 +77,15 @@ exports[`modelRepositoryLocationView matches snapshot when locations greater tha
             "onClick": [Function],
             "text": "modelRepository.commands.revert.label",
           },
+          Object {
+            "ariaLabel": "modelRepository.commands.help.ariaLabel",
+            "iconProps": Object {
+              "iconName": "Help",
+            },
+            "key": "help",
+            "onClick": [Function],
+            "text": "modelRepository.commands.help.label",
+          },
         ]
       }
     />
@@ -128,19 +124,6 @@ exports[`modelRepositoryLocationView matches snapshot when no locations 1`] = `
     className="view-command"
   >
     <StyledCommandBarBase
-      farItems={
-        Array [
-          Object {
-            "ariaLabel": "modelRepository.commands.help.ariaLabel",
-            "iconProps": Object {
-              "iconName": "Help",
-            },
-            "key": "help",
-            "onClick": [Function],
-            "text": "modelRepository.commands.help.label",
-          },
-        ]
-      }
       items={
         Array [
           Object {
@@ -205,6 +188,15 @@ exports[`modelRepositoryLocationView matches snapshot when no locations 1`] = `
             "key": "revert",
             "onClick": [Function],
             "text": "modelRepository.commands.revert.label",
+          },
+          Object {
+            "ariaLabel": "modelRepository.commands.help.ariaLabel",
+            "iconProps": Object {
+              "iconName": "Help",
+            },
+            "key": "help",
+            "onClick": [Function],
+            "text": "modelRepository.commands.help.label",
           },
         ]
       }

--- a/src/app/modelRepository/components/modelRepositoryLocationListItem.tsx
+++ b/src/app/modelRepository/components/modelRepositoryLocationListItem.tsx
@@ -202,12 +202,14 @@ export const ModelRepositoryLocationListItem: React.FC<ModelRepositoryLocationLi
         return (
             <div role="dialog">
                 <Dialog
-                    className="folder-picker-dialog"
                     hidden={!showFolderPicker}
                     title={t(ResourceKeys.modelRepository.types.local.folderPicker.dialog.title)}
-                    subText={currentFolder && t(ResourceKeys.modelRepository.types.local.folderPicker.dialog.subText, {folder: currentFolder})}
                     modalProps={{
-                        isBlocking: false,
+                        className: 'folder-picker-dialog',
+                        isBlocking: false
+                    }}
+                    dialogContentProps={{
+                        subText: currentFolder && t(ResourceKeys.modelRepository.types.local.folderPicker.dialog.subText, {folder: currentFolder})
                     }}
                     onDismiss={dismissFolderPicker}
                 >

--- a/src/app/modelRepository/components/modelRepositoryLocationView.tsx
+++ b/src/app/modelRepository/components/modelRepositoryLocationView.tsx
@@ -40,7 +40,7 @@ export const ModelRepositoryLocationView: React.FC = () => {
     const getCommandBarItems = (): ICommandBarItemProps[] => {
         const addItems = getCommandBarItemsAdd();
 
-        return [
+        const items = [
             {
                 ariaLabel: t(ResourceKeys.modelRepository.commands.save.ariaLabel),
                 disabled: !dirty,
@@ -66,12 +66,7 @@ export const ModelRepositoryLocationView: React.FC = () => {
                 key: 'revert',
                 onClick: onRevertModelRepositorySettingsClick,
                 text: t(ResourceKeys.modelRepository.commands.revert.label)
-            }
-        ];
-    };
-
-    const getCommandBarItemsFar = (): ICommandBarItemProps[] => {
-        const items: ICommandBarItemProps[] = [
+            },
             {
                 ariaLabel: t(ResourceKeys.modelRepository.commands.help.ariaLabel),
                 iconProps: { iconName: HELP},
@@ -201,7 +196,6 @@ export const ModelRepositoryLocationView: React.FC = () => {
             <div className="view-command">
                 <CommandBar
                     items={getCommandBarItems()}
-                    farItems={getCommandBarItemsFar()}
                 />
             </div>
             <div className="view-scroll-vertical">

--- a/src/app/notifications/components/__snapshots__/notificationList.spec.tsx.snap
+++ b/src/app/notifications/components/__snapshots__/notificationList.spec.tsx.snap
@@ -2,77 +2,66 @@
 
 exports[`notificationList matches snapshot where there is no notifications 1`] = `
 <Fragment>
-  <CustomizedActionButton
-    ariaLabel="header.notifications.show"
-    iconProps={
-      Object {
-        "className": false,
-        "iconName": "Ringer",
-      }
+  <StyledCommandBarBase
+    items={
+      Array [
+        Object {
+          "ariaLabel": "modelRepository.commands.back.ariaLabel",
+          "disabled": true,
+          "iconProps": Object {
+            "iconName": "Cancel",
+          },
+          "key": "back",
+          "onClick": [Function],
+          "text": "header.notifications.dismiss",
+        },
+      ]
     }
-    id="notifications"
-    onClick={[Function]}
-    text="header.notifications.show"
   />
-  <StyledPanelBase
-    closeButtonAriaLabel="common.close"
-    isBlocking={true}
-    isOpen={false}
-    onDismiss={[Function]}
-    onRenderHeader={[Function]}
-    type={1}
-  >
-    <div>
-      <div>
-        header.notifications.panel.noNotifications
-      </div>
+  <div>
+    <div
+      className="notification-list-entry"
+    >
+      header.notifications.panel.noNotifications
     </div>
-  </StyledPanelBase>
+  </div>
 </Fragment>
 `;
 
 exports[`notificationList matches snapshot where there is no notifications 2`] = `
 <Fragment>
-  <CustomizedActionButton
-    ariaLabel="header.notifications.show"
-    iconProps={
-      Object {
-        "className": "new-notifications",
-        "iconName": "Ringer",
-      }
+  <StyledCommandBarBase
+    items={
+      Array [
+        Object {
+          "ariaLabel": "modelRepository.commands.back.ariaLabel",
+          "disabled": false,
+          "iconProps": Object {
+            "iconName": "Cancel",
+          },
+          "key": "back",
+          "onClick": [Function],
+          "text": "header.notifications.dismiss",
+        },
+      ]
     }
-    id="notifications"
-    onClick={[Function]}
-    text="header.notifications.show"
   />
-  <StyledPanelBase
-    closeButtonAriaLabel="common.close"
-    isBlocking={true}
-    isOpen={false}
-    onDismiss={[Function]}
-    onRenderHeader={[Function]}
-    type={1}
-  >
-    <div>
-      <div
-        key="0"
-      >
-        <Component
-          notification={
-            Object {
-              "text": Object {
-                "translationKey": "test",
-              },
-              "type": 2,
-            }
+  <div>
+    <div
+      key="0"
+    >
+      <Component
+        notification={
+          Object {
+            "text": Object {
+              "translationKey": "test",
+            },
+            "type": 2,
           }
-          showAnnoucement={false}
-        />
-        <hr
-          className="notification-list-divider"
-        />
-      </div>
+        }
+        showAnnoucement={false}
+      />
     </div>
-  </StyledPanelBase>
+  </div>
 </Fragment>
 `;

--- a/src/app/notifications/components/__snapshots__/notificationPane.spec.tsx.snap
+++ b/src/app/notifications/components/__snapshots__/notificationPane.spec.tsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`notificationPane matches snapshot 1`] = `
+<Fragment>
+  <CustomizedActionButton
+    ariaLabel="header.notifications.show"
+    iconProps={
+      Object {
+        "className": false,
+        "iconName": "Ringer",
+      }
+    }
+    onClick={[Function]}
+    text="header.notifications.show"
+  />
+  <StyledPanelBase
+    className="headerPane"
+    closeButtonAriaLabel="common.close"
+    isFooterAtBottom={true}
+    isLightDismiss={true}
+    isOpen={false}
+    onDismiss={[Function]}
+    role="dialog"
+    type={1}
+  >
+    <header
+      className="panel-header"
+    >
+      <h2>
+        header.notifications.panel.title
+      </h2>
+    </header>
+    <section
+      aria-label="header.notifications.panel.title"
+    >
+      <span>
+        header.notifications.panel.redirect
+      </span>
+      <StyledLinkBase
+        className="home-link"
+        href="#/home/notifications?from"
+        onClick={[Function]}
+      >
+        header.notifications.panel.redirectLink
+      </StyledLinkBase>
+    </section>
+  </StyledPanelBase>
+</Fragment>
+`;

--- a/src/app/notifications/components/notificationList.spec.tsx
+++ b/src/app/notifications/components/notificationList.spec.tsx
@@ -9,6 +9,12 @@ import * as GlobalStateContext from '../../shared/contexts/globalStateContext';
 import { globalStateInitial } from '../../shared/global/state';
 import { NotificationType } from '../../api/models/notification';
 
+jest.mock('react-router-dom', () => ({
+    useHistory: () => ({ push: jest.fn() }),
+    useLocation: () => ({ search: '?deviceId=testDevice' }),
+    useRouteMatch: () => ({ url: 'url', path: 'path'})
+}));
+
 describe('notificationList', () => {
     it('matches snapshot where there is no notifications', () => {
         jest.spyOn(GlobalStateContext, 'useGlobalStateContext').mockReturnValueOnce({globalState: globalStateInitial(), dispatch: jest.fn()});

--- a/src/app/notifications/components/notificationListEntry.spec.tsx
+++ b/src/app/notifications/components/notificationListEntry.spec.tsx
@@ -7,6 +7,12 @@ import { shallow } from 'enzyme';
 import { NotificationListEntry, getIconName, getIconColor } from './notificationListEntry';
 import { NotificationType } from '../../api/models/notification';
 
+const pathname = '/devices/add';
+jest.mock('react-router-dom', () => ({
+    useHistory: () => ({ push: jest.fn() }),
+    useLocation: () => ({ pathname })
+}));
+
 describe('notificationListEntry', () => {
 
     it('matches snapshot', () => {

--- a/src/app/notifications/components/notificationListEntry.tsx
+++ b/src/app/notifications/components/notificationListEntry.tsx
@@ -4,9 +4,12 @@
  **********************************************************/
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation, useHistory } from 'react-router-dom';
 import { Icon } from 'office-ui-fabric-react/lib/components/Icon';
 import { Announced } from 'office-ui-fabric-react/lib/components/Announced';
+import { Link } from 'office-ui-fabric-react/lib/components/Link';
 import { Notification, NotificationType } from '../../api/models/notification';
+import { ROUTE_PARAMS, ROUTE_PARTS } from '../../constants/routes';
 import '../../css/_notification.scss';
 
 export interface NotificationListEntryProps {
@@ -17,10 +20,20 @@ export interface NotificationListEntryProps {
 export const NotificationListEntry: React.SFC<NotificationListEntryProps> = (props: NotificationListEntryProps) => {
     const { t } = useTranslation();
     const { notification } = props;
+    const { pathname } = useLocation();
+    const history = useHistory();
+
     const iconName = getIconName(notification.type);
     const iconColor = getIconColor(notification.type);
     const message = t(notification.text.translationKey, notification.text.translationOptions);
-    const readingFriendlyMessage = message.split('. ');
+    const friendlyMessage = <>{message.split('. ').map((m: React.ReactNode, index: number) => (<div className="message" key={index}>{m + '.'}<br/></div>))}</>;
+    const longMessageLength = 200;
+    const shortMessageLength = 150;
+
+    const navigateToNotificationCenter = () => {
+        const path = `/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.NOTIFICATIONS}?${ROUTE_PARAMS.NAV_FROM}`;
+        history.push(path);
+    };
 
     return (
         <div className="notification-list-entry">
@@ -33,7 +46,17 @@ export const NotificationListEntry: React.SFC<NotificationListEntryProps> = (pro
                 {notification.title &&
                     <div className="title">{t(notification.title.translationKey, notification.title.translationOptions)}</div>
                 }
-                {readingFriendlyMessage.map((m: React.ReactNode, index: number) => (<div className="message" key={index}>{m + '.'}<br/></div>))}
+                {pathname.endsWith(ROUTE_PARTS.NOTIFICATIONS) ? friendlyMessage :
+                    <>
+                        {message?.length < longMessageLength ?
+                            friendlyMessage :
+                            <>
+                                <div className="message">{`${message.substring(0, shortMessageLength)}...`}</div>
+                                <Link onClick={navigateToNotificationCenter}>{'Go to notification center'}</Link>
+                            </>
+                        }
+                    </>
+                }
                 <div className="time">{notification.issued}</div>
             </div>
         </div>

--- a/src/app/notifications/components/notificationListEntry.tsx
+++ b/src/app/notifications/components/notificationListEntry.tsx
@@ -27,8 +27,7 @@ export const NotificationListEntry: React.SFC<NotificationListEntryProps> = (pro
     const iconColor = getIconColor(notification.type);
     const message = t(notification.text.translationKey, notification.text.translationOptions);
     const friendlyMessage = <>{message.split('. ').map((m: React.ReactNode, index: number) => (<div className="message" key={index}>{m + '.'}<br/></div>))}</>;
-    const longMessageLength = 200;
-    const shortMessageLength = 150;
+    const longMessageLength = 300;
 
     const navigateToNotificationCenter = () => {
         const path = `/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.NOTIFICATIONS}?${ROUTE_PARAMS.NAV_FROM}`;
@@ -51,7 +50,7 @@ export const NotificationListEntry: React.SFC<NotificationListEntryProps> = (pro
                         {message?.length < longMessageLength ?
                             friendlyMessage :
                             <>
-                                <div className="message">{`${message.substring(0, shortMessageLength)}...`}</div>
+                                <div className="message">{`${message.substring(0, longMessageLength)}...`}</div>
                                 <Link onClick={navigateToNotificationCenter}>{'Go to notification center'}</Link>
                             </>
                         }

--- a/src/app/notifications/components/notificationPane.spec.tsx
+++ b/src/app/notifications/components/notificationPane.spec.tsx
@@ -1,0 +1,27 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+ import 'jest';
+ import * as React from 'react';
+ import { shallow, mount } from 'enzyme';
+ import { Panel } from 'office-ui-fabric-react/lib/components/Panel';
+ import { ActionButton } from 'office-ui-fabric-react/lib/components/Button';
+ import { act } from 'react-dom/test-utils';
+ import { NotificationPane } from './notificationPane';
+
+ describe('notificationPane', () => {
+    it('matches snapshot', () => {
+        expect(shallow(<NotificationPane/>)).toMatchSnapshot();
+    });
+
+    it('toggles visibility', () => {
+        jest.spyOn(React, 'useState').mockImplementationOnce(() => React.useState(true));
+        const wrapper = mount(<NotificationPane/>);
+        expect(wrapper.find(Panel).props().isOpen).toEqual(true);
+
+        act(() => wrapper.find(ActionButton).first().props().onClick(null));
+        wrapper.update()
+        expect(wrapper.find(Panel).props().isOpen).toEqual(false);
+    });
+});

--- a/src/app/notifications/components/notificationPane.tsx
+++ b/src/app/notifications/components/notificationPane.tsx
@@ -1,0 +1,57 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Panel, PanelType } from 'office-ui-fabric-react/lib/components/Panel';
+import { Link } from 'office-ui-fabric-react/lib/components/Link';
+import { ActionButton } from 'office-ui-fabric-react/lib/components/Button';
+import { ResourceKeys } from '../../../localization/resourceKeys';
+import { ROUTE_PARTS, ROUTE_PARAMS } from '../../constants/routes';
+import '../../css/_headerPane.scss';
+
+export const NotificationPane: React.FC = () => {
+    const [ showPanel, setShowPanel ] = React.useState<boolean>(false);
+    const { t } = useTranslation();
+
+    const togglePanelVisibility = () => {
+        setShowPanel(!showPanel);
+    };
+
+    return (
+        <>
+            <ActionButton
+                iconProps={{iconName: 'Ringer'}}
+                onClick={togglePanelVisibility}
+                text={t(ResourceKeys.header.notifications.show)}
+                ariaLabel={t(ResourceKeys.header.notifications.show)}
+            />
+
+            <Panel
+                className="headerPane"
+                role="dialog"
+                isOpen={showPanel}
+                isLightDismiss={true}
+                onDismiss={togglePanelVisibility}
+                type={PanelType.smallFixedFar}
+                isFooterAtBottom={true}
+                closeButtonAriaLabel={t(ResourceKeys.common.close)}
+            >
+                <header className="panel-header">
+                    <h2>{t(ResourceKeys.header.notifications.panel.title)}</h2>
+                </header>
+                <section aria-label={t(ResourceKeys.header.notifications.panel.title)}>
+                    <span>{t(ResourceKeys.header.notifications.panel.redirect)}</span>
+                    <Link
+                        className="home-link"
+                        onClick={togglePanelVisibility}
+                        href={`#/${ROUTE_PARTS.HOME}/${ROUTE_PARTS.NOTIFICATIONS}?${ROUTE_PARAMS.NAV_FROM}`}
+                    >
+                        {t(ResourceKeys.header.notifications.panel.redirectLink)}
+                    </Link>
+                </section>
+            </Panel>
+        </>
+    );
+};

--- a/src/app/notifications/components/notificationPane.tsx
+++ b/src/app/notifications/components/notificationPane.tsx
@@ -9,11 +9,15 @@ import { Link } from 'office-ui-fabric-react/lib/components/Link';
 import { ActionButton } from 'office-ui-fabric-react/lib/components/Button';
 import { ResourceKeys } from '../../../localization/resourceKeys';
 import { ROUTE_PARTS, ROUTE_PARAMS } from '../../constants/routes';
+import { useGlobalStateContext } from '../../shared/contexts/globalStateContext';
 import '../../css/_headerPane.scss';
 
 export const NotificationPane: React.FC = () => {
-    const [ showPanel, setShowPanel ] = React.useState<boolean>(false);
     const { t } = useTranslation();
+
+    const [ showPanel, setShowPanel ] = React.useState<boolean>(false);
+    const { globalState } = useGlobalStateContext();
+    const { hasNew } = globalState.notificationsState;
 
     const togglePanelVisibility = () => {
         setShowPanel(!showPanel);
@@ -22,7 +26,10 @@ export const NotificationPane: React.FC = () => {
     return (
         <>
             <ActionButton
-                iconProps={{iconName: 'Ringer'}}
+                iconProps={{
+                    className: hasNew && 'new-notifications',
+                    iconName: 'Ringer'
+                }}
                 onClick={togglePanelVisibility}
                 text={t(ResourceKeys.header.notifications.show)}
                 ariaLabel={t(ResourceKeys.header.notifications.show)}

--- a/src/app/settings/components/__snapshots__/settingsPane.spec.tsx.snap
+++ b/src/app/settings/components/__snapshots__/settingsPane.spec.tsx.snap
@@ -13,9 +13,10 @@ exports[`settingsPane matches snapshot 1`] = `
     text="header.settings.launch"
   />
   <StyledPanelBase
-    className="settingsPane"
+    className="headerPane"
     closeButtonAriaLabel="common.close"
     isFooterAtBottom={true}
+    isLightDismiss={true}
     isOpen={false}
     onDismiss={[Function]}
     onRenderFooter={[Function]}

--- a/src/app/settings/components/settingsPane.tsx
+++ b/src/app/settings/components/settingsPane.tsx
@@ -12,7 +12,7 @@ import { ResourceKeys } from '../../../localization/resourceKeys';
 import { Theme, useThemeContext } from '../../shared/contexts/themeContext';
 import { THEME_SELECTION } from '../../constants/browserStorage';
 import { ROUTE_PARTS, ROUTE_PARAMS } from '../../constants/routes';
-import '../../css/_settingsPane.scss';
+import '../../css/_headerPane.scss';
 
 export const SettingsPane: React.FC = () => {
     const [ showPanel, setShowPanel ] = React.useState<boolean>(false);
@@ -37,7 +37,7 @@ export const SettingsPane: React.FC = () => {
 
     const renderFooter = () => {
         return (
-            <footer className="settings-footer">
+            <footer className="header-footer">
                 <section className="footer-buttons">
                     <DefaultButton
                         type="reset"
@@ -59,9 +59,10 @@ export const SettingsPane: React.FC = () => {
             />
 
             <Panel
-                className="settingsPane"
+                className="headerPane"
                 role="dialog"
                 isOpen={showPanel}
+                isLightDismiss={true}
                 onDismiss={togglePanelVisibility}
                 type={PanelType.smallFixedFar}
                 isFooterAtBottom={true}

--- a/src/app/shared/components/header.tsx
+++ b/src/app/shared/components/header.tsx
@@ -5,8 +5,8 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ResourceKeys } from '../../../localization/resourceKeys';
-import { NotificationList } from '../../notifications/components/notificationList';
 import { SettingsPane } from '../../settings/components/settingsPane';
+import { NotificationPane } from '../../notifications/components/notificationPane';
 import '../../css/_header.scss';
 
 export const Header: React.FC = () => {
@@ -15,7 +15,7 @@ export const Header: React.FC = () => {
     return (
         <header className="header">
             <div className="title">{t(ResourceKeys.header.applicationName)}</div>
-            <div><NotificationList/></div>
+            <div><NotificationPane/></div>
             <div><SettingsPane/></div>
         </header>
     );

--- a/src/app/shared/utils/jsonSchemaAdaptor.spec.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.spec.ts
@@ -274,7 +274,7 @@ describe('parse interface model definition to Json schema', () => {
 
     describe('checks if schema is simple type', () => {
         it('returns is simple schema type', () => {
-            expect(isSchemaSimpleType('boolean')).toEqual(true);
+            expect(isSchemaSimpleType('boolean', undefined)).toEqual(true);
             expect(isSchemaSimpleType({
                 '@id': 'dtmi:txs:cellular:RoamingStatus:ldbrgbd9;1',
                 '@type': 'Enum',
@@ -300,7 +300,7 @@ describe('parse interface model definition to Json schema', () => {
                     'enumValue': 1,
                     'name': 'Roaming'
                 }]
-            })).toEqual(true);
+            }, undefined)).toEqual(true);
         });
 
         it('returns is complex schema type', () => {
@@ -314,8 +314,9 @@ describe('parse interface model definition to Json schema', () => {
                     name: 'telemetryConfig',
                     schema: 'integer'
                 }
-            })).toEqual(false);
-            expect(isSchemaSimpleType(['boolean'])).toEqual(false);
+            }, undefined)).toEqual(false);
+            expect(isSchemaSimpleType(['boolean'], undefined)).toEqual(false);
+            expect(isSchemaSimpleType('dtmi:impinj:R700:System:Time:TimeInfo;1', '#/definitions/dtmi:impinj:R700:System:Time:TimeInfo;1')).toEqual(false);
         });
     });
 });

--- a/src/app/shared/utils/jsonSchemaAdaptor.ts
+++ b/src/app/shared/utils/jsonSchemaAdaptor.ts
@@ -35,7 +35,10 @@ export const getSchemaType = (schema: any): string => {
 };
 
 // tslint:disable-next-line: no-any
-export const isSchemaSimpleType = (schema: any): boolean => {
+export const isSchemaSimpleType = (schema: any, ref: string): boolean => {
+    if (ref) {
+        return false;
+    }
     return schema &&
         (typeof schema === 'string' ||
         typeof schema['@type'] === 'string' && schema['@type'].toLowerCase() === 'enum');

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -821,7 +821,7 @@
         "updateDeviceTwinOnError": "Failed to update device twin on device {{deviceId}}: {{error}}",
         "updateDeviceTwinOnSuccess": "Successfully updated device twin on device {{deviceId}}.",
         "invokeDigitalTwinCommandOnError": "Failed to invoke the IoT Plug and Play command '{{commandName}}' on device '{{deviceId}}': {{error}}",
-        "invokeDigitalTwinCommandOnSuccess": "Successfully invoked the IoT Plug and Play command '{{commandName}}' on device '{{deviceId}}': {{response}}.",
+        "invokeDigitalTwinCommandOnSuccess": "Successfully invoked the IoT Plug and Play command '{{commandName}}' on device '{{deviceId}}': {{response}}",
         "invokingDigitalTwinCommand": "Trying to invoke the IoT Plug and Play command '{{commandName}}' on device '{{deviceId}}' with no payload",
         "invokingDigitalTwinCommandWithPayload": "Trying to invoke the IoT Plug and Play command '{{commandName}}' on device '{{deviceId}}' with payload {{payload}}",
         "invokeDigitalTwinCommandOnSuccessButResponseIsNotValid": "Successfully invoked the IoT Plug and Play command '{{commandName}}' on device '{{deviceId}}': {{response}}. But the response is not valid: {{validationResult}}",

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -47,9 +47,9 @@
             "dismiss": "Clear all notifications",
             "panel": {
                 "title": "Notifications",
-                "noNotifications": "There are new notifications for this session",
+                "noNotifications": "There are no new notifications for this session.",
                 "redirect": "Looking for notifications?",
-                "redirectLink": "Please vist Notification Center"
+                "redirectLink": "Please visit Notification Center"
             }
         },
         "questions": {

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -43,12 +43,13 @@
             "watermark": "Find on page"
         },
         "notifications": {
-            "hide":"Hide notifications",
             "show": "Notifications",
-            "dismiss": "dismiss all",
+            "dismiss": "Dismiss",
             "panel": {
                 "title": "Notifications",
-                "noNotifications": "No new notifications for this session"
+                "noNotifications": "There are new notifications for this session",
+                "redirect": "Looking for notifications?",
+                "redirectLink": "Please vist Notification Center"
             }
         },
         "questions": {
@@ -117,7 +118,8 @@
         "moduleMethod": "Module direct method",
         "addModuleIdentity": "Add module identity",
         "modulePnp": "IoT Plug and Play components",
-        "moduleEvents": "Telemetry"
+        "moduleEvents": "Telemetry",
+        "notificationCenter": "Notification Center"
     },
     "deviceContent": {
         "start": "Select a device to start",

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -44,7 +44,7 @@
         },
         "notifications": {
             "show": "Notifications",
-            "dismiss": "Dismiss",
+            "dismiss": "Clear all notifications",
             "panel": {
                 "title": "Notifications",
                 "noNotifications": "There are new notifications for this session",
@@ -441,6 +441,7 @@
         "componentName": "Component",
         "steps": {
             "zero": "Your device is not recognized as a IoT Plug and Play device. To learn more, please check out ",
+            "zeroModule": "Your module is not recognized as a IoT Plug and Play module. To learn more, please check out ",
             "firstModule": "Step1. Your module has been discovered as a Plug and Play module",
             "first": "Step 1. Your device has been discovered as a IoT Plug and Play device",
             "secondSuccess": "Step 2. We've resolved your IoT Plug and Play model",
@@ -856,8 +857,8 @@
         "modelRepoistorySettingsUpdated": "Model repository locations successfully updated.",
         "startEventMonitoringOnError": "Failed to start monitoring device telemetry: {{error}}",
         "stopEventMonitoringOnError": "Failed to stop monitoring device telemetry: {{error}}",
-        "connectionStringsWithoutExpiryRemovalWarning": "Due to security requirments, previously stored hub connection strings have been removed. The new connection string being added would automatically have an expiration date one year from now.",
-        "connectionStringsWithExpiryRemovalWarning": "Due to security requirments, one or more hub connection strings stored more than a year ago have been removed."
+        "connectionStringsWithoutExpiryRemovalWarning": "Due to security requirements, previously stored hub connection strings have been removed. The new connection string being added would automatically have an expiration date one year from now.",
+        "connectionStringsWithExpiryRemovalWarning": "Due to security requirements, one or more hub connection strings stored more than a year ago have been removed."
     },
     "errorBoundary": {
         "text": "Something went wrong"

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -26,6 +26,7 @@ export class ResourceKeys {
       moduleMethod : "breadcrumb.moduleMethod",
       modulePnp : "breadcrumb.modulePnp",
       moduleTwin : "breadcrumb.moduleTwin",
+      notificationCenter : "breadcrumb.notificationCenter",
       properties : "breadcrumb.properties",
       repos : "breadcrumb.repos",
       resources : "breadcrumb.resources",
@@ -686,9 +687,10 @@ export class ResourceKeys {
       applicationName : "header.applicationName",
       notifications : {
          dismiss : "header.notifications.dismiss",
-         hide : "header.notifications.hide",
          panel : {
             noNotifications : "header.notifications.panel.noNotifications",
+            redirect : "header.notifications.panel.redirect",
+            redirectLink : "header.notifications.panel.redirectLink",
             title : "header.notifications.panel.title",
          },
          show : "header.notifications.show",

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -664,6 +664,7 @@ export class ResourceKeys {
          secondSuccess : "digitalTwin.steps.secondSuccess",
          third : "digitalTwin.steps.third",
          zero : "digitalTwin.steps.zero",
+         zeroModule : "digitalTwin.steps.zeroModule",
       },
    };
    public static directMethod = {


### PR DESCRIPTION
* Make notification center full page
![image](https://user-images.githubusercontent.com/5489222/111718679-9c218580-8817-11eb-9fd0-2e3f2d9172bf.png)
    * If notification is too long, the flyout would show partial message, with a link to help guide users to the full page.
    * The old notification panel would also help redirect users who are used to open panel to see notifications.
* Bug fixes
    * when dtdl schema is an inline schema, where we are seeing it as a simple type, and thus don't provide user a 'click to view value' button
    * we should be validating the 'payload' of command not the full response
    * when local folder file content retrieved being empty, we should show error instead of showing a file with no content to the users
* Text updates



- [x] If introducing new functionality or modified behavior, are they backed by unit tests?
- [x] Have **all** unit tests passed locally? (by running `npm run test` command)
- [ ] Have you updated the README.md with new screenshots if significant changes have been made?
- [x] Have you update the package version if the current version in package.json is not higher than the version released?