### PR TITLE
Track if update banner is displayed

### DIFF
--- a/src/app/constants/telemetry.ts
+++ b/src/app/constants/telemetry.ts
@@ -28,8 +28,7 @@ export enum TELEMETRY_PAGE_NAMES {
 export enum TELEMETRY_EVENTS {
     FETCH_DEVICES = 'fetch_devices',
     INTERNAL_USER = 'internal_user',
-    UPDATE_BANNER_DISPLAYED = 'update_banner:displayed',
-    UPDATE_BANNER_CLICKED = 'update_banner:clicked',
+    UPDATE_BANNER = 'update_banner',
     USER_ACTION = 'user_action'
 }
 

--- a/src/app/home/components/appVersionMessageBar.spec.tsx
+++ b/src/app/home/components/appVersionMessageBar.spec.tsx
@@ -18,6 +18,10 @@ const realUseState = React.useState;
 jest
   .spyOn(React, 'useState')
   .mockImplementationOnce(() => realUseState('v10.0.0'));
+jest
+  .spyOn(React, 'useState')
+  .mockImplementationOnce(() => realUseState(true));
+
 
 describe('components/devices/appVersionMessageBar', () => {
     it('shows and hides message bar', () => {


### PR DESCRIPTION
Changing what telemetry we're collecting on the update banner from whether it was displayed and clicked to whether it was displayed or not
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the Azure IoT Explorer!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit tests?
- [ ] Have **all** unit tests passed locally? (by running `npm run test` command)
- [ ] Have you updated the README.md with new screenshots if significant changes have been made?
- [ ] Have you update the package version if the current version in package.json is not higher than the version released?