### PR TITLE
update root folder per dmr convention and remove some more tests warning

### DIFF
--- a/src/app/devices/addDevice/saga.spec.ts
+++ b/src/app/devices/addDevice/saga.spec.ts
@@ -21,8 +21,8 @@ describe('addDeviceSaga', () => {
     const connectionString = 'connection_string';
     const deviceId = 'device_id';
     const mockDevice: DeviceIdentity = {
-        authentication: null,
-        capabilities: null,
+        authentication: null as any,
+        capabilities: null as any,
         cloudToDeviceMessageCount: 1,
         deviceId,
         etag: 'etag',
@@ -39,6 +39,7 @@ describe('addDeviceSaga', () => {
         deviceId,
         iotEdge: true,
         lastActivityTime: '',
+        modelId: '',
         status: 'Enabled',
         statusUpdatedTime: ''
     };
@@ -77,7 +78,7 @@ describe('addDeviceSaga', () => {
 
         expect(success.next()).toEqual({
             done: false,
-            value: put(addDeviceAction.done({params: mockDevice, result: mockResult}))
+            value: put(addDeviceAction.done({params: mockDevice, result: mockResult as any}))
         });
 
         expect(success.next().done).toEqual(true);

--- a/src/app/devices/pnp/components/deviceCommands/__snapshots__/deviceCommandsPerInterface.spec.tsx.snap
+++ b/src/app/devices/pnp/components/deviceCommands/__snapshots__/deviceCommandsPerInterface.spec.tsx.snap
@@ -71,8 +71,9 @@ exports[`components/devices/deviceCommandsPerInterface matches snapshot 1`] = `
       componentName="urn:interfaceId"
       deviceId="device1"
       handleCollapseToggle={[Function]}
-      invokeDigitalTwinInterfaceCommand={[MockFunction]}
+      invokeCommand={[MockFunction]}
       key="0"
+      moduleId=""
       parsedSchema={
         Object {
           "description": "command1 description",

--- a/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterface.spec.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterface.spec.tsx
@@ -12,7 +12,7 @@ import { DeviceCommandsPerInterfacePerCommand } from './deviceCommandsPerInterfa
 
 describe('components/devices/deviceCommandsPerInterface', () => {
     const deviceCommandsDispatchProps: DeviceCommandDispatchProps = {
-        invokeDigitalTwinInterfaceCommand: jest.fn()
+        invokeCommand: jest.fn()
     };
     const deviceCommandDataProps: DeviceCommandDataProps = {
         commandSchemas: [
@@ -28,7 +28,8 @@ describe('components/devices/deviceCommandsPerInterface', () => {
             }
         ],
         componentName: 'urn:interfaceId',
-        deviceId: 'device1'
+        deviceId: 'device1',
+        moduleId: ''
     };
 
     const getComponent = (overrides = {}) => {

--- a/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterfacePerCommand.spec.tsx
+++ b/src/app/devices/pnp/components/deviceCommands/deviceCommandsPerInterfacePerCommand.spec.tsx
@@ -26,7 +26,8 @@ describe('components/devices/deviceCommandsPerInterfacePerCommand', () => {
         parsedSchema: {
             description: 'command1 description',
             name: 'command1'
-        }
+        },
+        moduleId: ''
     };
 
     const getComponent = (overrides = {}) => {
@@ -124,7 +125,7 @@ describe('components/devices/deviceCommandsPerInterfacePerCommand', () => {
                     }
                 }
             });
-    
+
             const sendCommandConfirmation = wrapper.find(SendCommandConfirmation);
             expect(sendCommandConfirmation.props().hidden).toEqual(false);
         });
@@ -156,7 +157,6 @@ describe('components/devices/deviceCommandsPerInterfacePerCommand', () => {
                     }
                 }
             });
-    
 
             const sendCommandConfirmation = wrapper.find(SendCommandConfirmation);
             sendCommandConfirmation.props().onSendConfirm = onConfirmSendCommand;
@@ -193,13 +193,11 @@ describe('components/devices/deviceCommandsPerInterfacePerCommand', () => {
                     }
                 }
             });
-    
 
             const sendCommandConfirmation = wrapper.find(SendCommandConfirmation);
             sendCommandConfirmation.props().onSendCancel = onCancelSendCommand;
             sendCommandConfirmation.props().onSendCancel();
             wrapper.update();
-
 
             expect(onCancelSendCommand).toHaveBeenCalled();
         });

--- a/src/app/devices/pnp/components/deviceSettings/__snapshots__/deviceSettingsPerInterface.spec.tsx.snap
+++ b/src/app/devices/pnp/components/deviceSettings/__snapshots__/deviceSettingsPerInterface.spec.tsx.snap
@@ -59,6 +59,7 @@ exports[`components/devices/deviceSettingsPerInterface matches snapshot 1`] = `
       handleOverlayToggle={[Function]}
       interfaceId="urn:contoso:com:EnvironmentalSensor;1"
       key="0"
+      moduleId=""
       patchTwin={[MockFunction]}
       reportedSection={
         Object {
@@ -158,6 +159,7 @@ exports[`components/devices/deviceSettingsPerInterface matches snapshot 1`] = `
       handleOverlayToggle={[Function]}
       interfaceId="urn:contoso:com:EnvironmentalSensor;1"
       key="1"
+      moduleId=""
       patchTwin={[MockFunction]}
       reportedSection={
         Object {

--- a/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterface.spec.tsx
+++ b/src/app/devices/pnp/components/deviceSettings/deviceSettingsPerInterface.spec.tsx
@@ -18,7 +18,8 @@ describe('components/devices/deviceSettingsPerInterface', () => {
         componentName: testComponentName,
         deviceId: 'testDevice',
         interfaceId: 'urn:contoso:com:EnvironmentalSensor;1',
-        twinWithSchema
+        twinWithSchema,
+        moduleId: ''
     };
 
     const deviceSettingsDispatchProps: DeviceSettingDispatchProps = {

--- a/src/app/devices/pnp/sagas/getModelDefinitionSaga.spec.ts
+++ b/src/app/devices/pnp/sagas/getModelDefinitionSaga.spec.ts
@@ -128,7 +128,7 @@ describe('modelDefinition sagas', () => {
                 getModelDefinitionAction.started({
                     digitalTwinId,
                     interfaceId,
-                    locations: [{ repositoryLocationType: REPOSITORY_LOCATION_TYPE.LocalDMR, value: 'f:/dtmi' }],
+                    locations: [{ repositoryLocationType: REPOSITORY_LOCATION_TYPE.LocalDMR, value: 'f:/' }],
                 })
             );
 

--- a/src/app/devices/pnp/sagas/utils.spec.ts
+++ b/src/app/devices/pnp/sagas/utils.spec.ts
@@ -38,6 +38,6 @@ describe('utils ', () => {
     });
 
     it('gets expected dmr params', () => {
-        expect(getDmrParams('d:/test/dtmi', interfaceId)).toEqual({folderPath: 'd:/test/dtmi/com/example', fileName: 'thermostat-1.json'});
+        expect(getDmrParams('d:/test/', interfaceId)).toEqual({folderPath: 'd:/test/dtmi/com/example', fileName: 'thermostat-1.json'});
     });
 });

--- a/src/app/devices/pnp/sagas/utils.ts
+++ b/src/app/devices/pnp/sagas/utils.ts
@@ -34,7 +34,7 @@ export const getLocationSettingValue = (locations: ModelRepositoryConfiguration[
 export const getDmrParams = (path: string, interfaceId: string): {folderPath: string, fileName: string} => {
     // convert dtmi name to follow drm convention
     // for example: dtmi:com:example:Thermostat;1 -> dtmi/com/example/thermostat-1.json
-    const fullPath = path.substring(0, path.lastIndexOf('/') + 1) + `${interfaceId.toLowerCase().replace(/:/g, '/').replace(';', '-')}.json`;
-    // path will be converted to for example: original path/dtmi/com/example, file name will be thermostat-1.json
+    const fullPath = `${path.replace(/\/$/, '')}/${interfaceId.toLowerCase().replace(/:/g, '/').replace(';', '-')}.json`;
+    // folderPath will be converted to for example: ${path}/dtmi/com/example, and fileName will be thermostat-1.json
     return {folderPath: fullPath.substring(0, fullPath.lastIndexOf('/')), fileName: fullPath.substring(fullPath.lastIndexOf('/') + 1, fullPath.length)};
 };

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -997,7 +997,7 @@
             },
             "dmr": {
                 "label": "Local Repository",
-                "infoText": "Use your local folder as a model repository following the <0>resolution convention spec</0>. Please configure the file path to be your local DTMI folder."
+                "infoText": "Use your local folder as a model repository following the <0>resolution convention spec</0>. Please configure the file path to your root repository directory containing a sub dtmi directory."
             },
             "notAvailable": "--",
             "mandatory": "Input is required."


### PR DESCRIPTION
As titled, per dmr convention, users will use the root folder **containg** dtmi directory for their local repo, not the dtmi folder path.

- [x] If introducing new functionality or modified behavior, are they backed by unit tests?
- [x] Have **all** unit tests passed locally? (by running `npm run test` command)
- [ ] Have you updated the README.md with new screenshots if significant changes have been made?
- [ ] Have you update the package version if the current version in package.json is not higher than the version released?