### PR TITLE
add old event client logic as a catch, and stringify electron error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.14.13",
+  "version": "0.14.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.14.13",
+  "version": "0.14.14",
   "description": "This project welcomes contributions and suggestions. Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "host/electron.js",
   "build": {

--- a/public/handlers/eventHubHandler.ts
+++ b/public/handlers/eventHubHandler.ts
@@ -32,12 +32,27 @@ export const onStopMonitoring = async (): Promise<void> => {
 }
 
 const eventHubProvider = async (params: StartEventHubMonitoringParameters) =>  {
+    await initializeEventHubClient(params);
+    updateEntityIdIfNecessary(params);
+
+    return listeningToMessages(client, params);
+};
+
+const initializeEventHubClient = async (params: StartEventHubMonitoringParameters) =>  {
     if (needToCreateNewEventHubClient(params))
     {
         // hub has changed, reinitialize client, receivers and mesages
-        client = params.customEventHubConnectionString ?
-            await EventHubClient.createFromConnectionString(params.customEventHubConnectionString, params.customEventHubName) :
-            await EventHubClient.createFromConnectionString(await convertIotHubToEventHubsConnectionString(params.hubConnectionString), params.customEventHubName);
+        if (params.customEventHubConnectionString) {
+            client = await EventHubClient.createFromConnectionString(params.customEventHubConnectionString, params.customEventHubName);
+        }
+        else {
+            try {
+                client = await EventHubClient.createFromConnectionString(await convertIotHubToEventHubsConnectionString(params.hubConnectionString));
+            }
+            catch {
+                client = await EventHubClient.createFromIotHubConnectionString(params.hubConnectionString);
+            }
+        }
 
         connectionString = params.customEventHubConnectionString ?
             `${params.customEventHubConnectionString}/${params.customEventHubName}` :
@@ -45,9 +60,6 @@ const eventHubProvider = async (params: StartEventHubMonitoringParameters) =>  {
         receivers = [];
         messages = [];
     }
-    updateEntityIdIfNecessary(params);
-
-    return listeningToMessages(client, params);
 };
 
 const listeningToMessages = async (eventHubClient: EventHubClient, params: StartEventHubMonitoringParameters) => {

--- a/public/utils/invokeHelper.ts
+++ b/public/utils/invokeHelper.ts
@@ -15,7 +15,7 @@ export const invokeInMainWorld = async <T>(channel: string, ...args: Array<unkno
     // using customer invoker that returns the original error if handler throws.
     const { error, result } =  await ipcRenderer.invoke(channel, ...args);
     if (error) {
-        throw error;
+        throw new Error(JSON.stringify(error.message));
     }
 
     return result;


### PR DESCRIPTION
add old event client logic as a catch to address #541 , and stringify electron error message

- [x] If introducing new functionality or modified behavior, are they backed by unit tests?
- [x] Have **all** unit tests passed locally? (by running `npm run test` command)
- [x] Have you updated the README.md with new screenshots if significant changes have been made?
- [x] Have you update the package version if the current version in package.json is not higher than the version released?