### PR TITLE
Switch to TextField when typing secrets

### DIFF
--- a/src/app/authentication/azureActiveDirectory/components/hubList.tsx
+++ b/src/app/authentication/azureActiveDirectory/components/hubList.tsx
@@ -66,7 +66,7 @@ export const HubList: React.FC = () => {
                     </Label>
                 );
             default:
-                return;
+                return <></>;
         }
     };
 

--- a/src/app/authentication/azureActiveDirectory/components/subscrptionList.tsx
+++ b/src/app/authentication/azureActiveDirectory/components/subscrptionList.tsx
@@ -73,7 +73,7 @@ export const SubscriptionList: React.FC<SubscriptionListPros> = props => {
                     </Label>
                 );
             default:
-                return;
+                return <></>;
         }
     };
 

--- a/src/app/connectionStrings/components/__snapshots__/connectionString.spec.tsx.snap
+++ b/src/app/connectionStrings/components/__snapshots__/connectionString.spec.tsx.snap
@@ -56,7 +56,6 @@ exports[`connectionString matches snapshot 1`] = `
       allowMask={true}
       ariaLabel="connectionStrings.properties.connectionString.ariaLabel"
       label="connectionStrings.properties.connectionString.label"
-      readOnly={true}
       value="HostName=test.azure-devices-int.net;SharedAccessKeyName=iothubowner;SharedAccessKey=key"
     />
     <div

--- a/src/app/connectionStrings/components/__snapshots__/connectionStringProperties.spec.tsx.snap
+++ b/src/app/connectionStrings/components/__snapshots__/connectionStringProperties.spec.tsx.snap
@@ -6,21 +6,18 @@ exports[`ConnectionSTringProperties matches snapshot 1`] = `
     allowMask={false}
     ariaLabel="connectionStrings.properties.hostName.ariaLabel"
     label="connectionStrings.properties.hostName.label"
-    readOnly={true}
     value="hostName"
   />
   <MaskedCopyableTextField
     allowMask={false}
     ariaLabel="connectionStrings.properties.sharedAccessPolicyName.ariaLabel"
     label="connectionStrings.properties.sharedAccessPolicyName.label"
-    readOnly={true}
     value="sharedAccessKeyName"
   />
   <MaskedCopyableTextField
     allowMask={true}
     ariaLabel="connectionStrings.properties.sharedAccessPolicyKey.ariaLabel"
     label="connectionStrings.properties.sharedAccessPolicyKey.label"
-    readOnly={true}
     value="sharedAccessKey"
   />
 </Fragment>

--- a/src/app/connectionStrings/components/connectionString.tsx
+++ b/src/app/connectionStrings/components/connectionString.tsx
@@ -99,7 +99,6 @@ export const ConnectionString: React.FC<ConnectionStringProps> = (props: Connect
                     allowMask={true}
                     label={t(ResourceKeys.connectionStrings.properties.connectionString.label)}
                     value={connectionString}
-                    readOnly={true}
                 />
                 {daysTillExpire <= CONNECTION_STRING_EXPIRATION_WARNING_IN_DAYS &&
                     <div className="expiration-warning">

--- a/src/app/connectionStrings/components/connectionStringProperties.tsx
+++ b/src/app/connectionStrings/components/connectionStringProperties.tsx
@@ -25,7 +25,6 @@ export const ConnectionStringProperties: React.FC<ConnectionStringPropertiesProp
                 allowMask={false}
                 label={t(ResourceKeys.connectionStrings.properties.hostName.label)}
                 value={hostName}
-                readOnly={true}
             />
 
             <MaskedCopyableTextField
@@ -33,7 +32,6 @@ export const ConnectionStringProperties: React.FC<ConnectionStringPropertiesProp
                 allowMask={false}
                 label={t(ResourceKeys.connectionStrings.properties.sharedAccessPolicyName.label)}
                 value={sharedAccessKeyName}
-                readOnly={true}
             />
 
             <MaskedCopyableTextField
@@ -41,7 +39,6 @@ export const ConnectionStringProperties: React.FC<ConnectionStringPropertiesProp
                 allowMask={true}
                 label={t(ResourceKeys.connectionStrings.properties.sharedAccessPolicyKey.label)}
                 value={sharedAccessKey}
-                readOnly={true}
             />
         </>
     );

--- a/src/app/css/_index.scss
+++ b/src/app/css/_index.scss
@@ -51,6 +51,12 @@ a:link, a:visited, a:hover, a:active {
     }
 }
 
+a:focus-visible {
+    @include themify($themes) {
+        outline: 1px solid themed('linkColor');
+    }
+}
+
 input::placeholder {
     opacity: 0.5;
     @include themify($themes) {

--- a/src/app/css/_mainArea.scss
+++ b/src/app/css/_mainArea.scss
@@ -15,6 +15,9 @@
 
         .mainleftnav {
             grid-area: leftnav;
+            .ms-Nav-groupContent {
+                margin-top: 12px;
+            }
         }
 
         .mainleftnav.collapsed {

--- a/src/app/css/_maskedCopyableTextField.scss
+++ b/src/app/css/_maskedCopyableTextField.scss
@@ -61,17 +61,4 @@
             background-color: themed('maskedCopyableReadonlyBackground');
         }
     }
-
-    .error {
-        @include themify($themes) {
-            border-color: themed('errorBorder');
-        }
-    }
-
-    .errorSection {
-        @include themify($themes) {
-            color: themed('errorText');
-        }
-        font-size: $textSize;
-    }
 }

--- a/src/app/devices/addDevice/components/__snapshots__/addDevice.spec.tsx.snap
+++ b/src/app/devices/addDevice/components/__snapshots__/addDevice.spec.tsx.snap
@@ -35,16 +35,13 @@ exports[`addDevice matches snapshot 1`] = `
     <div
       className="form"
     >
-      <MaskedCopyableTextField
-        allowMask={false}
+      <StyledTextFieldBase
         ariaLabel="deviceIdentity.deviceID"
-        error=""
+        description="deviceIdentity.deviceIDTooltip"
+        errorMessage=""
         label="deviceIdentity.deviceID"
-        labelCallout="deviceIdentity.deviceIDTooltip"
-        onTextChange={[Function]}
-        readOnly={false}
+        onChange={[Function]}
         required={true}
-        setFocus={true}
         value=""
       />
       <div

--- a/src/app/devices/addDevice/components/addDevice.spec.tsx
+++ b/src/app/devices/addDevice/components/addDevice.spec.tsx
@@ -6,9 +6,8 @@ import 'jest';
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { shallow, mount } from 'enzyme';
-import { ChoiceGroup, Toggle, CommandBar } from '@fluentui/react';
+import { ChoiceGroup, Toggle, CommandBar, TextField } from '@fluentui/react';
 import { AddDevice } from './addDevice';
-import { MaskedCopyableTextField } from '../../../shared/components/maskedCopyableTextField';
 import { SynchronizationStatus } from '../../../api/models/synchronizationStatus';
 import { DeviceAuthenticationType } from '../../../api/models/deviceAuthenticationType';
 import * as AsyncSagaReducer from '../../../shared/hooks/useAsyncSagaReducer';
@@ -36,22 +35,22 @@ describe('addDevice', () => {
     it('renders symmetric key input field if not auto generating keys', () => {
         // auto generate
         const wrapper = mount(<AddDevice/>);
-        expect(wrapper.find(MaskedCopyableTextField).length).toEqual(1);
+        expect(wrapper.find(TextField).length).toEqual(1);
 
         // uncheck auto generate
         const autoGenerateButton = wrapper.find('.autoGenerateButton').first();
         act(() => autoGenerateButton.props().onChange?.(undefined as any));
         wrapper.update();
-        expect(wrapper.find(MaskedCopyableTextField).length).toEqual(3); // tslint:disable-line:no-magic-numbers
+        expect(wrapper.find(TextField).length).toEqual(3); // tslint:disable-line:no-magic-numbers
 
-        act(() => wrapper.find(MaskedCopyableTextField).at(1).props().onTextChange?.('test-key1'));
-        act(() => wrapper.find(MaskedCopyableTextField).at(2).props().onTextChange?.('test-key2')); // tslint:disable-line:no-magic-numbers
+        act(() => wrapper.find(TextField).at(1).props().onChange?.(undefined as any, 'test-key1'));
+        act(() => wrapper.find(TextField).at(2).props().onChange?.(undefined as any, 'test-key2')); // tslint:disable-line:no-magic-numbers
         wrapper.update();
-        const fields = wrapper.find(MaskedCopyableTextField);
+        const fields = wrapper.find(TextField);
         expect(fields.at(1).props().value).toEqual('test-key1');
-        expect(fields.at(1).props().error).toEqual('deviceIdentity.validation.invalidKey');
+        expect(fields.at(1).props().errorMessage).toEqual('deviceIdentity.validation.invalidKey');
         expect(fields.last().props().value).toEqual('test-key2');
-        expect(fields.last().props().error).toEqual('deviceIdentity.validation.invalidKey');
+        expect(fields.last().props().errorMessage).toEqual('deviceIdentity.validation.invalidKey');
     });
 
     it('renders selfSigned input field', () => {
@@ -60,27 +59,27 @@ describe('addDevice', () => {
         const choiceGroup = wrapper.find(ChoiceGroup).first();
         act(() => choiceGroup.props().onChange?.(undefined as any, { key: DeviceAuthenticationType.SelfSigned, text: 'text' } ));
         wrapper.update();
-        expect(wrapper.find(MaskedCopyableTextField).length).toEqual(3);  // tslint:disable-line:no-magic-numbers
+        expect(wrapper.find(TextField).length).toEqual(3);  // tslint:disable-line:no-magic-numbers
 
-        act(() => wrapper.find(MaskedCopyableTextField).at(1).props().onTextChange?.('test-thumbprint1'));
-        act(() => wrapper.find(MaskedCopyableTextField).last().props().onTextChange?.('test-thumbprint2'));
+        act(() => wrapper.find(TextField).at(1).props().onChange?.(undefined as any, 'test-thumbprint1'));
+        act(() => wrapper.find(TextField).last().props().onChange?.(undefined as any, 'test-thumbprint2'));
         wrapper.update();
-        const fields = wrapper.find(MaskedCopyableTextField);
+        const fields = wrapper.find(TextField);
         expect(fields.at(1).props().value).toEqual('test-thumbprint1');
-        expect(fields.at(1).props().error).toEqual('deviceIdentity.validation.invalidThumbprint');
+        expect(fields.at(1).props().errorMessage).toEqual('deviceIdentity.validation.invalidThumbprint');
         expect(fields.last().props().value).toEqual('test-thumbprint2');
-        expect(fields.last().props().error).toEqual('deviceIdentity.validation.invalidThumbprint');
+        expect(fields.last().props().errorMessage).toEqual('deviceIdentity.validation.invalidThumbprint');
     });
 
     it('saves new device identity', () => {
         const addDeviceActionSpy = jest.spyOn(addDeviceAction, 'started');
         const wrapper = mount(<AddDevice/>);
 
-        act(() => wrapper.find(MaskedCopyableTextField).first().props().onTextChange?.('test-device'));
+        act(() => wrapper.find(TextField).first().props().onChange?.(undefined as any, 'test-device'));
         act(() => wrapper.find(Toggle).first().props().onChange?.(undefined as any, false));
         wrapper.update();
 
-        expect(wrapper.find(MaskedCopyableTextField).first().props().value).toEqual('test-device');
+        expect(wrapper.find(TextField).first().props().value).toEqual('test-device');
         const toggle = wrapper.find('.connectivity').find(Toggle).first();
         expect(toggle.props().checked).toBeFalsy();
         const commandBar = wrapper.find(CommandBar).first();

--- a/src/app/devices/addDevice/components/addDevice.tsx
+++ b/src/app/devices/addDevice/components/addDevice.tsx
@@ -5,14 +5,13 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useHistory } from 'react-router-dom';
-import { Overlay, Toggle, ChoiceGroup, IChoiceGroupOption, Checkbox, CommandBar } from '@fluentui/react';
+import { Overlay, Toggle, ChoiceGroup, IChoiceGroupOption, Checkbox, CommandBar, TextField } from '@fluentui/react';
 import { ResourceKeys } from '../../../../localization/resourceKeys';
 import { DeviceAuthenticationType } from '../../../api/models/deviceAuthenticationType';
 import { DeviceIdentity } from '../../../api/models/deviceIdentity';
 import { DeviceStatus } from '../../../api/models/deviceStatus';
 import { validateKey, validateThumbprint, validateDeviceId, processThumbprint } from '../../../shared/utils/utils';
 import { LabelWithTooltip } from '../../../shared/components/labelWithTooltip';
-import { MaskedCopyableTextField } from '../../../shared/components/maskedCopyableTextField';
 import { useAsyncSagaReducer } from '../../../shared/hooks/useAsyncSagaReducer';
 import { SynchronizationStatus } from '../../../api/models/synchronizationStatus';
 import { SAVE, CANCEL } from '../../../constants/iconNames';
@@ -64,17 +63,14 @@ export const AddDevice: React.FC = () => {
 
     const showDeviceId = () => {
         return (
-            <MaskedCopyableTextField
+            <TextField
                 ariaLabel={t(ResourceKeys.deviceIdentity.deviceID)}
                 label={t(ResourceKeys.deviceIdentity.deviceID)}
                 value={device.id}
                 required={true}
-                onTextChange={changeDeviceId}
-                allowMask={false}
-                readOnly={false}
-                error={!!device.error ? t(device.error) : ''}
-                labelCallout={t(ResourceKeys.deviceIdentity.deviceIDTooltip)}
-                setFocus={true}
+                onChange={changeDeviceId}
+                errorMessage={!!device.error ? t(device.error) : ''}
+                description={t(ResourceKeys.deviceIdentity.deviceIDTooltip)}
             />
         );
     };
@@ -109,27 +105,27 @@ export const AddDevice: React.FC = () => {
     const renderSymmetricKeySection = () => {
         return (
             <>
-                <MaskedCopyableTextField
+                <TextField
                     ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryKey)}
                     label={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryKey)}
                     value={primaryKey.value}
                     required={true}
-                    onTextChange={changePrimaryKey}
-                    allowMask={true}
-                    readOnly={false}
-                    error={!!primaryKey.error ? t(primaryKey.error) : ''}
-                    labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryKeyTooltip)}
+                    onChange={changePrimaryKey}
+                    type={'password'}
+                    canRevealPassword={true}
+                    errorMessage={!!primaryKey.error ? t(primaryKey.error) : ''}
+                    description={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryKeyTooltip)}
                 />
-                <MaskedCopyableTextField
+                <TextField
                     ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryKey)}
                     label={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryKey)}
                     value={secondaryKey.value}
                     required={true}
-                    onTextChange={changeSecondaryKey}
-                    allowMask={true}
-                    readOnly={false}
-                    error={!!secondaryKey.error ? t(secondaryKey.error) : ''}
-                    labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryKeyTooltip)}
+                    onChange={changeSecondaryKey}
+                    type={'password'}
+                    canRevealPassword={true}
+                    errorMessage={!!secondaryKey.error ? t(secondaryKey.error) : ''}
+                    description={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryKeyTooltip)}
                 />
             </>
         );
@@ -138,27 +134,27 @@ export const AddDevice: React.FC = () => {
     const renderSelfSignedSection = () => {
         return (
             <>
-                <MaskedCopyableTextField
+                <TextField
                     ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprint)}
                     label={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprint)}
                     value={primaryKey.thumbprint}
                     required={true}
-                    onTextChange={changePrimaryThumbprint}
-                    allowMask={true}
-                    readOnly={false}
-                    error={!!primaryKey.thumbprintError ? t(primaryKey.thumbprintError) : ''}
-                    labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprintTooltip)}
+                    onChange={changePrimaryThumbprint}
+                    type={'password'}
+                    canRevealPassword={true}
+                    errorMessage={!!primaryKey.thumbprintError ? t(primaryKey.thumbprintError) : ''}
+                    description={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprintTooltip)}
                 />
-                <MaskedCopyableTextField
+                <TextField
                     ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprint)}
                     label={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprint)}
                     value={secondaryKey.thumbprint}
                     required={true}
-                    onTextChange={changeSecondaryThumbprint}
-                    allowMask={true}
-                    readOnly={false}
-                    error={!!secondaryKey.thumbprintError ? t(secondaryKey.thumbprintError) : ''}
-                    labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip)}
+                    onChange={changeSecondaryThumbprint}
+                    type={'password'}
+                    canRevealPassword={true}
+                    errorMessage={!!secondaryKey.thumbprintError ? t(secondaryKey.thumbprintError) : ''}
+                    description={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip)}
                 />
             </>
         );
@@ -237,7 +233,7 @@ export const AddDevice: React.FC = () => {
         );
     };
 
-    const changeDeviceId = (newValue?: string) => {
+    const changeDeviceId = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const deviceIdError = getDeviceIdValidationMessage(newValue);
         setDevice({
             error: deviceIdError,
@@ -259,7 +255,7 @@ export const AddDevice: React.FC = () => {
         }
     };
 
-    const changePrimaryKey = (newValue?: string) => {
+    const changePrimaryKey = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const primaryKeyError = getSymmetricKeyValidationMessage(newValue);
         setPrimaryKey({
             ...primaryKey,
@@ -268,7 +264,7 @@ export const AddDevice: React.FC = () => {
         });
     };
 
-    const changeSecondaryKey = (newValue?: string) => {
+    const changeSecondaryKey = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const secondaryKeyError = getSymmetricKeyValidationMessage(newValue);
         setSecondaryKey({
             ...secondaryKey,
@@ -277,7 +273,7 @@ export const AddDevice: React.FC = () => {
         });
     };
 
-    const changePrimaryThumbprint = (newValue?: string) => {
+    const changePrimaryThumbprint = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const primaryThumbprintError = getThumbprintValidationMessage(newValue);
         setPrimaryKey({
             ...primaryKey,
@@ -286,7 +282,7 @@ export const AddDevice: React.FC = () => {
         });
     };
 
-    const changeSecondaryThumbprint = (newValue?: string) => {
+    const changeSecondaryThumbprint = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const secondaryThumbprintError = getThumbprintValidationMessage(newValue);
         setSecondaryKey({
             ...secondaryKey,

--- a/src/app/devices/cloudToDeviceMessage/components/cloudToDeviceMessage.tsx
+++ b/src/app/devices/cloudToDeviceMessage/components/cloudToDeviceMessage.tsx
@@ -238,7 +238,7 @@ export const CloudToDeviceMessage: React.FC = () => {
             case 'value':
                 return renderItemValueColumn(item, column);
             default:
-                return;
+                return <></>;
         }
     };
 

--- a/src/app/devices/deviceEvents/components/__snapshots__/deviceSimulationPanel.spec.tsx.snap
+++ b/src/app/devices/deviceEvents/components/__snapshots__/deviceSimulationPanel.spec.tsx.snap
@@ -44,7 +44,6 @@ exports[`deviceSimulationPanel matches snapshot  1`] = `
       allowMask={false}
       ariaLabel="deviceEvents.simulation.basic.copyLabel"
       label="deviceEvents.simulation.basic.copyLabel"
-      readOnly={true}
       value="az iot device simulate --device-id device1 --login \\"\\""
     />
   </CollapsibleSection>
@@ -168,7 +167,6 @@ exports[`deviceSimulationPanel matches snapshot  1`] = `
       allowMask={false}
       ariaLabel="deviceEvents.simulation.advanced.copyLabel"
       label="deviceEvents.simulation.advanced.copyLabel"
-      readOnly={true}
       value="az iot device simulate --device-id device1 --login \\"\\""
     />
   </CollapsibleSection>

--- a/src/app/devices/deviceEvents/components/deviceSimulationPanel.tsx
+++ b/src/app/devices/deviceEvents/components/deviceSimulationPanel.tsx
@@ -74,7 +74,6 @@ export const DeviceSimulationPanel: React.FC<DeviceSimulationPanelProps> = props
                         label={t(ResourceKeys.deviceEvents.simulation.basic.copyLabel, {deviceId})}
                         value={`az iot device simulate --device-id ${deviceId} --login \"${hubConnectionString}\"`}
                         allowMask={false}
-                        readOnly={true}
                     />
                 </CollapsibleSection>
                 <CollapsibleSection
@@ -90,7 +89,6 @@ export const DeviceSimulationPanel: React.FC<DeviceSimulationPanelProps> = props
                         label={t(ResourceKeys.deviceEvents.simulation.advanced.copyLabel, {deviceId})}
                         value={convertToCliCommand()}
                         allowMask={false}
-                        readOnly={true}
                     />
                 </CollapsibleSection>
             </Panel>
@@ -173,7 +171,7 @@ export const DeviceSimulationPanel: React.FC<DeviceSimulationPanelProps> = props
             case 'value':
                 return renderItemValueColumn(item, column);
             default:
-                return;
+                return <></>;
         }
     };
 

--- a/src/app/devices/deviceIdentity/components/__snapshots__/deviceIdentity.spec.tsx.snap
+++ b/src/app/devices/deviceIdentity/components/__snapshots__/deviceIdentity.spec.tsx.snap
@@ -12,11 +12,10 @@ exports[`deviceIdentity snapshot matches snapshot 1`] = `
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="deviceIdentity.deviceID"
+      description="deviceIdentity.deviceIDTooltip"
       label="deviceIdentity.deviceID"
-      labelCallout="deviceIdentity.deviceIDTooltip"
       readOnly={true}
       value={null}
     />
@@ -45,11 +44,10 @@ exports[`deviceIdentity snapshot matches snapshot with CA auth type 1`] = `
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="deviceIdentity.deviceID"
+      description="deviceIdentity.deviceIDTooltip"
       label="deviceIdentity.deviceID"
-      labelCallout="deviceIdentity.deviceIDTooltip"
       readOnly={true}
       value={null}
     />
@@ -78,11 +76,10 @@ exports[`deviceIdentity snapshot matches snapshot with SelfSigned auth type 1`] 
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="deviceIdentity.deviceID"
+      description="deviceIdentity.deviceIDTooltip"
       label="deviceIdentity.deviceID"
-      labelCallout="deviceIdentity.deviceIDTooltip"
       readOnly={true}
       value={null}
     />
@@ -111,11 +108,10 @@ exports[`deviceIdentity snapshot matches snapshot with SymmetricKey auth type 1`
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="deviceIdentity.deviceID"
+      description="deviceIdentity.deviceIDTooltip"
       label="deviceIdentity.deviceID"
-      labelCallout="deviceIdentity.deviceIDTooltip"
       readOnly={true}
       value={null}
     />
@@ -144,11 +140,10 @@ exports[`deviceIdentity snapshot matches snapshot with Synchronization Status of
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="deviceIdentity.deviceID"
+      description="deviceIdentity.deviceIDTooltip"
       label="deviceIdentity.deviceID"
-      labelCallout="deviceIdentity.deviceIDTooltip"
       readOnly={true}
       value={null}
     />
@@ -177,11 +172,10 @@ exports[`deviceIdentity snapshot matches snapshot with Synchronization Status of
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="deviceIdentity.deviceID"
+      description="deviceIdentity.deviceIDTooltip"
       label="deviceIdentity.deviceID"
-      labelCallout="deviceIdentity.deviceIDTooltip"
       readOnly={true}
       value={null}
     />
@@ -210,11 +204,10 @@ exports[`deviceIdentity snapshot matches snapshot with auth type of None 1`] = `
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="deviceIdentity.deviceID"
+      description="deviceIdentity.deviceIDTooltip"
       label="deviceIdentity.deviceID"
-      labelCallout="deviceIdentity.deviceIDTooltip"
       readOnly={true}
       value={null}
     />
@@ -243,11 +236,10 @@ exports[`deviceIdentity snapshot matches snapshot with identity wrapper 1`] = `
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="deviceIdentity.deviceID"
+      description="deviceIdentity.deviceIDTooltip"
       label="deviceIdentity.deviceID"
-      labelCallout="deviceIdentity.deviceIDTooltip"
       readOnly={true}
       value={null}
     />

--- a/src/app/devices/deviceIdentity/components/deviceIdentity.tsx
+++ b/src/app/devices/deviceIdentity/components/deviceIdentity.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License
  **********************************************************/
 import * as React from 'react';
-import { Label, Toggle } from '@fluentui/react';
+import { Label, Toggle, TextField } from '@fluentui/react';
 import { useTranslation } from 'react-i18next';
 import { ResourceKeys } from '../../../../localization/resourceKeys';
 import { DeviceIdentity } from '../../../api/models/deviceIdentity';
@@ -13,7 +13,6 @@ import { DeviceAuthenticationType } from '../../../api/models/deviceAuthenticati
 import { DeviceStatus } from '../../../api/models/deviceStatus';
 import { generateKey } from '../../../shared/utils/utils';
 import { SynchronizationStatus } from '../../../api/models/synchronizationStatus';
-import { MaskedCopyableTextField } from '../../../shared/components/maskedCopyableTextField';
 import { MultiLineShimmer } from '../../../shared/components/multiLineShimmer';
 import { HeaderView } from '../../../shared/components/headerView';
 import { SasTokenGenerationView } from '../../shared/components/sasTokenGenerationView';
@@ -92,13 +91,12 @@ export const DeviceIdentityInformation: React.FC<DeviceIdentityDataProps & Devic
                 {props.synchronizationStatus === SynchronizationStatus.working || props.synchronizationStatus === SynchronizationStatus.updating ?
                     <MultiLineShimmer /> :
                     <>
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.deviceID)}
                             label={t(ResourceKeys.deviceIdentity.deviceID)}
                             value={state.identity && state.identity.deviceId}
-                            allowMask={false}
                             readOnly={true}
-                            labelCallout={t(ResourceKeys.deviceIdentity.deviceIDTooltip)}
+                            description={t(ResourceKeys.deviceIdentity.deviceIDTooltip)}
                         />
                         {renderDeviceAuthProperties()}
                         <br />
@@ -127,29 +125,32 @@ export const DeviceIdentityInformation: React.FC<DeviceIdentityDataProps & Devic
                 return (
                     <>
                         <Label>{t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.text)}</Label>
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprint)}
                             label={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprint)}
                             value={state.identity.authentication.x509Thumbprint.primaryThumbprint}
-                            allowMask={true}
+                            type={'password'}
+                            canRevealPassword={true}
                             readOnly={true}
-                            labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprintTooltip)}
+                            description={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.primaryThumbprintTooltip)}
                         />
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprint)}
                             label={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprint)}
                             value={state.identity.authentication.x509Thumbprint.secondaryThumbprint}
-                            allowMask={true}
+                            type={'password'}
+                            canRevealPassword={true}
                             readOnly={true}
-                            labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip)}
+                            description={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip)}
                         />
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.connectionString)}
                             label={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.connectionString)}
                             value={generateX509ConnectionString(hostName, identity.deviceId)}
-                            allowMask={true}
+                            type={'password'}
+                            canRevealPassword={true}
                             readOnly={true}
-                            labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.connectionStringTooltip)}
+                            description={t(ResourceKeys.deviceIdentity.authenticationType.selfSigned.connectionStringTooltip)}
                         />
                     </>
                 );
@@ -157,55 +158,58 @@ export const DeviceIdentityInformation: React.FC<DeviceIdentityDataProps & Devic
                 return (
                     <>
                         <Label>{t(ResourceKeys.deviceIdentity.authenticationType.ca.text)}</Label>
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.ca.connectionString)}
                             label={t(ResourceKeys.deviceIdentity.authenticationType.ca.connectionString)}
                             value={generateX509ConnectionString(hostName, identity.deviceId)}
-                            allowMask={true}
+                            type={'password'}
+                            canRevealPassword={true}
                             readOnly={true}
-                            labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.ca.connectionStringTooltip)}
+                            description={t(ResourceKeys.deviceIdentity.authenticationType.ca.connectionStringTooltip)}
                         />
                     </>
                 );
             case DeviceAuthenticationType.SymmetricKey:
                 return (
                     <>
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryKey)}
                             label={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryKey)}
                             value={state.identity.authentication.symmetricKey.primaryKey}
-                            allowMask={true}
-                            readOnly={false}
-                            onTextChange={changePrimaryKey}
-                            labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryKeyTooltip)}
+                            type={'password'}
+                            canRevealPassword={true}
+                            onChange={changePrimaryKey}
+                            description={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryKeyTooltip)}
                         />
 
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryKey)}
                             label={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryKey)}
                             value={state.identity.authentication.symmetricKey.secondaryKey}
-                            allowMask={true}
-                            readOnly={false}
-                            onTextChange={changeSecondaryKey}
-                            labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryKeyTooltip)}
+                            type={'password'}
+                            canRevealPassword={true}
+                            onChange={changeSecondaryKey}
+                            description={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryKeyTooltip)}
                         />
 
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryConnectionString)}
                             label={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryConnectionString)}
                             value={generateConnectionString(hostName, identity.deviceId, identity.authentication.symmetricKey.primaryKey)}
-                            allowMask={true}
+                            type={'password'}
+                            canRevealPassword={true}
                             readOnly={true}
-                            labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryConnectionStringTooltip)}
+                            description={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.primaryConnectionStringTooltip)}
                         />
 
-                        <MaskedCopyableTextField
+                        <TextField
                             ariaLabel={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryConnectionString)}
                             label={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryConnectionString)}
                             value={generateConnectionString(hostName, identity.deviceId, identity.authentication.symmetricKey.secondaryKey)}
-                            allowMask={true}
+                            type={'password'}
+                            canRevealPassword={true}
                             readOnly={true}
-                            labelCallout={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryConnectionStringTooltip)}
+                            description={t(ResourceKeys.deviceIdentity.authenticationType.symmetricKey.secondaryConnectionStringTooltip)}
                         />
                     </>
                 );
@@ -227,7 +231,7 @@ export const DeviceIdentityInformation: React.FC<DeviceIdentityDataProps & Devic
         );
     };
 
-    const changePrimaryKey = (value: string) => {
+    const changePrimaryKey = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
         const identityDeepCopy: DeviceIdentity = JSON.parse(JSON.stringify(state.identity));
         identityDeepCopy.authentication.symmetricKey.primaryKey = value;
         setState({
@@ -237,7 +241,7 @@ export const DeviceIdentityInformation: React.FC<DeviceIdentityDataProps & Devic
         });
     };
 
-    const changeSecondaryKey = (value: string) => {
+    const changeSecondaryKey = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
         const identityDeepCopy: DeviceIdentity = JSON.parse(JSON.stringify(state.identity));
         identityDeepCopy.authentication.symmetricKey.secondaryKey = value;
         setState({

--- a/src/app/devices/deviceList/components/deviceList.tsx
+++ b/src/app/devices/deviceList/components/deviceList.tsx
@@ -184,7 +184,7 @@ export const DeviceList: React.FC = () => {
                     />
             );
             default:
-                return;
+                return <></>;
         }
     };
 

--- a/src/app/devices/module/addModuleIdentity/components/__snapshots__/addModuleIdentity.spec.tsx.snap
+++ b/src/app/devices/module/addModuleIdentity/components/__snapshots__/addModuleIdentity.spec.tsx.snap
@@ -34,16 +34,13 @@ exports[`devices/components/addModuleIdentity snapshot matches snapshot while lo
   <div
     className="device-detail"
   >
-    <MaskedCopyableTextField
-      allowMask={false}
+    <StyledTextFieldBase
       ariaLabel="moduleIdentity.moduleId"
-      error=""
+      description="moduleIdentity.moduleIdTooltip"
+      errorMessage=""
       label="moduleIdentity.moduleId"
-      labelCallout="moduleIdentity.moduleIdTooltip"
-      onTextChange={[Function]}
-      readOnly={false}
+      onChange={[Function]}
       required={true}
-      setFocus={true}
       value=""
     />
     <div

--- a/src/app/devices/module/addModuleIdentity/components/addModuleIdentity.spec.tsx
+++ b/src/app/devices/module/addModuleIdentity/components/addModuleIdentity.spec.tsx
@@ -6,10 +6,9 @@ import * as React from 'react';
 import 'jest';
 import { act } from 'react-dom/test-utils';
 import { shallow, mount } from 'enzyme';
-import { ChoiceGroup, CommandBar } from '@fluentui/react';
+import { ChoiceGroup, CommandBar, TextField } from '@fluentui/react';
 import { AddModuleIdentity } from './addModuleIdentity';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
-import { MaskedCopyableTextField } from '../../../../shared/components/maskedCopyableTextField';
 import { DeviceAuthenticationType } from '../../../../api/models/deviceAuthenticationType';
 import * as AsyncSagaReducer from '../../../../shared/hooks/useAsyncSagaReducer';
 import { addModuleIdentityAction } from '../actions';
@@ -46,22 +45,22 @@ describe('devices/components/addModuleIdentity', () => {
 
         it('renders symmetric key input field if not auto generating keys', () => {
             const wrapper = mount(<AddModuleIdentity/>);
-            expect(wrapper.find(MaskedCopyableTextField).length).toEqual(1);
+            expect(wrapper.find(TextField).length).toEqual(1);
 
             // uncheck auto generate
             const autoGenerateButton = wrapper.find('.autoGenerateButton').first();
             act(() => autoGenerateButton.props().onChange?.(undefined as any));
             wrapper.update();
-            expect(wrapper.find(MaskedCopyableTextField).length).toEqual(3); // tslint:disable-line:no-magic-numbers
+            expect(wrapper.find(TextField).length).toEqual(3); // tslint:disable-line:no-magic-numbers
 
-            act(() => wrapper.find(MaskedCopyableTextField).at(1).props().onTextChange?.('test-key1'));
-            act(() => wrapper.find(MaskedCopyableTextField).at(2).props().onTextChange?.('test-key2')); // tslint:disable-line:no-magic-numbers
+            act(() => wrapper.find(TextField).at(1).props().onChange?.(undefined as any, 'test-key1'));
+            act(() => wrapper.find(TextField).at(2).props().onChange?.(undefined as any, 'test-key2')); // tslint:disable-line:no-magic-numbers
             wrapper.update();
-            const fields = wrapper.find(MaskedCopyableTextField);
+            const fields = wrapper.find(TextField);
             expect(fields.at(1).props().value).toEqual('test-key1');
-            expect(fields.at(1).props().error).toEqual('moduleIdentity.validation.invalidKey');
+            expect(fields.at(1).props().errorMessage).toEqual('moduleIdentity.validation.invalidKey');
             expect(fields.last().props().value).toEqual('test-key2');
-            expect(fields.last().props().error).toEqual('moduleIdentity.validation.invalidKey');
+            expect(fields.last().props().errorMessage).toEqual('moduleIdentity.validation.invalidKey');
         });
 
         it('renders selfSigned input field', () => {
@@ -70,16 +69,16 @@ describe('devices/components/addModuleIdentity', () => {
             const choiceGroup = wrapper.find(ChoiceGroup).first();
             act(() => choiceGroup.props().onChange?.(undefined as any, { key: DeviceAuthenticationType.SelfSigned, text: 'text' } ));
             wrapper.update();
-            expect(wrapper.find(MaskedCopyableTextField).length).toEqual(3);  // tslint:disable-line:no-magic-numbers
+            expect(wrapper.find(TextField).length).toEqual(3);  // tslint:disable-line:no-magic-numbers
 
-            act(() => wrapper.find(MaskedCopyableTextField).at(1).props().onTextChange?.('test-thumbprint1'));
-            act(() => wrapper.find(MaskedCopyableTextField).last().props().onTextChange?.('test-thumbprint2'));
+            act(() => wrapper.find(TextField).at(1).props().onChange?.(undefined as any, 'test-thumbprint1'));
+            act(() => wrapper.find(TextField).last().props().onChange?.(undefined as any, 'test-thumbprint2'));
             wrapper.update();
-            const fields = wrapper.find(MaskedCopyableTextField);
+            const fields = wrapper.find(TextField);
             expect(fields.at(1).props().value).toEqual('test-thumbprint1');
-            expect(fields.at(1).props().error).toEqual('moduleIdentity.validation.invalidThumbprint');
+            expect(fields.at(1).props().errorMessage).toEqual('moduleIdentity.validation.invalidThumbprint');
             expect(fields.last().props().value).toEqual('test-thumbprint2');
-            expect(fields.last().props().error).toEqual('moduleIdentity.validation.invalidThumbprint');
+            expect(fields.last().props().errorMessage).toEqual('moduleIdentity.validation.invalidThumbprint');
         });
     });
 });

--- a/src/app/devices/module/addModuleIdentity/components/addModuleIdentity.tsx
+++ b/src/app/devices/module/addModuleIdentity/components/addModuleIdentity.tsx
@@ -5,13 +5,12 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useHistory } from 'react-router-dom';
-import { CommandBar, ChoiceGroup, IChoiceGroupOption, Checkbox } from '@fluentui/react';
+import { CommandBar, ChoiceGroup, IChoiceGroupOption, Checkbox, TextField } from '@fluentui/react';
 import { ResourceKeys } from '../../../../../localization/resourceKeys';
 import { getDeviceIdFromQueryString } from '../../../../shared/utils/queryStringHelper';
 import { CANCEL, SAVE } from '../../../../constants/iconNames';
 import { SynchronizationStatus } from '../../../../api/models/synchronizationStatus';
 import { ROUTE_PARAMS } from '../../../../constants/routes';
-import { MaskedCopyableTextField } from '../../../../shared/components/maskedCopyableTextField';
 import { HeaderView } from '../../../../shared/components/headerView';
 import { DeviceAuthenticationType } from '../../../../api/models/deviceAuthenticationType';
 import { validateThumbprint, validateKey, validateModuleIdentityName, processThumbprint } from '../../../../shared/utils/utils';
@@ -20,9 +19,9 @@ import { addModuleIdentityReducer } from '../reducer';
 import { addModuleIdentitySaga } from '../saga';
 import { addModuleStateInitial } from '../state';
 import { addModuleIdentityAction } from '../actions';
-import '../../../../css/_deviceDetail.scss';
 import { AppInsightsClient } from '../../../../shared/appTelemetry/appInsightsClient';
 import { TELEMETRY_USER_ACTIONS } from '../../../../constants/telemetry';
+import '../../../../css/_deviceDetail.scss';
 
 const initialKeyValue = {
     error: '',
@@ -78,17 +77,14 @@ export const AddModuleIdentity: React.FC = () => {
 
     const showModuleId = () => {
         return (
-            <MaskedCopyableTextField
+            <TextField
                 ariaLabel={t(ResourceKeys.moduleIdentity.moduleId)}
                 label={t(ResourceKeys.moduleIdentity.moduleId)}
                 value={module.id}
                 required={true}
-                onTextChange={changeModuleIdentityName}
-                allowMask={false}
-                readOnly={false}
-                error={!!module.error ? t(module.error) : ''}
-                labelCallout={t(ResourceKeys.moduleIdentity.moduleIdTooltip)}
-                setFocus={true}
+                onChange={changeModuleIdentityName}
+                errorMessage={!!module.error ? t(module.error) : ''}
+                description={t(ResourceKeys.moduleIdentity.moduleIdTooltip)}
             />
         );
     };
@@ -123,27 +119,27 @@ export const AddModuleIdentity: React.FC = () => {
     const renderSymmetricKeySection = () => {
         return (
             <>
-                <MaskedCopyableTextField
+                <TextField
                     ariaLabel={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.primaryKey)}
                     label={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.primaryKey)}
                     value={primaryKey.value}
                     required={true}
-                    onTextChange={changePrimaryKey}
-                    allowMask={true}
-                    readOnly={false}
-                    error={!!primaryKey.error ? t(primaryKey.error) : ''}
-                    labelCallout={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.primaryKeyTooltip)}
+                    onChange={changePrimaryKey}
+                    type={'password'}
+                    canRevealPassword={true}
+                    errorMessage={!!primaryKey.error ? t(primaryKey.error) : ''}
+                    description={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.primaryKeyTooltip)}
                 />
-                <MaskedCopyableTextField
+                <TextField
                     ariaLabel={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.secondaryKey)}
                     label={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.secondaryKey)}
                     value={secondaryKey.value}
                     required={true}
-                    onTextChange={changeSecondaryKey}
-                    allowMask={true}
-                    readOnly={false}
-                    error={!!secondaryKey.error ? t(secondaryKey.error) : ''}
-                    labelCallout={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.secondaryKeyTooltip)}
+                    onChange={changeSecondaryKey}
+                    type={'password'}
+                    canRevealPassword={true}
+                    errorMessage={!!secondaryKey.error ? t(secondaryKey.error) : ''}
+                    description={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.secondaryKeyTooltip)}
                 />
             </>
         );
@@ -152,27 +148,28 @@ export const AddModuleIdentity: React.FC = () => {
     const renderSelfSignedSection = () => {
         return (
             <>
-                <MaskedCopyableTextField
+                <TextField
                     ariaLabel={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.primaryThumbprint)}
                     label={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.primaryThumbprint)}
                     value={primaryKey.thumbprint}
                     required={true}
-                    onTextChange={changePrimaryThumbprint}
-                    allowMask={true}
-                    readOnly={false}
-                    error={!!primaryKey.thumbprintError ? t(primaryKey.thumbprintError) : ''}
-                    labelCallout={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.primaryThumbprintTooltip)}
+                    onChange={changePrimaryThumbprint}
+                    type={'password'}
+                    canRevealPassword={true}
+                    errorMessage={!!primaryKey.thumbprintError ? t(primaryKey.thumbprintError) : ''}
+                    description={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.primaryThumbprintTooltip)}
                 />
-                <MaskedCopyableTextField
+                <TextField
                     ariaLabel={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.secondaryThumbprint)}
                     label={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.secondaryThumbprint)}
                     value={secondaryKey.thumbprint}
                     required={true}
-                    onTextChange={changeSecondaryThumbprint}
-                    allowMask={true}
+                    onChange={changeSecondaryThumbprint}
+                    type={'password'}
+                    canRevealPassword={true}
                     readOnly={false}
-                    error={!!secondaryKey.thumbprintError ? t(secondaryKey.thumbprintError) : ''}
-                    labelCallout={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip)}
+                    errorMessage={!!secondaryKey.thumbprintError ? t(secondaryKey.thumbprintError) : ''}
+                    description={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip)}
                 />
             </>
         );
@@ -254,7 +251,7 @@ export const AddModuleIdentity: React.FC = () => {
             validateThumbprint(secondaryKey.thumbprint);
     };
 
-    const changeModuleIdentityName = (newValue?: string) => {
+    const changeModuleIdentityName = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const moduleIdError = getModuleIdentityNameValidationMessage(newValue);
         setModule({
             error: moduleIdError,
@@ -274,7 +271,7 @@ export const AddModuleIdentity: React.FC = () => {
         }
     };
 
-    const changePrimaryKey = (newValue?: string) => {
+    const changePrimaryKey = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const primaryKeyError = getSymmetricKeyValidationMessage(newValue);
         setPrimaryKey({
             ...primaryKey,
@@ -283,7 +280,7 @@ export const AddModuleIdentity: React.FC = () => {
         });
     };
 
-    const changeSecondaryKey = (newValue?: string) => {
+    const changeSecondaryKey = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const secondaryKeyError = getSymmetricKeyValidationMessage(newValue);
         setSecondaryKey({
             ...secondaryKey,
@@ -292,7 +289,7 @@ export const AddModuleIdentity: React.FC = () => {
         });
     };
 
-    const changePrimaryThumbprint = (newValue?: string) => {
+    const changePrimaryThumbprint = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const primaryThumbprintError = getThumbprintValidationMessage(newValue);
         setPrimaryKey({
             ...primaryKey,
@@ -301,7 +298,7 @@ export const AddModuleIdentity: React.FC = () => {
         });
     };
 
-    const changeSecondaryThumbprint = (newValue?: string) => {
+    const changeSecondaryThumbprint = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const secondaryThumbprintError = getThumbprintValidationMessage(newValue);
         setSecondaryKey({
             ...secondaryKey,

--- a/src/app/devices/module/moduleIdentityList/components/moduleIdentityList.tsx
+++ b/src/app/devices/module/moduleIdentityList/components/moduleIdentityList.tsx
@@ -146,7 +146,7 @@ export const ModuleIdentityList: React.FC = () => {
                     </Label>
                 );
             default:
-                return;
+                return <></>;
         }
     };
 

--- a/src/app/devices/module/moduleIndentityDetail/components/__snapshots__/moduleIdentityDetail.spec.tsx.snap
+++ b/src/app/devices/module/moduleIndentityDetail/components/__snapshots__/moduleIdentityDetail.spec.tsx.snap
@@ -37,7 +37,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot after certificateAuthori
       ariaLabel="moduleIdentity.moduleId"
       label="moduleIdentity.moduleId"
       labelCallout="moduleIdentity.moduleIdTooltip"
-      readOnly={true}
       value="moduleId"
     />
     <StyledLabelBase>
@@ -84,7 +83,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot after module identity is
       ariaLabel="moduleIdentity.moduleId"
       label="moduleIdentity.moduleId"
       labelCallout="moduleIdentity.moduleIdTooltip"
-      readOnly={true}
       value="moduleId"
     />
   </div>
@@ -128,7 +126,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot after sas module identit
       ariaLabel="moduleIdentity.moduleId"
       label="moduleIdentity.moduleId"
       labelCallout="moduleIdentity.moduleIdTooltip"
-      readOnly={true}
       value="moduleId"
     />
     <MaskedCopyableTextField
@@ -136,7 +133,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot after sas module identit
       ariaLabel="moduleIdentity.authenticationType.symmetricKey.primaryKey"
       label="moduleIdentity.authenticationType.symmetricKey.primaryKey"
       labelCallout="moduleIdentity.authenticationType.symmetricKey.primaryKeyTooltip"
-      readOnly={true}
       value="mock_key_1"
     />
     <MaskedCopyableTextField
@@ -144,21 +140,18 @@ exports[`ModuleIdentityDetail snapshot matches snapshot after sas module identit
       ariaLabel="moduleIdentity.authenticationType.symmetricKey.secondaryKey"
       label="moduleIdentity.authenticationType.symmetricKey.secondaryKey"
       labelCallout="moduleIdentity.authenticationType.symmetricKey.secondaryKeyTooltip"
-      readOnly={true}
       value="mock_key_2"
     />
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="moduleIdentity.authenticationType.symmetricKey.primaryConnectionString"
       label="moduleIdentity.authenticationType.symmetricKey.primaryConnectionString"
-      readOnly={true}
       value="HostName=hostName;DeviceId=newdevice;ModuleId=moduleId;SharedAccessKey=mock_key_1"
     />
     <MaskedCopyableTextField
       allowMask={true}
       ariaLabel="moduleIdentity.authenticationType.symmetricKey.secondaryConnectionString"
       label="moduleIdentity.authenticationType.symmetricKey.secondaryConnectionString"
-      readOnly={true}
       value="HostName=hostName;DeviceId=newdevice;ModuleId=moduleId;SharedAccessKey=mock_key_2"
     />
     <SasTokenGenerationView
@@ -219,7 +212,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot after self signed module
       ariaLabel="moduleIdentity.moduleId"
       label="moduleIdentity.moduleId"
       labelCallout="moduleIdentity.moduleIdTooltip"
-      readOnly={true}
       value="moduleId"
     />
     <StyledLabelBase>
@@ -230,7 +222,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot after self signed module
       ariaLabel="moduleIdentity.authenticationType.selfSigned.primaryThumbprint"
       label="moduleIdentity.authenticationType.selfSigned.primaryThumbprint"
       labelCallout="moduleIdentity.authenticationType.selfSigned.primaryThumbprintTooltip"
-      readOnly={true}
       value="thumbprint1"
     />
     <MaskedCopyableTextField
@@ -238,7 +229,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot after self signed module
       ariaLabel="moduleIdentity.authenticationType.selfSigned.secondaryThumbprint"
       label="moduleIdentity.authenticationType.selfSigned.secondaryThumbprint"
       labelCallout="moduleIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip"
-      readOnly={true}
       value="thumbprint2"
     />
   </div>
@@ -282,7 +272,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot showing delete confirmat
       ariaLabel="moduleIdentity.moduleId"
       label="moduleIdentity.moduleId"
       labelCallout="moduleIdentity.moduleIdTooltip"
-      readOnly={true}
       value="moduleId"
     />
     <StyledLabelBase>
@@ -359,7 +348,6 @@ exports[`ModuleIdentityDetail snapshot matches snapshot while loading 1`] = `
       ariaLabel="moduleIdentity.moduleId"
       label="moduleIdentity.moduleId"
       labelCallout="moduleIdentity.moduleIdTooltip"
-      readOnly={true}
       value="moduleId"
     />
     <MultiLineShimmer />

--- a/src/app/devices/module/moduleIndentityDetail/components/moduleIdentityDetail.tsx
+++ b/src/app/devices/module/moduleIndentityDetail/components/moduleIdentityDetail.tsx
@@ -98,7 +98,6 @@ export const ModuleIdentityDetail: React.FC = () => {
                 label={t(ResourceKeys.moduleIdentity.moduleId)}
                 value={moduleId}
                 allowMask={false}
-                readOnly={true}
                 labelCallout={t(ResourceKeys.moduleIdentity.moduleIdTooltip)}
             />
         );
@@ -128,7 +127,6 @@ export const ModuleIdentityDetail: React.FC = () => {
                     label={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.primaryKey)}
                     value={moduleIdentity.authentication.symmetricKey.primaryKey}
                     allowMask={true}
-                    readOnly={true}
                     labelCallout={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.primaryKeyTooltip)}
                 />
 
@@ -137,7 +135,6 @@ export const ModuleIdentityDetail: React.FC = () => {
                     label={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.secondaryKey)}
                     value={moduleIdentity.authentication.symmetricKey.secondaryKey}
                     allowMask={true}
-                    readOnly={true}
                     labelCallout={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.secondaryKeyTooltip)}
                 />
 
@@ -146,7 +143,6 @@ export const ModuleIdentityDetail: React.FC = () => {
                     label={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.primaryConnectionString)}
                     value={generateConnectionString(moduleIdentity.authentication.symmetricKey.primaryKey)}
                     allowMask={true}
-                    readOnly={true}
                 />
 
                 <MaskedCopyableTextField
@@ -154,7 +150,6 @@ export const ModuleIdentityDetail: React.FC = () => {
                     label={t(ResourceKeys.moduleIdentity.authenticationType.symmetricKey.secondaryConnectionString)}
                     value={generateConnectionString(moduleIdentity.authentication.symmetricKey.secondaryKey)}
                     allowMask={true}
-                    readOnly={true}
                 />
 
                 {renderSasTokenSection()}
@@ -173,7 +168,6 @@ export const ModuleIdentityDetail: React.FC = () => {
                     label={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.primaryThumbprint)}
                     value={moduleIdentity.authentication.x509Thumbprint.primaryThumbprint}
                     allowMask={true}
-                    readOnly={true}
                     labelCallout={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.primaryThumbprintTooltip)}
                 />
                 <MaskedCopyableTextField
@@ -181,7 +175,6 @@ export const ModuleIdentityDetail: React.FC = () => {
                     label={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.secondaryThumbprint)}
                     value={moduleIdentity.authentication.x509Thumbprint.secondaryThumbprint}
                     allowMask={true}
-                    readOnly={true}
                     labelCallout={t(ResourceKeys.moduleIdentity.authenticationType.selfSigned.secondaryThumbprintTooltip)}
                 />
             </>

--- a/src/app/devices/pnp/components/deviceInterfaces/__snapshots__/deviceInterfaces.spec.tsx.snap
+++ b/src/app/devices/pnp/components/deviceInterfaces/__snapshots__/deviceInterfaces.spec.tsx.snap
@@ -49,21 +49,18 @@ exports[`deviceInterfaces shows interface information when status is fetched 1`]
           allowMask={false}
           ariaLabel="deviceInterfaces.columns.id"
           label="deviceInterfaces.columns.id"
-          readOnly={true}
           value={null}
         />
         <MaskedCopyableTextField
           allowMask={false}
           ariaLabel="deviceInterfaces.columns.displayName"
           label="deviceInterfaces.columns.displayName"
-          readOnly={true}
           value="--"
         />
         <MaskedCopyableTextField
           allowMask={false}
           ariaLabel="deviceInterfaces.columns.description"
           label="deviceInterfaces.columns.description"
-          readOnly={true}
           value="--"
         />
       </div>

--- a/src/app/devices/pnp/components/deviceInterfaces/deviceInterfaces.tsx
+++ b/src/app/devices/pnp/components/deviceInterfaces/deviceInterfaces.tsx
@@ -72,7 +72,6 @@ export const DeviceInterfaces: React.FC = () => {
                     label={t(ResourceKeys.deviceInterfaces.columns.id)}
                     value={interfaceId}
                     allowMask={false}
-                    readOnly={true}
                 />
                 {isValidInterface &&
                     <>
@@ -81,14 +80,12 @@ export const DeviceInterfaces: React.FC = () => {
                             label={t(ResourceKeys.deviceInterfaces.columns.displayName)}
                             value={modelDefinitionWithSource.modelDefinition && getLocalizedData(modelDefinitionWithSource.modelDefinition.displayName) || '--'}
                             allowMask={false}
-                            readOnly={true}
                         />
                         <MaskedCopyableTextField
                             ariaLabel={t(ResourceKeys.deviceInterfaces.columns.description)}
                             label={t(ResourceKeys.deviceInterfaces.columns.description)}
                             value={modelDefinitionWithSource.modelDefinition && getLocalizedData(modelDefinitionWithSource.modelDefinition.description) || '--'}
                             allowMask={false}
-                            readOnly={true}
                         />
                     </>
                 }

--- a/src/app/devices/pnp/components/deviceProperties/devicePropertiesPerInterface.tsx
+++ b/src/app/devices/pnp/components/deviceProperties/devicePropertiesPerInterface.tsx
@@ -44,7 +44,7 @@ export const DevicePropertiesPerInterface: React.FC<DevicePropertiesDataProps> =
             case 'value':
                 return renderPropertyReportedValue(item);
             default:
-                return;
+                return <></>;
         }
     };
 
@@ -75,7 +75,7 @@ export const DevicePropertiesPerInterface: React.FC<DevicePropertiesDataProps> =
     // tslint:disable-next-line:cyclomatic-complexity
     const renderPropertyReportedValue = (item: TwinWithSchema) => {
         if (!item) {
-            return;
+            return <></>;
         }
         const ariaLabel = t(ResourceKeys.deviceProperties.columns.value);
         // tslint:disable-next-line:no-any
@@ -114,7 +114,7 @@ export const DevicePropertiesPerInterface: React.FC<DevicePropertiesDataProps> =
 
     const createReportedValuePanel = () => {
         if (!selectedItem) {
-            return;
+            return <></>;
         }
         const { reportedTwin, propertyModelDefinition: modelDefinition, propertySchema: schema } = selectedItem;
         return (

--- a/src/app/devices/pnp/components/modelConfiguration/__snapshots__/digitalTwinModelId.spec.tsx.snap
+++ b/src/app/devices/pnp/components/modelConfiguration/__snapshots__/digitalTwinModelId.spec.tsx.snap
@@ -11,7 +11,6 @@ exports[`DigitalTwinModelId matches snapshot when empty model id is retrieved 1`
     allowMask={false}
     ariaLabel="digitalTwin.modelId"
     label="digitalTwin.modelId"
-    readOnly={true}
   />
 </div>
 `;
@@ -27,7 +26,6 @@ exports[`DigitalTwinModelId matches snapshot when model id is retrieved 1`] = `
     allowMask={false}
     ariaLabel="digitalTwin.modelId"
     label="digitalTwin.modelId"
-    readOnly={true}
   />
 </div>
 `;

--- a/src/app/devices/pnp/components/modelConfiguration/digitalTwinComponentList.tsx
+++ b/src/app/devices/pnp/components/modelConfiguration/digitalTwinComponentList.tsx
@@ -96,7 +96,7 @@ export const DigitalTwinComponentList: React.FC = () => {
                     </Label>
                 );
             default:
-                return;
+                return <></>;
         }
     };
 

--- a/src/app/devices/pnp/components/modelConfiguration/digitalTwinModelId.tsx
+++ b/src/app/devices/pnp/components/modelConfiguration/digitalTwinModelId.tsx
@@ -27,7 +27,6 @@ export const DigitalTwinModelId: React.FC = () => {
                 label={t(ResourceKeys.digitalTwin.modelId)}
                 value={modelId}
                 allowMask={false}
-                readOnly={true}
             />
         </div>
     );

--- a/src/app/devices/shared/components/__snapshots__/sasTokenGenerationView.spec.tsx.snap
+++ b/src/app/devices/shared/components/__snapshots__/sasTokenGenerationView.spec.tsx.snap
@@ -42,7 +42,6 @@ exports[`devices/components/moduleIdentityTwin snapshot matches snapshot when no
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.sasToken.textField.ariaLabel"
       label="deviceIdentity.authenticationType.sasToken.textField.label"
-      readOnly={true}
       value=""
     />
     <CustomizedPrimaryButton
@@ -98,7 +97,6 @@ exports[`devices/components/moduleIdentityTwin snapshot matches snapshot when no
       allowMask={true}
       ariaLabel="deviceIdentity.authenticationType.sasToken.textField.ariaLabel"
       label="deviceIdentity.authenticationType.sasToken.textField.label"
-      readOnly={true}
       value=""
     />
     <CustomizedPrimaryButton

--- a/src/app/devices/shared/components/sasTokenGenerationView.tsx
+++ b/src/app/devices/shared/components/sasTokenGenerationView.tsx
@@ -131,7 +131,6 @@ export const SasTokenGenerationView: React.FC<SasTokenGenerationDataProps> = (pr
                     label={t(ResourceKeys.deviceIdentity.authenticationType.sasToken.textField.label)}
                     value={sasTokenConnectionString}
                     allowMask={true}
-                    readOnly={true}
                 />
                 <PrimaryButton
                     className={'sas-token-generate-button'}

--- a/src/app/shared/components/__snapshots__/maskedCopyableTextField.spec.tsx.snap
+++ b/src/app/shared/components/__snapshots__/maskedCopyableTextField.spec.tsx.snap
@@ -17,13 +17,12 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
     className="controlSection"
   >
     <div
-      className="borderedSection  readOnly"
+      className="borderedSection readOnly"
     >
       <input
         aria-label="ariaLabel1"
         className="input"
         id="maskedCopyableTextField0"
-        onChange={[Function]}
         readOnly={true}
         type="text"
         value="value1"
@@ -72,13 +71,12 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
     className="controlSection"
   >
     <div
-      className="borderedSection  readOnly"
+      className="borderedSection readOnly"
     >
       <input
         aria-label="ariaLabel1"
         className="input"
         id="maskedCopyableTextField2"
-        onChange={[Function]}
         readOnly={true}
         type="password"
         value="value1"
@@ -121,152 +119,5 @@ exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = 
       />
     </div>
   </div>
-</div>
-`;
-
-exports[`MaskedCopyableTextField snapshots it matches snapshot when allowMask = true 2`] = `
-<div
-  className="maskedCopyableTextField"
->
-  <div
-    className="labelSection"
-  >
-    <LabelWithTooltip
-      htmlFor="maskedCopyableTextField4"
-    >
-      label1
-    </LabelWithTooltip>
-  </div>
-  <div
-    className="controlSection"
-  >
-    <div
-      className="borderedSection  readOnly"
-    >
-      <input
-        aria-label="ariaLabel1"
-        className="input"
-        id="maskedCopyableTextField4"
-        onChange={[Function]}
-        readOnly={true}
-        type="password"
-        value="value1"
-      />
-      <input
-        aria-hidden={true}
-        className="input"
-        readOnly={true}
-        style={
-          Object {
-            "height": "1px",
-            "opacity": 0,
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-        tabIndex={-1}
-        value="value1"
-      />
-      <StyledTooltipHostBase
-        content="common.maskedCopyableTextField.toggleMask.label.show"
-        id="toggleMaskButtonTooltipHost5"
-      >
-        <CustomizedIconButton
-          aria-labelledby="toggleMaskButtonTooltipHost5"
-          iconProps={
-            Object {
-              "iconName": "RedEye",
-            }
-          }
-          onClick={[Function]}
-        />
-      </StyledTooltipHostBase>
-    </div>
-    <div
-      className="copySection"
-    >
-      <CopyButton
-        copyText="value1"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`MaskedCopyableTextField snapshots it matches snapshot when error message specified 1`] = `
-<div
-  className="maskedCopyableTextField"
->
-  <div
-    className="labelSection"
-  >
-    <LabelWithTooltip
-      htmlFor="maskedCopyableTextField6"
-    >
-      label1
-    </LabelWithTooltip>
-  </div>
-  <div
-    className="controlSection"
-  >
-    <div
-      className="borderedSection error readOnly"
-    >
-      <input
-        aria-label="ariaLabel1"
-        className="input"
-        id="maskedCopyableTextField6"
-        onChange={[Function]}
-        readOnly={true}
-        type="password"
-        value="value1"
-      />
-      <input
-        aria-hidden={true}
-        className="input"
-        readOnly={true}
-        style={
-          Object {
-            "height": "1px",
-            "opacity": 0,
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-        tabIndex={-1}
-        value="value1"
-      />
-      <StyledTooltipHostBase
-        content="common.maskedCopyableTextField.toggleMask.label.show"
-        id="toggleMaskButtonTooltipHost7"
-      >
-        <CustomizedIconButton
-          aria-labelledby="toggleMaskButtonTooltipHost7"
-          iconProps={
-            Object {
-              "iconName": "RedEye",
-            }
-          }
-          onClick={[Function]}
-        />
-      </StyledTooltipHostBase>
-    </div>
-    <div
-      className="copySection"
-    >
-      <CopyButton
-        copyText="value1"
-      />
-    </div>
-  </div>
-  <div
-    aria-live="assertive"
-    className="errorSection"
-  >
-    error
-  </div>
-  <StyledAnnouncedBase
-    message="error"
-  />
 </div>
 `;

--- a/src/app/shared/components/maskedCopyableTextField.spec.tsx
+++ b/src/app/shared/components/maskedCopyableTextField.spec.tsx
@@ -18,8 +18,6 @@ describe('MaskedCopyableTextField', () => {
                     ariaLabel="ariaLabel1"
                     label="label1"
                     value="value1"
-                    onTextChange={jest.fn()}
-                    readOnly={true}
                 />
             )).toMatchSnapshot();
         });
@@ -31,35 +29,6 @@ describe('MaskedCopyableTextField', () => {
                     ariaLabel="ariaLabel1"
                     label="label1"
                     value="value1"
-                    onTextChange={jest.fn()}
-                    readOnly={true}
-                />
-            )).toMatchSnapshot();
-        });
-
-        it('it matches snapshot when allowMask = true', () => {
-            expect(shallow(
-                <MaskedCopyableTextField
-                    allowMask={true}
-                    ariaLabel="ariaLabel1"
-                    label="label1"
-                    value="value1"
-                    onTextChange={jest.fn()}
-                    readOnly={true}
-                />
-            )).toMatchSnapshot();
-        });
-
-        it('it matches snapshot when error message specified', () => {
-            expect(shallow(
-                <MaskedCopyableTextField
-                    allowMask={true}
-                    ariaLabel="ariaLabel1"
-                    error="error"
-                    label="label1"
-                    value="value1"
-                    onTextChange={jest.fn()}
-                    readOnly={true}
                 />
             )).toMatchSnapshot();
         });
@@ -73,8 +42,6 @@ describe('MaskedCopyableTextField', () => {
                     ariaLabel="ariaLabel1"
                     label="label1"
                     value="value1"
-                    onTextChange={jest.fn()}
-                    readOnly={true}
                 />);
 
             expect(wrapper.find(TooltipHost).first().props().content).toEqual('common.maskedCopyableTextField.toggleMask.label.show');
@@ -94,35 +61,13 @@ describe('MaskedCopyableTextField', () => {
                     ariaLabel="ariaLabel1"
                     label="label1"
                     value="value1"
-                    onTextChange={jest.fn()}
-                    readOnly={true}
                 />);
 
             const clipboardButton = wrapper.find(IconButton).first();
-            clipboardButton.props().onClick(undefined);
+            act(() => clipboardButton.props().onClick(undefined));
 
             expect(document.execCommand).toHaveBeenLastCalledWith('copy');
             done();
-        });
-    });
-
-    describe('change to input', () => {
-        it('call onTextChange prop', () => {
-            const onTextChange = jest.fn();
-            const wrapper = mount(
-                <MaskedCopyableTextField
-                    allowMask={false}
-                    ariaLabel="ariaLabel1"
-                    label="label1"
-                    value="value1"
-                    onTextChange={onTextChange}
-                    readOnly={true}
-                />);
-
-            const input = wrapper.find('input').first();
-            input.simulate('change', { target: { value: 'hello world' } });
-
-            expect(onTextChange).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/app/shared/components/maskedCopyableTextField.tsx
+++ b/src/app/shared/components/maskedCopyableTextField.tsx
@@ -16,14 +16,9 @@ export interface MaskedCopyableTextFieldProps {
     calloutContent?: JSX.Element;
     label: string;
     labelCallout?: string;
-    error?: string;
     value: string;
     allowMask: boolean;
-    readOnly: boolean;
-    required?: boolean;
-    onTextChange?(text: string): void;
     placeholder?: string;
-    setFocus?: boolean;
 }
 
 // tslint:disable-next-line: cyclomatic-complexity
@@ -35,35 +30,15 @@ export const MaskedCopyableTextField: React.FC<MaskedCopyableTextFieldProps> = (
 
     const { t } = useTranslation();
 
-    const { setFocus, ariaLabel, error, value, allowMask, readOnly, placeholder, calloutContent, labelCallout, required, label, onTextChange } = props;
+    const { ariaLabel, value, allowMask, placeholder, calloutContent, labelCallout, label } = props;
     const [hideContents, setHideContents] = React.useState(allowMask);
-
-    React.useEffect(
-        () => {
-            if (setFocus) {
-                const node = visibleInputRef.current;
-                if (node) {
-                    node.focus();
-                }
-            }
-        },
-        [setFocus]);
 
     const renderLabelSection = () => {
         if (calloutContent) {
-            return (<LabelWithRichCallout calloutContent={calloutContent} htmlFor={labelIdentifier} required={required}>{label}</LabelWithRichCallout>);
+            return (<LabelWithRichCallout calloutContent={calloutContent} htmlFor={labelIdentifier}>{label}</LabelWithRichCallout>);
         }
 
-        return (<LabelWithTooltip tooltipText={labelCallout} htmlFor={labelIdentifier} required={required}>{label}</LabelWithTooltip>);
-    };
-
-    const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const text = event.target.value;
-        setHideContents(false);
-
-        if (onTextChange) {
-            onTextChange(text);
-        }
+        return (<LabelWithTooltip tooltipText={labelCallout} htmlFor={labelIdentifier}>{label}</LabelWithTooltip>);
     };
 
     const toggleDisplay = () => setHideContents(!hideContents);
@@ -75,7 +50,7 @@ export const MaskedCopyableTextField: React.FC<MaskedCopyableTextFieldProps> = (
             </div>
 
             <div className="controlSection">
-                <div className={`borderedSection ${error ? 'error' : ''} ${readOnly ? 'readOnly' : ''}`}>
+                <div className="borderedSection readOnly">
                     <input
                         aria-label={ariaLabel}
                         id={labelIdentifier}
@@ -83,10 +58,8 @@ export const MaskedCopyableTextField: React.FC<MaskedCopyableTextFieldProps> = (
                         value={value || ''}
                         type={(allowMask && hideContents) ? 'password' : 'text'}
                         className="input"
-                        readOnly={readOnly}
-                        onChange={onChange}
+                        readOnly={true}
                         placeholder={placeholder}
-                        required={props.required}
                     />
                     <input
                         aria-hidden={true}
@@ -118,13 +91,6 @@ export const MaskedCopyableTextField: React.FC<MaskedCopyableTextFieldProps> = (
                     <CopyButton copyText={value} />
                 </div>
             </div>
-
-            {error &&
-                <>
-                    <div className="errorSection" aria-live={'assertive'}>{error}</div>
-                    <Announced message={error} />
-                </>
-            }
         </div>
     );
 };


### PR DESCRIPTION
Make MaskedCopyableTextField readonly and use Fluent's TextField forerrorMessage with password type.
This change is to address accessibility bug because errorMessage of MaskedCopyableTextField  is not announced, and we are adviced to use Fluent's TextField for it's builtin errorMessage property.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit tests?
- [x] Have **all** unit tests passed locally? (by running `npm run test` command)
- [x] Have you updated the README.md with new screenshots if significant changes have been made?
- [x] Have you update the package version if the current version in package.json is not higher than the version released?