### PR TITLE
Add parameter switches for individual OS build and sign jobs

### DIFF
--- a/pipelines/release-pipeline.yml
+++ b/pipelines/release-pipeline.yml
@@ -44,7 +44,7 @@ parameters:
 - name: build_mac
   displayName: 'Build a MacOS Release'
   type: boolean
-  default: true
+  default: false # Currently not building for Mac, so default is false
 - name: build_linux
   displayName: 'Build a Linux Release'
   type: boolean

--- a/pipelines/release-pipeline.yml
+++ b/pipelines/release-pipeline.yml
@@ -37,6 +37,18 @@ parameters:
   - 'macOS-10.15'
   - 'macOS-11'
   - 'macOS-latest'
+- name: build_win
+  displayName: 'Build a Windows release'
+  type: boolean
+  default: true
+- name: build_mac
+  displayName: 'Build a MacOS Release'
+  type: boolean
+  default: true
+- name: build_linux
+  displayName: 'Build a Linux Release'
+  type: boolean
+  default: true
 - name: release
   displayName: 'Publish Release'
   type: boolean
@@ -74,6 +86,7 @@ stages:
     jobs:
     - job: packageWindows
       displayName: "Package for Windows"
+      condition: ${{ parameters.build_win }}
       pool:
         name: $[variables.${{ parameters.buildAgentPoolVar }}]
         vmImage: $(winVmImage)
@@ -103,6 +116,7 @@ stages:
 
     - job: packageMac
       displayName: "Package for MacOS"
+      condition: ${{ parameters.build_mac }}
 
       pool:
         vmImage: ${{ parameters.macBuildImage }}
@@ -130,6 +144,7 @@ stages:
 
     - job: packageLinux
       displayName: "Package for Linux"
+      condition: ${{ parameters.build_linux }}
       pool:
         name: $[variables.${{ parameters.buildAgentPoolVar }}]
         vmImage: $(linuxVmImage)
@@ -167,6 +182,7 @@ stages:
 
     - job: signWindows
       displayName: 'Windows'
+      condition: ${{ parameters.build_win }}
       steps:
       - download: current
         artifact: Windows
@@ -221,6 +237,7 @@ stages:
         
     - job: signMac
       displayName: 'MacOS'
+      condition: ${{ parameters.build_mac }}
       steps:
       - download: current
         artifact: Mac
@@ -285,6 +302,7 @@ stages:
 
     - job: signLinux
       displayName: 'Linux'
+      condition: ${{ parameters.build_linux }}
       steps:
       - download: current
         artifact: Linux


### PR DESCRIPTION
This will give the release pipeline runner the opportunity to enable/disable specific OS packaging and signing tasks.

Note, currently Windows and Linux are enabled by default, and MacOS is disabled by default.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the Azure IoT Explorer!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit tests?
- [ ] Have **all** unit tests passed locally? (by running `npm run test` command)
- [ ] Have you updated the README.md with new screenshots if significant changes have been made?
- [ ] Have you update the package version if the current version in package.json is not higher than the version released?