### PR TITLE
add repo link to app

### DIFF
--- a/public/factories/menuFactory.ts
+++ b/public/factories/menuFactory.ts
@@ -85,16 +85,12 @@ export const generateHelpMenu = (params: GenerateMenuParameters): MenuItemConstr
                 label: 'Toggle Developer Tools'
             },
             { type: 'separator' },
+            { role: 'about' },
             {
                 click: () => {
-                    const version = app.getVersion();
-                    if (!!version) {
-                    shell.openExternal(`https://github.com/Azure/azure-iot-explorer/releases/tag/v${version}`);
-                    } else {
-                            shell.openExternal(`https://github.com/Azure/azure-iot-explorer/releases`);
-                    }
+                    shell.openExternal('https://github.com/Azure/azure-iot-explorer');
                 },
-                role: 'about'
+                label: `Go to Azure IoT Explorer's GitHub repository`
             }
         ]
     };


### PR DESCRIPTION
Role 'about' has been made consistent with Mac by electron that it only shows version.
Adding the link as a new submenu.