### PR TITLE
Update ESRP task version to 2.x

### DIFF
--- a/pipelines/build-windows.yml
+++ b/pipelines/build-windows.yml
@@ -8,7 +8,7 @@ steps:
 - script: 'npm run pack:win'
   displayName: 'Pre-package for electron'
 
-- task: EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   inputs:
     ConnectedServiceName: 'Azure IoT Explorer CodeSign'
     FolderPath: '$(Build.SourcesDirectory)/dist/win-unpacked'

--- a/pipelines/release-pipeline.yml
+++ b/pipelines/release-pipeline.yml
@@ -171,7 +171,7 @@ stages:
       - download: current
         artifact: Windows
       
-      - task: EsrpCodeSigning@1
+      - task: EsrpCodeSigning@2
         displayName: 'Sign Windows MSI package'
         inputs:
           ConnectedServiceName: 'Azure IoT Explorer CodeSign'
@@ -225,7 +225,7 @@ stages:
       - download: current
         artifact: Mac
 
-      - task: EsrpCodeSigning@1
+      - task: EsrpCodeSigning@2
         displayName: 'Sign MacOS DMG'
         inputs:
           ConnectedServiceName: 'Azure IoT Explorer CodeSign'
@@ -249,7 +249,7 @@ stages:
           MaxRetryAttempts: '5'
           VerboseLogin: false
 
-      - task: EsrpCodeSigning@1
+      - task: EsrpCodeSigning@2
         displayName: 'Sign MacOS DMG - Notarized'
         inputs:
           ConnectedServiceName: 'Azure IoT Explorer CodeSign'
@@ -288,7 +288,7 @@ stages:
       - download: current
         artifact: Linux
 
-      - task: EsrpCodeSigning@1
+      - task: EsrpCodeSigning@2
         displayName: 'Sign Linux DEB package'
         inputs:
           ConnectedServiceName: 'Azure IoT Explorer CodeSign'


### PR DESCRIPTION
Seems our pipelines are using EsrpCodeSigning@1, which requires older versions of .NET core not found on our more current pipeline agent images. This PR bumps it to v2, which should use a .NET Core version 3.x that exists on our newer agents.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the Azure IoT Explorer!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit tests?
- [ ] Have **all** unit tests passed locally? (by running `npm run test` command)
- [ ] Have you updated the README.md with new screenshots if significant changes have been made?
- [ ] Have you update the package version if the current version in package.json is not higher than the version released?