### PR TITLE
Confirm sending empty/partial pnp commands

### DIFF
--- a/src/app/devices/deviceEvents/components/deviceEvents.tsx
+++ b/src/app/devices/deviceEvents/components/deviceEvents.tsx
@@ -206,7 +206,6 @@ export const DeviceEvents: React.FC = () => {
 
     // tslint:disable-next-line: cyclomatic-complexity
     const filterMessage = (message: Message) => {
-        return true;
         if (!message || !message.systemProperties) {
             return false;
         }

--- a/src/app/devices/pnp/components/deviceCommands/__snapshots__/sendCommandConfirmation.spec.tsx.snap
+++ b/src/app/devices/pnp/components/deviceCommands/__snapshots__/sendCommandConfirmation.spec.tsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SendCommandConfirmation matches snapshot hidden 1`] = `
+<Dialog
+  dialogContentProps={
+    Object {
+      "title": "deviceCommands.confirmSend.title",
+    }
+  }
+  hidden={true}
+  modalProps={
+    Object {
+      "isBlocking": true,
+    }
+  }
+  onDismiss={[MockFunction]}
+>
+  <div>
+    deviceCommands.confirmSend.body
+  </div>
+  <StyledDialogFooterBase>
+    <CustomizedPrimaryButton
+      ariaLabel="deviceCommands.confirmSend.yes.ariaLabel"
+      onClick={[MockFunction]}
+      text="deviceCommands.confirmSend.yes.label"
+    />
+    <CustomizedDefaultButton
+      ariaLabel="deviceCommands.confirmSend.no.ariaLabel"
+      onClick={[MockFunction]}
+      text="deviceCommands.confirmSend.no.label"
+    />
+  </StyledDialogFooterBase>
+</Dialog>
+`;
+
+exports[`SendCommandConfirmation matches snapshot visible 1`] = `
+<Dialog
+  dialogContentProps={
+    Object {
+      "title": "deviceCommands.confirmSend.title",
+    }
+  }
+  hidden={false}
+  modalProps={
+    Object {
+      "isBlocking": true,
+    }
+  }
+  onDismiss={[MockFunction]}
+>
+  <div>
+    deviceCommands.confirmSend.body
+  </div>
+  <StyledDialogFooterBase>
+    <CustomizedPrimaryButton
+      ariaLabel="deviceCommands.confirmSend.yes.ariaLabel"
+      onClick={[MockFunction]}
+      text="deviceCommands.confirmSend.yes.label"
+    />
+    <CustomizedDefaultButton
+      ariaLabel="deviceCommands.confirmSend.no.ariaLabel"
+      onClick={[MockFunction]}
+      text="deviceCommands.confirmSend.no.label"
+    />
+  </StyledDialogFooterBase>
+</Dialog>
+`;

--- a/src/app/devices/pnp/components/deviceCommands/confirmSend.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/confirmSend.tsx
@@ -1,0 +1,46 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+ import * as React from 'react';
+ import { useTranslation } from 'react-i18next';
+ import { Dialog, DialogFooter, PrimaryButton, DefaultButton } from '@fluentui/react';
+ import { ResourceKeys } from '../../../../../localization/resourceKeys';
+
+ export interface ConnectionStringDeleteProps {
+     hidden: boolean;
+     onSendConfirm(): void;
+     onSendCancel(): void;
+ }
+
+ export const ConfirmSend: React.FC<ConnectionStringDeleteProps> = (props: ConnectionStringDeleteProps) => {
+     const { hidden, onSendCancel, onSendConfirm } = props;
+     const { t } = useTranslation();
+
+     return (
+         <Dialog
+             hidden={hidden}
+             onDismiss={onSendCancel}
+             dialogContentProps={{
+                 title: t(ResourceKeys.deviceCommands.confirmSend.title)
+             }}
+             modalProps={{
+                 isBlocking: true
+             }}
+         >
+             <div>{t(ResourceKeys.deviceCommands.confirmSend.body)}</div>
+             <DialogFooter>
+                 <PrimaryButton
+                     onClick={onSendConfirm}
+                     ariaLabel={t(ResourceKeys.deviceCommands.confirmSend.yes.ariaLabel)}
+                     text={t(ResourceKeys.deviceCommands.confirmSend.yes.label)}
+                 />
+                 <DefaultButton
+                     onClick={onSendCancel}
+                     ariaLabel={t(ResourceKeys.deviceCommands.confirmSend.no.ariaLabel)}
+                     text={t(ResourceKeys.deviceCommands.confirmSend.no.label)}
+                 />
+             </DialogFooter>
+         </Dialog>
+     );
+ };

--- a/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterfacePerCommand.spec.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterfacePerCommand.spec.tsx
@@ -8,11 +8,12 @@ import * as React from 'react';
 import { Label } from '@fluentui/react';
 import { DeviceCommandsPerInterfacePerCommand, DeviceCommandDataProps, DeviceCommandDispatchProps } from './deviceCommandsPerInterfacePerCommand';
 import { DataForm } from '../../../shared/components/dataForm';
+import { SendCommandConfirmation } from './sendCommandConfirmation';
 
 describe('components/devices/deviceCommandsPerInterfacePerCommand', () => {
     const deviceCommandsDispatchProps: DeviceCommandDispatchProps = {
         handleCollapseToggle: jest.fn(),
-        invokeDigitalTwinInterfaceCommand: jest.fn()
+        invokeCommand: jest.fn()
     };
     const deviceCommandDataProps: DeviceCommandDataProps = {
         collapsed: true,
@@ -96,4 +97,112 @@ describe('components/devices/deviceCommandsPerInterfacePerCommand', () => {
         expect(dataForm).toBeDefined();
         expect(dataForm.props().buttonText).toEqual('deviceCommands.command.submit');
     });
+
+    describe('send confirmation scenario', () => {
+        it('launches send confirmation when showConfirmationDialog is true', () => {
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => React.useState(true));
+            const wrapper = getComponent({
+                collapsed: false,
+                commandModelDefinition: {
+                    '@type': 'Command',
+                    'commandType': 'synchronous',
+                    'description': 'Command description for testing',
+                    'displayName': 'Command Number 1',
+                    'name': 'command1',
+                    'request': {
+                        name: 'interval',
+                        schema: 'long'
+                    }
+                },
+                parsedSchema: {
+                    description: 'Command description for testing',
+                    name: 'command1',
+                    requestSchema: {
+                        description: '',
+                        title: 'interval',
+                        type: 'number'
+                    }
+                }
+            });
+    
+            const sendCommandConfirmation = wrapper.find(SendCommandConfirmation);
+            expect(sendCommandConfirmation.props().hidden).toEqual(false);
+        });
+
+        it('calls onConfirmSendCommand when SendCommandConfirmation confirmed', () => {
+            const onConfirmSendCommand = jest.fn();
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => React.useState(true));
+
+            const wrapper = getComponent({
+                collapsed: false,
+                commandModelDefinition: {
+                    '@type': 'Command',
+                    'commandType': 'synchronous',
+                    'description': 'Command description for testing',
+                    'displayName': 'Command Number 1',
+                    'name': 'command1',
+                    'request': {
+                        name: 'interval',
+                        schema: 'long'
+                    }
+                },
+                parsedSchema: {
+                    description: 'Command description for testing',
+                    name: 'command1',
+                    requestSchema: {
+                        description: '',
+                        title: 'interval',
+                        type: 'number'
+                    }
+                }
+            });
+    
+
+            const sendCommandConfirmation = wrapper.find(SendCommandConfirmation);
+            sendCommandConfirmation.props().onSendConfirm = onConfirmSendCommand;
+            sendCommandConfirmation.props().onSendConfirm();
+            wrapper.update();
+
+            expect(onConfirmSendCommand).toHaveBeenCalled();
+        });
+
+        it('calls onCancelSendCommand when SendCommandConfirmation canceled', () => {
+            const onCancelSendCommand = jest.fn();
+            jest.spyOn(React, 'useState').mockImplementationOnce(() => React.useState(true));
+
+            const wrapper = getComponent({
+                collapsed: false,
+                commandModelDefinition: {
+                    '@type': 'Command',
+                    'commandType': 'synchronous',
+                    'description': 'Command description for testing',
+                    'displayName': 'Command Number 1',
+                    'name': 'command1',
+                    'request': {
+                        name: 'interval',
+                        schema: 'long'
+                    }
+                },
+                parsedSchema: {
+                    description: 'Command description for testing',
+                    name: 'command1',
+                    requestSchema: {
+                        description: '',
+                        title: 'interval',
+                        type: 'number'
+                    }
+                }
+            });
+    
+
+            const sendCommandConfirmation = wrapper.find(SendCommandConfirmation);
+            sendCommandConfirmation.props().onSendCancel = onCancelSendCommand;
+            sendCommandConfirmation.props().onSendCancel();
+            wrapper.update();
+
+
+            expect(onCancelSendCommand).toHaveBeenCalled();
+        });
+    });
+
 });

--- a/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterfacePerCommand.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterfacePerCommand.tsx
@@ -15,7 +15,7 @@ import { ErrorBoundary } from '../../../shared/components/errorBoundary';
 import { getLocalizedData } from '../../../../api/dataTransforms/modelDefinitionTransform';
 import { getSchemaType } from '../../../../shared/utils/jsonSchemaAdaptor';
 import { CONNECTION_TIMEOUT_IN_SECONDS, DEFAULT_COMPONENT_FOR_DIGITAL_TWIN, RESPONSE_TIME_IN_SECONDS } from '../../../../constants/devices';
-import { ConfirmSend } from './confirmSend';
+import { SendCommandConfirmation } from './sendCommandConfirmation';
 
 export interface DeviceCommandDataProps extends CommandSchema {
     collapsed: boolean;
@@ -37,8 +37,8 @@ export interface CommandSchema {
 export const DeviceCommandsPerInterfacePerCommand: React.FC<DeviceCommandDataProps & DeviceCommandDispatchProps> = (props: DeviceCommandDataProps & DeviceCommandDispatchProps) => {
     const { t } = useTranslation();
     const { collapsed, deviceId, moduleId, componentName, commandModelDefinition, parsedSchema, handleCollapseToggle, invokeCommand  } = props;
-    const [ confirmingSend, setConfirmingSend ] = React.useState<boolean>(false);
-    const [ confirmingSendData, setConfirmingSendData ] = React.useState({});
+    const [ showConfirmationDialog, setShowConfirmationDialog ] = React.useState<boolean>(false);
+    const [ confirmationCmdData, setConfirmationCmdData ] = React.useState({});
 
     const createCollapsedSummary = () => {
         return (
@@ -140,8 +140,8 @@ export const DeviceCommandsPerInterfacePerCommand: React.FC<DeviceCommandDataPro
         };
 
         if (hasUndefinedFields(data)) {
-            setConfirmingSend(true);
-            setConfirmingSendData(data);
+            setShowConfirmationDialog(true);
+            setConfirmationCmdData(data);
         } else {
             invokeCommand({
                 connectTimeoutInSeconds: CONNECTION_TIMEOUT_IN_SECONDS,
@@ -159,18 +159,18 @@ export const DeviceCommandsPerInterfacePerCommand: React.FC<DeviceCommandDataPro
         handleCollapseToggle();
     };
 
-    const onSendCancel = () => {
-        setConfirmingSend(false);
+    const onCancelSendCommand = () => {
+        setShowConfirmationDialog(false);
     };
 
-    const onSendConfirm = () => {
-        setConfirmingSend(false);
+    const onConfirmSendCommand = () => {
+        setShowConfirmationDialog(false);
         invokeCommand({
             connectTimeoutInSeconds: CONNECTION_TIMEOUT_IN_SECONDS,
             deviceId,
             methodName: componentName === DEFAULT_COMPONENT_FOR_DIGITAL_TWIN ? commandModelDefinition.name : `${componentName}*${commandModelDefinition.name}`,
             moduleId,
-            payload: confirmingSendData,
+            payload: confirmationCmdData,
             responseSchema: parsedSchema.responseSchema,
             responseTimeoutInSeconds: RESPONSE_TIME_IN_SECONDS
         });
@@ -182,10 +182,10 @@ export const DeviceCommandsPerInterfacePerCommand: React.FC<DeviceCommandDataPro
                 {createCollapsedSummary()}
                 {createUncollapsedCard()}
             </ErrorBoundary>
-            <ConfirmSend
-                hidden={!confirmingSend}
-                onSendCancel={onSendCancel}
-                onSendConfirm={onSendConfirm}
+            <SendCommandConfirmation
+                hidden={!showConfirmationDialog}
+                onSendCancel={onCancelSendCommand}
+                onSendConfirm={onConfirmSendCommand}
             />
         </article>
     );

--- a/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterfacePerCommand.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterfacePerCommand.tsx
@@ -4,7 +4,7 @@
  **********************************************************/
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Label, IconButton, PrimaryButton } from '@fluentui/react';
+import { Label, IconButton, PrimaryButton, Dialog } from '@fluentui/react';
 import { ResourceKeys } from '../../../../../localization/resourceKeys';
 import { InterfaceDetailCard, SUBMIT } from '../../../../constants/iconNames';
 import { ParsedCommandSchema } from '../../../../api/models/interfaceJsonParserOutput';
@@ -15,6 +15,7 @@ import { ErrorBoundary } from '../../../shared/components/errorBoundary';
 import { getLocalizedData } from '../../../../api/dataTransforms/modelDefinitionTransform';
 import { getSchemaType } from '../../../../shared/utils/jsonSchemaAdaptor';
 import { CONNECTION_TIMEOUT_IN_SECONDS, DEFAULT_COMPONENT_FOR_DIGITAL_TWIN, RESPONSE_TIME_IN_SECONDS } from '../../../../constants/devices';
+import { ConfirmSend } from './confirmSend';
 
 export interface DeviceCommandDataProps extends CommandSchema {
     collapsed: boolean;
@@ -36,6 +37,8 @@ export interface CommandSchema {
 export const DeviceCommandsPerInterfacePerCommand: React.FC<DeviceCommandDataProps & DeviceCommandDispatchProps> = (props: DeviceCommandDataProps & DeviceCommandDispatchProps) => {
     const { t } = useTranslation();
     const { collapsed, deviceId, moduleId, componentName, commandModelDefinition, parsedSchema, handleCollapseToggle, invokeCommand  } = props;
+    const [ confirmingSend, setConfirmingSend ] = React.useState<boolean>(false);
+    const [ confirmingSendData, setConfirmingSendData ] = React.useState({});
 
     const createCollapsedSummary = () => {
         return (
@@ -124,19 +127,53 @@ export const DeviceCommandsPerInterfacePerCommand: React.FC<DeviceCommandDataPro
     };
 
     const onSubmit = (data: any) => () => { // tslint:disable-line:no-any
+        const hasUndefinedFields = (requestData: any) => { // tslint:disable-line:no-any
+            if (requestData === undefined) {
+                return true;
+            }
+
+            for (const field in requestData) {
+                if (data[field] === undefined) {
+                    return true;
+                }
+            }
+        };
+
+        if (hasUndefinedFields(data)) {
+            setConfirmingSend(true);
+            setConfirmingSendData(data);
+        } else {
+            invokeCommand({
+                connectTimeoutInSeconds: CONNECTION_TIMEOUT_IN_SECONDS,
+                deviceId,
+                methodName: componentName === DEFAULT_COMPONENT_FOR_DIGITAL_TWIN ? commandModelDefinition.name : `${componentName}*${commandModelDefinition.name}`,
+                moduleId,
+                payload: data,
+                responseSchema: parsedSchema.responseSchema,
+                responseTimeoutInSeconds: RESPONSE_TIME_IN_SECONDS
+            });
+        }
+    };
+
+    const handleToggleCollapse = () => {
+        handleCollapseToggle();
+    };
+
+    const onSendCancel = () => {
+        setConfirmingSend(false);
+    };
+
+    const onSendConfirm = () => {
+        setConfirmingSend(false);
         invokeCommand({
             connectTimeoutInSeconds: CONNECTION_TIMEOUT_IN_SECONDS,
             deviceId,
             methodName: componentName === DEFAULT_COMPONENT_FOR_DIGITAL_TWIN ? commandModelDefinition.name : `${componentName}*${commandModelDefinition.name}`,
             moduleId,
-            payload: data,
+            payload: confirmingSendData,
             responseSchema: parsedSchema.responseSchema,
             responseTimeoutInSeconds: RESPONSE_TIME_IN_SECONDS
         });
-    };
-
-    const handleToggleCollapse = () => {
-        handleCollapseToggle();
     };
 
     return (
@@ -145,6 +182,11 @@ export const DeviceCommandsPerInterfacePerCommand: React.FC<DeviceCommandDataPro
                 {createCollapsedSummary()}
                 {createUncollapsedCard()}
             </ErrorBoundary>
+            <ConfirmSend
+                hidden={!confirmingSend}
+                onSendCancel={onSendCancel}
+                onSendConfirm={onSendConfirm}
+            />
         </article>
     );
 };

--- a/src/app/devices/pnp/components/deviceCommands/sendCommandConfirmation.spec.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/sendCommandConfirmation.spec.tsx
@@ -1,0 +1,60 @@
+/***********************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License
+ **********************************************************/
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { PrimaryButton, DefaultButton } from '@fluentui/react';
+import { SendCommandConfirmation, SendCommandConfirmationProps } from './sendCommandConfirmation';
+ 
+ describe('SendCommandConfirmation', () => {
+     it('matches snapshot hidden', () => {
+         const props: SendCommandConfirmationProps = {
+             hidden: true,
+             onSendCancel: jest.fn(),
+             onSendConfirm: jest.fn(),
+         };
+ 
+         const wrapper = shallow(<SendCommandConfirmation {...props}/>);
+         expect(wrapper).toMatchSnapshot();
+     });
+     it('matches snapshot visible', () => {
+         const props: SendCommandConfirmationProps = {
+            hidden: false,
+            onSendCancel: jest.fn(),
+            onSendConfirm: jest.fn(),
+        };
+ 
+         const wrapper = shallow(<SendCommandConfirmation {...props}/>);
+         expect(wrapper).toMatchSnapshot();
+     });
+ 
+     it('calls onSendCancel when Cancel clicked', () => {
+         const onSendCancel = jest.fn();
+         const props: SendCommandConfirmationProps = {
+            hidden: false,
+            onSendCancel,
+            onSendConfirm: jest.fn(),
+        };
+ 
+         const wrapper = shallow(<SendCommandConfirmation {...props}/>);
+         wrapper.find(DefaultButton).props().onClick(undefined);
+ 
+         expect(onSendCancel).toHaveBeenCalled();
+     });
+ 
+     it('calls onDeleteConfirm when Confirm clicked', () => {
+         const onSendConfirm = jest.fn();
+         const props: SendCommandConfirmationProps = {
+            hidden: false,
+            onSendCancel: jest.fn(),
+            onSendConfirm,
+        };
+ 
+         const wrapper = shallow(<SendCommandConfirmation {...props}/>);
+         wrapper.find(PrimaryButton).props().onClick(undefined);
+ 
+         expect(onSendConfirm).toHaveBeenCalled();
+     });
+ });
+ 

--- a/src/app/devices/pnp/components/deviceCommands/sendCommandConfirmation.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/sendCommandConfirmation.tsx
@@ -7,13 +7,13 @@
  import { Dialog, DialogFooter, PrimaryButton, DefaultButton } from '@fluentui/react';
  import { ResourceKeys } from '../../../../../localization/resourceKeys';
 
- export interface ConnectionStringDeleteProps {
+ export interface SendCommandConfirmationProps {
      hidden: boolean;
      onSendConfirm(): void;
      onSendCancel(): void;
  }
 
- export const ConfirmSend: React.FC<ConnectionStringDeleteProps> = (props: ConnectionStringDeleteProps) => {
+ export const SendCommandConfirmation: React.FC<SendCommandConfirmationProps> = (props: SendCommandConfirmationProps) => {
      const { hidden, onSendCancel, onSendConfirm } = props;
      const { t } = useTranslation();
 

--- a/src/app/devices/shared/components/dataForm.tsx
+++ b/src/app/devices/shared/components/dataForm.tsx
@@ -102,9 +102,9 @@ export const DataForm: React.FC<DataFormDataProps & DataFormActionProps> = (prop
     };
 
     const onChange = (data: string) => {
-        setIsPayloadValid(true);
         try {
             JSON.parse(data);
+            setIsPayloadValid(true);
         }
         catch  {
             setIsPayloadValid(false);

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -535,6 +535,18 @@
                 "response": "Response schema"
             },
             "type": "Command type"
+        },
+        "confirmSend": {
+            "title": "Confirm Send",
+            "body":"One or more fields are empty or invalid, do you still want to send this command?",
+            "yes": {
+                "label": "Send Anyway",
+                "ariaLabel": "Send command anyway"
+            },
+            "no": {
+                "label": "Cancel",
+                "ariaLabel": "Cancel command"
+            }
         }
     },
     "deviceInterfaces": {

--- a/src/localization/resourceKeys.ts
+++ b/src/localization/resourceKeys.ts
@@ -251,6 +251,18 @@ export class ResourceKeys {
          refresh : "deviceCommands.command.refresh",
          submit : "deviceCommands.command.submit",
       },
+      confirmSend : {
+         body : "deviceCommands.confirmSend.body",
+         no : {
+            ariaLabel : "deviceCommands.confirmSend.no.ariaLabel",
+            label : "deviceCommands.confirmSend.no.label",
+         },
+         title : "deviceCommands.confirmSend.title",
+         yes : {
+            ariaLabel : "deviceCommands.confirmSend.yes.ariaLabel",
+            label : "deviceCommands.confirmSend.yes.label",
+         },
+      },
       headerText : "deviceCommands.headerText",
       noCommands : "deviceCommands.noCommands",
    };


### PR DESCRIPTION
Add a popup for the user to confirm that they want to send a pnp command with either empty or invalid values in the request scehma
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the Azure IoT Explorer!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit tests?
- [ ] Have **all** unit tests passed locally? (by running `npm run test` command)
- [ ] Have you updated the README.md with new screenshots if significant changes have been made?
- [ ] Have you update the package version if the current version in package.json is not higher than the version released?