### PR TITLE
address telemetry loss in very short intervals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-iot-explorer",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "MIT",
       "dependencies": {
         "@azure/core-amqp": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-explorer",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "This project welcomes contributions and suggestions. Most contributions require you to agree to a\r Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us\r the rights to use your contribution. For details, visit https://cla.microsoft.com.",
   "main": "host/electron.js",
   "build": {

--- a/src/app/devices/deviceEvents/components/deviceEvents.tsx
+++ b/src/app/devices/deviceEvents/components/deviceEvents.tsx
@@ -73,11 +73,11 @@ export const DeviceEvents: React.FC = () => {
 
     React.useEffect(
         () => {
-            client.onmessage = message => {
-                if (monitoringData) {
+            if (monitoringData) {
+                client.onmessage = message => {
                     api.setEvents(JSON.parse(message.data));
-                }
-            };
+                };
+            }
         },
         [monitoringData]);
 

--- a/src/app/devices/deviceEvents/components/deviceEvents.tsx
+++ b/src/app/devices/deviceEvents/components/deviceEvents.tsx
@@ -68,11 +68,18 @@ export const DeviceEvents: React.FC = () => {
     React.useEffect(
         () => {
             client = new WebSocket(WEBSOCKET_ENDPOINT);
-            client.onmessage = message => {
-                api.setEvents(JSON.parse(message.data));
-            };
         },
         []);
+
+    React.useEffect(
+        () => {
+            client.onmessage = message => {
+                if (monitoringData) {
+                    api.setEvents(JSON.parse(message.data));
+                }
+            };
+        },
+        [monitoringData]);
 
     React.useEffect(    // tslint:disable-next-line: cyclomatic-complexity
         () => {

--- a/src/app/devices/deviceEvents/reducers.ts
+++ b/src/app/devices/deviceEvents/reducers.ts
@@ -96,11 +96,7 @@ export const deviceEventsReducer = reducerWithInitialState<DeviceEventsStateInte
         };
     })
     .case(setEventsMessagesAction.done, (state: DeviceEventsStateInterface, payload: { params: Message[], result: Message[]}) => {
-        let messages = payload.result ? payload.result.reverse().map((message: Message) => message) : [];
-        if (state.message.length > 0 && messages.length > 0) {
-            // filter overlapped messages returned from event hub
-            messages = messages.filter(message => message.enqueuedTime > state.message[0].enqueuedTime);
-        }
+        const messages = payload.result ? payload.result.reverse().map((message: Message) => message) : [];
         return {
             ...state,
             formMode: 'fetched',

--- a/src/app/devices/deviceEvents/saga.ts
+++ b/src/app/devices/deviceEvents/saga.ts
@@ -84,6 +84,6 @@ export function* EventMonitoringSaga() {
         takeEvery(startEventsMonitoringAction.started, startEventsMonitoringSagaWorker),
         takeLatest(stopEventsMonitoringAction.started, stopEventsMonitoringSagaWorker),
         takeLatest(setDecoderInfoAction.started, setDecoderInfoSagaWorker),
-        takeLatest(setEventsMessagesAction.started, setEventsSagaWorker)
+        takeEvery(setEventsMessagesAction.started, setEventsSagaWorker)
     ]);
 }


### PR DESCRIPTION
Address two root causes of events/telemetry data loss.
1. Websocket was pushing messages to client too frequently and is causing ui not able to pick up all messages fast enough.
2. EnqueueTimeUtc is not realiable enough to check duplicates as event hub can return messages not always in order.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit tests?
- [x] Have **all** unit tests passed locally? (by running `npm run test` command)
- [x] Have you updated the README.md with new screenshots if significant changes have been made?
- [x] Have you update the package version if the current version in package.json is not higher than the version released?