### PR TITLE
fix codeql issues

### DIFF
--- a/src/server/serverBase.ts
+++ b/src/server/serverBase.ts
@@ -141,7 +141,7 @@ export const handleGetDirectoriesRequest = (req: express.Request, res: express.R
         }
     }
     catch (error) {
-        res.status(SERVER_ERROR).send(error);
+        res.status(SERVER_ERROR).send(error?.message);
     }
 };
 

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -17,9 +17,11 @@ export const fetchDrivesOnWindows = (res: express.Response) => {
 
 export const fetchDirectories = (dir: string, res: express.Response) => {
     const result: string[] = [];
-    for (const item of fs.readdirSync(dir)) {
+    const resolvedPath = fs.realpathSync(dir, { encoding: "utf8" }); 
+
+    for (const item of fs.readdirSync(resolvedPath)) {
         try {
-            const stat = fs.statSync(path.join(dir, item));
+            const stat = fs.statSync(path.join(resolvedPath, item));
             if (stat.isDirectory()) {
                 result.push(item);
             }


### PR DESCRIPTION
Fix two codeQl alerts.
1. Should not expose stack trace through error
2. Validate user input before using it to construct a file path